### PR TITLE
Restrict skill frontmatter to the six Agent Skills spec fields

### DIFF
--- a/.agents/skills/clone-prototype/SKILL.md
+++ b/.agents/skills/clone-prototype/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: clone-prototype
-argument-hint: [reference screenshots, or the app and screens to clone]
 description: Clone a real app's screens as pixel-accurate, self-contained HTML artboards on the prototype canvas. Overlay a grid on the reference and sample colours visually, derive one measured design-token block, generate one HTML file per screen from a single script, verify by re-rendering, and park the reference underneath its mockup. Use when asked to 100% copy / clone an app's UI, rebuild screens from screenshots or Mobbin, extract a design system from reference images, or check a mockup against its reference.
 ---
 

--- a/.agents/skills/new-ui-mock/SKILL.md
+++ b/.agents/skills/new-ui-mock/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: new-ui-mock
-argument-hint: [the screen, flow or component to design]
 description: Design a new screen, flow or component as a self-contained HTML artboard on the prototype canvas, built from the board's existing design tokens rather than invented values. Covers picking or extending the token block, generating a row of screens from one script, iterating against annotated screenshots, and verifying by rendering. Use when asked to mock up a new screen or feature, design variants/proposals to compare, extend an existing board with more states, or turn a spec into artboards.
 ---
 

--- a/.agents/skills/prototype-canvas/SKILL.md
+++ b/.agents/skills/prototype-canvas/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: prototype-canvas
-argument-hint: [canvas slug, or a screenshot to act on]
 description: Start and operate the local tldraw design canvas in this repo. Launch the dev server, add or switch boards under mockups/canvases/, drive shapes through the bounded window.snapCanvas bridge, and act on annotated screenshots of the canvas. Use when asked to open/launch the canvas, put a mockup on the canvas, annotate or draw on it, fix overlapping frames after a layout.json edit, or respond to a screenshot of the canvas with notes drawn on it.
 ---
 


### PR DESCRIPTION
Follow-up to #3, which added `argument-hint` to all three skills.

`argument-hint` is valid for Claude Code skills at any level, but it is not in
the Agent Skills spec. That spec allows six keys: `name`, `description`,
`license`, `compatibility`, `metadata`, `allowed-tools`. claude.ai uploads, the
Skills API, and `package_skill.py` fail with a **hard error** on anything else,
and the docs' own example of that error names this exact field:

```
Unexpected key(s) in SKILL.md frontmatter: argument-hint.
Allowed properties are: allowed-tools, compatibility, description, license, metadata, name
```

Claude Code accepts all six spec fields, so nothing changes locally.

Rest of the format checked at the same time and already compliant: frontmatter
opens line 1, `name` matches the directory, descriptions are 508 / 494 / 446
against the 1,536-character cap with the use case first, bodies are
488 / 124 / 124 against the "under 500 lines" guidance, and the `references/*.md`
files are linked with relative markdown links that say what each contains.

`claude plugin validate .agents/skills` passes. Note it does not follow
symlinks, so pointing it at `.claude/skills` reads nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)