### PR TITLE
Add a templates board: the skeleton every new board starts from

### DIFF
--- a/.agents/skills/clone-prototype/SKILL.md
+++ b/.agents/skills/clone-prototype/SKILL.md
@@ -192,9 +192,12 @@ Cover, in this order, with a short prefix per app (`--n-` for Notion):
 token board, two evidence boards, 8 screens, 8 references), a three-row
 `layout.json`, a committed `gen.py`, and per-screen mean deltas of 3.47 to
 4.50 levels against the captures.
-`mockups/canvases/notion-ios/00-design-tokens.html` is a smaller
-single-board example. Copy one, change the prefix, replace every value and
-every evidence row.
+Start from the skeleton rather than a finished board:
+`cp -r mockups/canvases/templates mockups/canvases/<slug>`. Its `gen.py`
+builds the `:root` block *and* the evidence table from one `TOKENS` list, so
+a value cannot drift from the evidence behind it and a token cannot ship
+without one. Change `NAME` and the prefix, then replace every placeholder row
+with something you measured.
 
 Build the token board as the **first generated artboard** of the folder (the
 reference row is already up). It is the contract. When a screen looks wrong
@@ -217,7 +220,8 @@ Write **one** script that emits every `.html` file, and commit it with the
 boards it produces: `mockups/canvases/<slug>/gen.py`, plus its asset JSON,
 resolving paths relative to `__file__` so
 `python3 mockups/canvases/<slug>/gen.py` regenerates the folder in place
-(`mockups/canvases/luma-ios/gen.py` is the shape). Do not hand-edit the
+(`mockups/canvases/templates/gen.py` is the skeleton,
+`mockups/canvases/luma-ios/gen.py` a finished one). Do not hand-edit the
 artboards afterwards; edit the generator and re-run. That is what keeps
 eight files consistent through a dozen correction passes, and it only
 outlives the session if the generator is in the repo; a scratch-dir

--- a/.agents/skills/new-ui-mock/SKILL.md
+++ b/.agents/skills/new-ui-mock/SKILL.md
@@ -23,8 +23,8 @@ Never invent a palette when the product already has one.
   has no shared stylesheet.
 - **Cloning a real app's look?** Stop and run `clone-prototype` Phase 1 and
   Phase 2 first; come back with a measured token block.
-- **Genuinely new product, nothing to measure?** Start from
-  `mockups/canvases/notion-ios/00-design-tokens.html`, change the prefix,
+- **Genuinely new product, nothing to measure?** Copy
+  `mockups/canvases/templates/`, change `NAME` and the prefix,
   and pick deliberately: platform-native stack, a neutral ramp, one accent,
   one danger. Keep the evidence table and write *why* in it ("iOS system
   blue", "brand hex from the logo"). An unexplained hex is a future bug.

--- a/mockups/canvases/README.md
+++ b/mockups/canvases/README.md
@@ -117,6 +117,13 @@ files sitting in the folder are invisible to the canvas.
   sitting above the Figma render of the same screen. Every feature lands
   within a pixel of its reference in both Chromium and WebKit; its
   `README.md` records the two bugs that only the second engine showed.
+- `templates/`: the starting point, not a finished board. The four boards
+  every run produces (design tokens, evidence, one phone screen, one parked
+  reference) with placeholder values, generated from one list of tokens so
+  the `:root` block and the evidence table cannot drift apart. It carries
+  the parts that are the same on every board and nothing else: the 393 x 852
+  frame, the 52pt corners and bezel, the 54pt status bar with its island and
+  three glyphs, the home indicator. Copy the folder to start.
 - `apple-icons/`: a different kind of board, an asset board. The 43 native
   iOS 26 app icons in both the default and the dark appearance, embedded as
   the shipped art rather than redrawn, tiled five across with no chrome.
@@ -127,5 +134,13 @@ files sitting in the folder are invisible to the canvas.
   folder's `README.md` records what the run measured and where the replica
   knowingly differs from its source.
 
-To start a new board: copy a `00-design-tokens.html`, replace every value
-with one you measured, and build your screens against it.
+To start a new board, copy the `templates/` folder and run its generator:
+
+```bash
+cp -r mockups/canvases/templates mockups/canvases/<slug>
+python3 mockups/canvases/<slug>/gen.py
+```
+
+That hands you the four boards a run always produces, wired together and
+already passing `refkit tokens`. Then replace every placeholder with a value
+you measured.

--- a/mockups/canvases/templates/00-design-tokens.html
+++ b/mockups/canvases/templates/00-design-tokens.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Templates - Design Tokens</title>
+<style>
+:root{
+  /* Font */
+  --x-font:-apple-system,BlinkMacSystemFont,"SF Pro Text","SF Pro Display","Helvetica Neue",Helvetica,Arial,sans-serif;
+
+  /* Surface */
+  --x-bg:#FFFFFF;
+  --x-card:#F6F6F7;
+  --x-scrim:rgba(0,0,0,.20);
+
+  /* Line */
+  --x-hairline:#E4E4E6;
+  --x-border:#D9D9DC;
+
+  /* Ink */
+  --x-ink:#111113;
+  --x-ink-2:#6B6B70;
+  --x-ink-3:#9B9BA1;
+  --x-ink-inv:#FFFFFF;
+
+  /* Accent */
+  --x-accent:#007AFF;
+  --x-danger:#FF3B30;
+
+  /* Radius */
+  --x-r-field:10px;
+  --x-r-card:14px;
+  --x-r-sheet:20px;
+  --x-r-pill:999px;
+  --x-r-phone:52px;
+
+  /* Type */
+  --x-t-title:700 28px/34px var(--x-font);
+  --x-t-head:600 17px/22px var(--x-font);
+  --x-t-row:400 17px/22px var(--x-font);
+  --x-t-note:400 13px/16px var(--x-font);
+  --x-t-time:590 17px/22px var(--x-font);
+
+  /* Metrics */
+  --x-w:393px;
+  --x-h:852px;
+  --x-status:54px;
+  --x-gutter:20px;
+  --x-row:44px;
+}
+
+*{box-sizing:border-box;margin:0;padding:0}
+body{font-family:var(--x-font);-webkit-font-smoothing:antialiased;
+  display:flex;justify-content:center;padding:24px}
+.phone{position:relative;flex:none;width:var(--x-w);height:var(--x-h);
+  border-radius:var(--x-r-phone);overflow:hidden;background:var(--x-bg);color:var(--x-ink);
+  box-shadow:0 0 0 11px #1D191A,0 0 0 12.5px #3A3735,0 24px 60px rgba(29,25,26,.28)}
+.sb{position:absolute;left:0;top:0;width:var(--x-w);height:var(--x-status);z-index:6}
+.sb .time{position:absolute;left:0;top:18.2px;width:142.4px;text-align:center;font:var(--x-t-time)}
+.sb .island{position:absolute;top:11px;left:50%;transform:translateX(-50%);
+  width:125px;height:36px;border-radius:20px;background:#000}
+.sb svg{position:absolute;display:block;fill:currentColor}
+/* iOS picks the indicator colour against the wallpaper: measure it per screen */
+.home{position:absolute;left:50%;bottom:8px;transform:translateX(-50%);
+  width:139px;height:5px;border-radius:3px;background:currentColor;z-index:6}
+body{padding:0;background:var(--x-bg);color:var(--x-ink)}
+.sheet{width:478px;height:980px;padding:20px;overflow:hidden}
+h1{font:var(--x-t-head);margin-bottom:2px}
+header p{font:var(--x-t-note);color:var(--x-ink-3);margin-bottom:14px}
+h2{font:600 9px/12px var(--x-font);letter-spacing:.8px;text-transform:uppercase;
+  color:var(--x-ink-3);margin:12px 0 5px}
+.grid{display:grid;grid-template-columns:repeat(4,1fr);gap:6px}
+.sw .chip{height:26px;border-radius:6px;border:1px solid var(--x-border)}
+.sw b{display:block;margin-top:3px;font:600 8.5px/11px ui-monospace,Menlo,monospace}
+.sw i{display:block;font:400 8px/11px ui-monospace,Menlo,monospace;
+  color:var(--x-ink-3);font-style:normal;word-break:break-all}
+.rad{display:flex;gap:9px}
+.rb{width:44px;height:26px;background:var(--x-card);border:1px solid var(--x-border)}
+.rad em{display:block;margin-top:2px;font:400 8.5px/11px var(--x-font);
+  color:var(--x-ink-3);font-style:normal;text-align:center}
+.tr{display:flex;align-items:baseline;justify-content:space-between;gap:10px;
+  padding-bottom:2px;border-bottom:1px solid var(--x-hairline)}
+.tr span{white-space:nowrap;overflow:hidden}
+.tr em{font:400 8px/11px ui-monospace,Menlo,monospace;color:var(--x-ink-3);
+  font-style:normal;white-space:nowrap;flex:none}
+.met{font:400 9px/13px ui-monospace,Menlo,monospace;color:var(--x-ink-2)}
+table.ev{width:100%;border-collapse:collapse}
+table.ev td{vertical-align:top;padding:2.5px 6px 2.5px 0;
+  border-bottom:1px solid var(--x-hairline);font:400 8.5px/11px var(--x-font)}
+td.t,td.v{font-family:ui-monospace,Menlo,monospace;white-space:nowrap}
+td.t{color:var(--x-accent)}
+td.v{color:var(--x-ink-2);max-width:150px;overflow:hidden;text-overflow:ellipsis}
+td.e{color:var(--x-ink-3)}</style>
+</head>
+<body>
+<div class="sheet"><header><h1>Templates</h1><p>Every value below is a placeholder. Replace each one, and its evidence row, before the board means anything.</p></header><h2>Colour</h2><div class="grid"><div class="sw"><div class="chip" style="background:var(--x-bg)"></div><b>--x-bg</b><i>#FFFFFF</i></div><div class="sw"><div class="chip" style="background:var(--x-card)"></div><b>--x-card</b><i>#F6F6F7</i></div><div class="sw"><div class="chip" style="background:var(--x-scrim)"></div><b>--x-scrim</b><i>rgba(0,0,0,.20)</i></div><div class="sw"><div class="chip" style="background:var(--x-hairline)"></div><b>--x-hairline</b><i>#E4E4E6</i></div><div class="sw"><div class="chip" style="background:var(--x-border)"></div><b>--x-border</b><i>#D9D9DC</i></div><div class="sw"><div class="chip" style="background:var(--x-ink)"></div><b>--x-ink</b><i>#111113</i></div><div class="sw"><div class="chip" style="background:var(--x-ink-2)"></div><b>--x-ink-2</b><i>#6B6B70</i></div><div class="sw"><div class="chip" style="background:var(--x-ink-3)"></div><b>--x-ink-3</b><i>#9B9BA1</i></div><div class="sw"><div class="chip" style="background:var(--x-ink-inv)"></div><b>--x-ink-inv</b><i>#FFFFFF</i></div><div class="sw"><div class="chip" style="background:var(--x-accent)"></div><b>--x-accent</b><i>#007AFF</i></div><div class="sw"><div class="chip" style="background:var(--x-danger)"></div><b>--x-danger</b><i>#FF3B30</i></div></div><h2>Radius</h2><div class="rad"><div><div class="rb" style="border-radius:10px"></div><em>10px</em></div><div><div class="rb" style="border-radius:14px"></div><em>14px</em></div><div><div class="rb" style="border-radius:20px"></div><em>20px</em></div><div><div class="rb" style="border-radius:999px"></div><em>999px</em></div></div><h2>Type</h2><div class="tr"><span style="font:var(--x-t-title)">Grumpy wizards</span><em>--x-t-title &middot; 700 28px/34px</em></div><div class="tr"><span style="font:var(--x-t-head)">Grumpy wizards</span><em>--x-t-head &middot; 600 17px/22px</em></div><div class="tr"><span style="font:var(--x-t-row)">Grumpy wizards</span><em>--x-t-row &middot; 400 17px/22px</em></div><div class="tr"><span style="font:var(--x-t-note)">Grumpy wizards</span><em>--x-t-note &middot; 400 13px/16px</em></div><div class="tr"><span style="font:var(--x-t-time)">Grumpy wizards</span><em>--x-t-time &middot; 590 17px/22px</em></div><h2>Metrics</h2><div class="met">--x-w: 393px<br>--x-h: 852px<br>--x-status: 54px<br>--x-gutter: 20px<br>--x-row: 44px</div></div>
+</body>
+</html>

--- a/mockups/canvases/templates/00b-evidence.html
+++ b/mockups/canvases/templates/00b-evidence.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Templates - Evidence</title>
+<style>
+:root{
+  /* Font */
+  --x-font:-apple-system,BlinkMacSystemFont,"SF Pro Text","SF Pro Display","Helvetica Neue",Helvetica,Arial,sans-serif;
+
+  /* Surface */
+  --x-bg:#FFFFFF;
+  --x-card:#F6F6F7;
+  --x-scrim:rgba(0,0,0,.20);
+
+  /* Line */
+  --x-hairline:#E4E4E6;
+  --x-border:#D9D9DC;
+
+  /* Ink */
+  --x-ink:#111113;
+  --x-ink-2:#6B6B70;
+  --x-ink-3:#9B9BA1;
+  --x-ink-inv:#FFFFFF;
+
+  /* Accent */
+  --x-accent:#007AFF;
+  --x-danger:#FF3B30;
+
+  /* Radius */
+  --x-r-field:10px;
+  --x-r-card:14px;
+  --x-r-sheet:20px;
+  --x-r-pill:999px;
+  --x-r-phone:52px;
+
+  /* Type */
+  --x-t-title:700 28px/34px var(--x-font);
+  --x-t-head:600 17px/22px var(--x-font);
+  --x-t-row:400 17px/22px var(--x-font);
+  --x-t-note:400 13px/16px var(--x-font);
+  --x-t-time:590 17px/22px var(--x-font);
+
+  /* Metrics */
+  --x-w:393px;
+  --x-h:852px;
+  --x-status:54px;
+  --x-gutter:20px;
+  --x-row:44px;
+}
+
+*{box-sizing:border-box;margin:0;padding:0}
+body{font-family:var(--x-font);-webkit-font-smoothing:antialiased;
+  display:flex;justify-content:center;padding:24px}
+.phone{position:relative;flex:none;width:var(--x-w);height:var(--x-h);
+  border-radius:var(--x-r-phone);overflow:hidden;background:var(--x-bg);color:var(--x-ink);
+  box-shadow:0 0 0 11px #1D191A,0 0 0 12.5px #3A3735,0 24px 60px rgba(29,25,26,.28)}
+.sb{position:absolute;left:0;top:0;width:var(--x-w);height:var(--x-status);z-index:6}
+.sb .time{position:absolute;left:0;top:18.2px;width:142.4px;text-align:center;font:var(--x-t-time)}
+.sb .island{position:absolute;top:11px;left:50%;transform:translateX(-50%);
+  width:125px;height:36px;border-radius:20px;background:#000}
+.sb svg{position:absolute;display:block;fill:currentColor}
+/* iOS picks the indicator colour against the wallpaper: measure it per screen */
+.home{position:absolute;left:50%;bottom:8px;transform:translateX(-50%);
+  width:139px;height:5px;border-radius:3px;background:currentColor;z-index:6}
+body{padding:0;background:var(--x-bg);color:var(--x-ink)}
+.sheet{width:478px;height:980px;padding:20px;overflow:hidden}
+h1{font:var(--x-t-head);margin-bottom:2px}
+header p{font:var(--x-t-note);color:var(--x-ink-3);margin-bottom:14px}
+h2{font:600 9px/12px var(--x-font);letter-spacing:.8px;text-transform:uppercase;
+  color:var(--x-ink-3);margin:12px 0 5px}
+.grid{display:grid;grid-template-columns:repeat(4,1fr);gap:6px}
+.sw .chip{height:26px;border-radius:6px;border:1px solid var(--x-border)}
+.sw b{display:block;margin-top:3px;font:600 8.5px/11px ui-monospace,Menlo,monospace}
+.sw i{display:block;font:400 8px/11px ui-monospace,Menlo,monospace;
+  color:var(--x-ink-3);font-style:normal;word-break:break-all}
+.rad{display:flex;gap:9px}
+.rb{width:44px;height:26px;background:var(--x-card);border:1px solid var(--x-border)}
+.rad em{display:block;margin-top:2px;font:400 8.5px/11px var(--x-font);
+  color:var(--x-ink-3);font-style:normal;text-align:center}
+.tr{display:flex;align-items:baseline;justify-content:space-between;gap:10px;
+  padding-bottom:2px;border-bottom:1px solid var(--x-hairline)}
+.tr span{white-space:nowrap;overflow:hidden}
+.tr em{font:400 8px/11px ui-monospace,Menlo,monospace;color:var(--x-ink-3);
+  font-style:normal;white-space:nowrap;flex:none}
+.met{font:400 9px/13px ui-monospace,Menlo,monospace;color:var(--x-ink-2)}
+table.ev{width:100%;border-collapse:collapse}
+table.ev td{vertical-align:top;padding:2.5px 6px 2.5px 0;
+  border-bottom:1px solid var(--x-hairline);font:400 8.5px/11px var(--x-font)}
+td.t,td.v{font-family:ui-monospace,Menlo,monospace;white-space:nowrap}
+td.t{color:var(--x-accent)}
+td.v{color:var(--x-ink-2);max-width:150px;overflow:hidden;text-overflow:ellipsis}
+td.e{color:var(--x-ink-3)}</style>
+</head>
+<body>
+<div class="sheet"><header><h1>Evidence</h1><p>One row per token. A token with no evidence is a guess.</p></header><table class="ev"><tr><td class="t">--x-font</td><td class="v">-apple-system,BlinkMacSystemFont,"SF Pro Text","SF Pro Display","Helvetica Neue",Helvetica,Arial,sans-serif</td><td class="e">PLACEHOLDER - platform stack; confirm with refkit font on the largest title</td></tr><tr><td class="t">--x-bg</td><td class="v">#FFFFFF</td><td class="e">PLACEHOLDER - flat-fill census, page background</td></tr><tr><td class="t">--x-card</td><td class="v">#F6F6F7</td><td class="e">PLACEHOLDER - flat-fill census inside a card</td></tr><tr><td class="t">--x-scrim</td><td class="v">rgba(0,0,0,.20)</td><td class="e">PLACEHOLDER - native capture over a photo</td></tr><tr><td class="t">--x-hairline</td><td class="v">#E4E4E6</td><td class="e">PLACEHOLDER - refkit hairline solve, list divider</td></tr><tr><td class="t">--x-border</td><td class="v">#D9D9DC</td><td class="e">PLACEHOLDER - refkit hairline solve, card outline</td></tr><tr><td class="t">--x-ink</td><td class="v">#111113</td><td class="e">PLACEHOLDER - ink core of a title, darkest 2%</td></tr><tr><td class="t">--x-ink-2</td><td class="v">#6B6B70</td><td class="e">PLACEHOLDER - ink core of a subtitle</td></tr><tr><td class="t">--x-ink-3</td><td class="v">#9B9BA1</td><td class="e">PLACEHOLDER - ink core of a caption</td></tr><tr><td class="t">--x-ink-inv</td><td class="v">#FFFFFF</td><td class="e">PLACEHOLDER - ink core on the accent fill</td></tr><tr><td class="t">--x-accent</td><td class="v">#007AFF</td><td class="e">PLACEHOLDER - mode of a button core</td></tr><tr><td class="t">--x-danger</td><td class="v">#FF3B30</td><td class="e">PLACEHOLDER - mode of a destructive label core</td></tr><tr><td class="t">--x-r-field</td><td class="v">10px</td><td class="e">PLACEHOLDER - refkit bbox on a search field corner</td></tr><tr><td class="t">--x-r-card</td><td class="v">14px</td><td class="e">PLACEHOLDER - refkit bbox on a card corner</td></tr><tr><td class="t">--x-r-sheet</td><td class="v">20px</td><td class="e">PLACEHOLDER - refkit bbox on the sheet corner</td></tr><tr><td class="t">--x-r-pill</td><td class="v">999px</td><td class="e">by construction, not measured</td></tr><tr><td class="t">--x-r-phone</td><td class="v">52px</td><td class="e">iPhone 15/16 display corner, 1pt = 1px</td></tr><tr><td class="t">--x-t-title</td><td class="v">700 28px/34px var(--x-font)</td><td class="e">PLACEHOLDER - refkit bands on the title</td></tr><tr><td class="t">--x-t-head</td><td class="v">600 17px/22px var(--x-font)</td><td class="e">PLACEHOLDER - refkit bands on a section header</td></tr><tr><td class="t">--x-t-row</td><td class="v">400 17px/22px var(--x-font)</td><td class="e">PLACEHOLDER - refkit bands on a list row</td></tr><tr><td class="t">--x-t-note</td><td class="v">400 13px/16px var(--x-font)</td><td class="e">PLACEHOLDER - refkit bands on a caption</td></tr><tr><td class="t">--x-t-time</td><td class="v">590 17px/22px var(--x-font)</td><td class="e">iOS status bar clock</td></tr><tr><td class="t">--x-w</td><td class="v">393px</td><td class="e">iPhone 15/16 logical width</td></tr><tr><td class="t">--x-h</td><td class="v">852px</td><td class="e">iPhone 15/16 logical height</td></tr><tr><td class="t">--x-status</td><td class="v">54px</td><td class="e">iOS status bar, Dynamic Island devices</td></tr><tr><td class="t">--x-gutter</td><td class="v">20px</td><td class="e">PLACEHOLDER - refkit scan on the left inset</td></tr><tr><td class="t">--x-row</td><td class="v">44px</td><td class="e">PLACEHOLDER - refkit bands pitch on the list</td></tr></table></div>
+</body>
+</html>

--- a/mockups/canvases/templates/01-screen.html
+++ b/mockups/canvases/templates/01-screen.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Templates - Screen</title>
+<style>
+:root{
+  /* Font */
+  --x-font:-apple-system,BlinkMacSystemFont,"SF Pro Text","SF Pro Display","Helvetica Neue",Helvetica,Arial,sans-serif;
+
+  /* Surface */
+  --x-bg:#FFFFFF;
+  --x-card:#F6F6F7;
+  --x-scrim:rgba(0,0,0,.20);
+
+  /* Line */
+  --x-hairline:#E4E4E6;
+  --x-border:#D9D9DC;
+
+  /* Ink */
+  --x-ink:#111113;
+  --x-ink-2:#6B6B70;
+  --x-ink-3:#9B9BA1;
+  --x-ink-inv:#FFFFFF;
+
+  /* Accent */
+  --x-accent:#007AFF;
+  --x-danger:#FF3B30;
+
+  /* Radius */
+  --x-r-field:10px;
+  --x-r-card:14px;
+  --x-r-sheet:20px;
+  --x-r-pill:999px;
+  --x-r-phone:52px;
+
+  /* Type */
+  --x-t-title:700 28px/34px var(--x-font);
+  --x-t-head:600 17px/22px var(--x-font);
+  --x-t-row:400 17px/22px var(--x-font);
+  --x-t-note:400 13px/16px var(--x-font);
+  --x-t-time:590 17px/22px var(--x-font);
+
+  /* Metrics */
+  --x-w:393px;
+  --x-h:852px;
+  --x-status:54px;
+  --x-gutter:20px;
+  --x-row:44px;
+}
+
+*{box-sizing:border-box;margin:0;padding:0}
+body{font-family:var(--x-font);-webkit-font-smoothing:antialiased;
+  display:flex;justify-content:center;padding:24px}
+.phone{position:relative;flex:none;width:var(--x-w);height:var(--x-h);
+  border-radius:var(--x-r-phone);overflow:hidden;background:var(--x-bg);color:var(--x-ink);
+  box-shadow:0 0 0 11px #1D191A,0 0 0 12.5px #3A3735,0 24px 60px rgba(29,25,26,.28)}
+.sb{position:absolute;left:0;top:0;width:var(--x-w);height:var(--x-status);z-index:6}
+.sb .time{position:absolute;left:0;top:18.2px;width:142.4px;text-align:center;font:var(--x-t-time)}
+.sb .island{position:absolute;top:11px;left:50%;transform:translateX(-50%);
+  width:125px;height:36px;border-radius:20px;background:#000}
+.sb svg{position:absolute;display:block;fill:currentColor}
+/* iOS picks the indicator colour against the wallpaper: measure it per screen */
+.home{position:absolute;left:50%;bottom:8px;transform:translateX(-50%);
+  width:139px;height:5px;border-radius:3px;background:currentColor;z-index:6}
+.pad{position:absolute;left:var(--x-gutter);right:var(--x-gutter);
+  top:calc(var(--x-status) + 10px)}
+.pad h1{font:var(--x-t-title);margin-bottom:14px}
+.r{height:var(--x-row);display:flex;align-items:center;justify-content:space-between;
+  font:var(--x-t-row);border-bottom:1px solid var(--x-hairline)}
+.r span{font:var(--x-t-note);color:var(--x-ink-3)}</style>
+</head>
+<body>
+<div class="phone"><div class="sb" style="color:var(--x-ink)"><div class="island"></div><div class="time">9:41</div><svg style="left:282px;top:23.34px;width:19.33px;height:12px" viewBox="0 0 19.33 12"><rect x="0" y="7.67" width="3.33" height="4.33" rx="1.05"/><rect x="5.33" y="5.33" width="3.33" height="6.67" rx="1.05"/><rect x="10.67" y="2.67" width="3.33" height="9.33" rx="1.05"/><rect x="16" y="0" width="3.33" height="12" rx="1.05"/></svg><svg preserveAspectRatio="none" viewBox="335 22.008 19.114 13.796" style="left:309px;top:23px;width:16.62px;height:12.3px"><path d="M344.555 35.8042C344.738 35.8042 344.896 35.7212 345.219 35.4058L347.245 33.4634C347.369 33.3389 347.403 33.1562 347.286 33.0068C346.747 32.3096 345.726 31.7036 344.555 31.7036C343.352 31.7036 342.331 32.3345 341.791 33.0566C341.708 33.1895 341.741 33.3389 341.874 33.4634L343.891 35.4058C344.215 35.7129 344.373 35.8042 344.555 35.8042ZM339.7 31.2886C339.882 31.4629 340.106 31.438 340.272 31.2554C341.268 30.1514 342.895 29.3462 344.555 29.3545C346.232 29.3462 347.859 30.1763 348.872 31.2803C349.021 31.4546 349.229 31.4463 349.411 31.2803L350.698 30.002C350.831 29.8691 350.848 29.6865 350.723 29.5371C349.47 28.0015 347.145 26.8477 344.555 26.8477C341.966 26.8477 339.641 28.0015 338.388 29.5371C338.263 29.6865 338.272 29.8525 338.413 30.002L339.7 31.2886ZM336.255 27.8189C336.421 27.9766 336.653 27.9766 336.811 27.8106C338.853 25.644 341.542 24.4985 344.555 24.4985C347.585 24.4985 350.291 25.6523 352.317 27.8189C352.466 27.9683 352.69 27.96 352.856 27.8022L354.002 26.6567C354.151 26.5073 354.143 26.3247 354.027 26.1836C352.076 23.7764 348.407 22.0083 344.555 22.0083C340.712 22.0083 337.027 23.7764 335.084 26.1836C334.968 26.3247 334.968 26.5073 335.109 26.6567L336.255 27.8189Z"/></svg><svg style="left:333px;top:23px;width:27.3px;height:12.7px" viewBox="0 0 27.3 12.7"><rect x=".6" y=".6" width="24.1" height="11.5" rx="4" fill="none" stroke="currentColor" stroke-opacity=".38"/><rect x="2" y="2" width="21.3" height="8.7" rx="2.6"/><path d="M26.1 4.3c.9.7.9 3 0 3.7V4.3Z" fill-opacity=".38"/></svg></div><div class="pad"><h1>Screen title</h1><div class="r">First row<span>Detail</span></div><div class="r">Second row<span>Detail</span></div><div class="r">Third row<span>Detail</span></div></div><div class="home" style="color:var(--x-ink)"></div></div>
+</body>
+</html>

--- a/mockups/canvases/templates/gen.py
+++ b/mockups/canvases/templates/gen.py
@@ -1,0 +1,339 @@
+"""The Templates board, and the skeleton for every new iPhone board.
+
+Open it on the canvas to see the four boards a clone run always produces --
+design tokens, the evidence table, one phone screen, one parked reference --
+built from placeholder values so the shapes are visible before anything has
+been measured. To start a real board, copy the folder and edit this file:
+
+    cp -r mockups/canvases/templates mockups/canvases/<slug>
+    python3 mockups/canvases/<slug>/gen.py
+
+The copy regenerates itself in place, byte-identical, from anywhere: every
+path in here resolves against __file__.
+
+Change, in this order:
+
+    NAME     the page name on the canvas.
+    P        the token prefix, one to three letters ("n" -> --n-bg).
+    TOKENS   every row: the value *and* the evidence. The :root block and the
+             evidence table are both generated from this one list, so a value
+             cannot drift from the evidence behind it and a token cannot ship
+             without one. A row you cannot defend is not a token; delete it.
+    SCREENS  one entry per screen, each returning body HTML.
+    REFS     one entry per capture, in the same order as SCREENS, so the
+             canvas parks each reference directly under its mockup.
+
+Already measured, and not to be re-derived per board: the 393 x 852 pt phone
+at 1pt = 1px, its 52pt corners and bezel, the 54pt status bar with its
+125 x 36 island at top 11, the three status glyphs, and the 139 x 5 home
+indicator at bottom 8.
+
+Both the status bar and the home indicator take a colour, because iOS picks
+one against the wallpaper. Measure it per screen; white is a guess.
+
+Artboards are output. Never hand-edit the .html -- edit this file and re-run.
+"""
+import base64, json
+from pathlib import Path
+
+OUT = Path(__file__).resolve().parent
+
+NAME = "Templates"
+P = "x"          # token prefix: --x-bg, --x-ink, --x-t-row
+
+# ---------------------------------------------------------------- tokens ----
+# (group, name, value, evidence). Phase 2 order: font, then surface -> line ->
+# ink -> accent, then radii, type, metrics. Values are written with the
+# placeholder prefix --x- throughout this file and rewritten to P on the way
+# out, so the CSS below stays readable instead of %s-riddled.
+TOKENS = [
+ ("Font", "font",
+  '-apple-system,BlinkMacSystemFont,"SF Pro Text","SF Pro Display",'
+  '"Helvetica Neue",Helvetica,Arial,sans-serif',
+  "PLACEHOLDER - platform stack; confirm with refkit font on the largest title"),
+
+ ("Surface", "bg",       "#FFFFFF",         "PLACEHOLDER - flat-fill census, page background"),
+ ("Surface", "card",     "#F6F6F7",         "PLACEHOLDER - flat-fill census inside a card"),
+ ("Surface", "scrim",    "rgba(0,0,0,.20)", "PLACEHOLDER - native capture over a photo"),
+
+ ("Line", "hairline",    "#E4E4E6",         "PLACEHOLDER - refkit hairline solve, list divider"),
+ ("Line", "border",      "#D9D9DC",         "PLACEHOLDER - refkit hairline solve, card outline"),
+
+ ("Ink", "ink",          "#111113",         "PLACEHOLDER - ink core of a title, darkest 2%"),
+ ("Ink", "ink-2",        "#6B6B70",         "PLACEHOLDER - ink core of a subtitle"),
+ ("Ink", "ink-3",        "#9B9BA1",         "PLACEHOLDER - ink core of a caption"),
+ ("Ink", "ink-inv",      "#FFFFFF",         "PLACEHOLDER - ink core on the accent fill"),
+
+ ("Accent", "accent",    "#007AFF",         "PLACEHOLDER - mode of a button core"),
+ ("Accent", "danger",    "#FF3B30",         "PLACEHOLDER - mode of a destructive label core"),
+
+ ("Radius", "r-field",   "10px",            "PLACEHOLDER - refkit bbox on a search field corner"),
+ ("Radius", "r-card",    "14px",            "PLACEHOLDER - refkit bbox on a card corner"),
+ ("Radius", "r-sheet",   "20px",            "PLACEHOLDER - refkit bbox on the sheet corner"),
+ ("Radius", "r-pill",    "999px",           "by construction, not measured"),
+ ("Radius", "r-phone",   "52px",            "iPhone 15/16 display corner, 1pt = 1px"),
+
+ ("Type", "t-title",     "700 28px/34px var(--x-font)", "PLACEHOLDER - refkit bands on the title"),
+ ("Type", "t-head",      "600 17px/22px var(--x-font)", "PLACEHOLDER - refkit bands on a section header"),
+ ("Type", "t-row",       "400 17px/22px var(--x-font)", "PLACEHOLDER - refkit bands on a list row"),
+ ("Type", "t-note",      "400 13px/16px var(--x-font)", "PLACEHOLDER - refkit bands on a caption"),
+ ("Type", "t-time",      "590 17px/22px var(--x-font)", "iOS status bar clock"),
+
+ ("Metrics", "w",        "393px",           "iPhone 15/16 logical width"),
+ ("Metrics", "h",        "852px",           "iPhone 15/16 logical height"),
+ ("Metrics", "status",   "54px",            "iOS status bar, Dynamic Island devices"),
+ ("Metrics", "gutter",   "20px",            "PLACEHOLDER - refkit scan on the left inset"),
+ ("Metrics", "row",      "44px",            "PLACEHOLDER - refkit bands pitch on the list"),
+]
+
+
+def _root():
+    """One :root block, byte-identical in every board. No `}` inside it:
+    refkit tokens reads it with a non-greedy regex."""
+    out, seen = [":root{"], None
+    for group, name, value, _ in TOKENS:
+        if group != seen:
+            out.append("" if seen else None)
+            out.append("  /* %s */" % group)
+            seen = group
+        out.append("  --x-%s:%s;" % (name, value))
+    return "\n".join(x for x in out if x is not None) + "\n}"
+
+
+TOKENS_CSS = _root()
+
+# ------------------------------------------------------------ phone frame ----
+# Measured once, for every board. The bezel is this repo's own framing, not a
+# property of the app being cloned, so it is the same in every folder.
+BASE = """*{box-sizing:border-box;margin:0;padding:0}
+body{font-family:var(--x-font);-webkit-font-smoothing:antialiased;
+  display:flex;justify-content:center;padding:24px}"""
+
+PHONE = """.phone{position:relative;flex:none;width:var(--x-w);height:var(--x-h);
+  border-radius:var(--x-r-phone);overflow:hidden;background:var(--x-bg);color:var(--x-ink);
+  box-shadow:0 0 0 11px #1D191A,0 0 0 12.5px #3A3735,0 24px 60px rgba(29,25,26,.28)}
+.sb{position:absolute;left:0;top:0;width:var(--x-w);height:var(--x-status);z-index:6}
+.sb .time{position:absolute;left:0;top:18.2px;width:142.4px;text-align:center;font:var(--x-t-time)}
+.sb .island{position:absolute;top:11px;left:50%;transform:translateX(-50%);
+  width:125px;height:36px;border-radius:20px;background:#000}
+.sb svg{position:absolute;display:block;fill:currentColor}
+/* iOS picks the indicator colour against the wallpaper: measure it per screen */
+.home{position:absolute;left:50%;bottom:8px;transform:translateX(-50%);
+  width:139px;height:5px;border-radius:3px;background:currentColor;z-index:6}"""
+
+# Cellular, wifi, battery at their measured status-bar positions, inheriting
+# currentColor so one call recolours the whole bar.
+SB_ICONS = (
+ '<svg style="left:282px;top:23.34px;width:19.33px;height:12px" viewBox="0 0 19.33 12">'
+ '<rect x="0" y="7.67" width="3.33" height="4.33" rx="1.05"/>'
+ '<rect x="5.33" y="5.33" width="3.33" height="6.67" rx="1.05"/>'
+ '<rect x="10.67" y="2.67" width="3.33" height="9.33" rx="1.05"/>'
+ '<rect x="16" y="0" width="3.33" height="12" rx="1.05"/></svg>'
+ '<svg preserveAspectRatio="none" viewBox="335 22.008 19.114 13.796"'
+ ' style="left:309px;top:23px;width:16.62px;height:12.3px">'
+ '<path d="M344.555 35.8042C344.738 35.8042 344.896 35.7212 345.219 35.4058L347.245'
+ ' 33.4634C347.369 33.3389 347.403 33.1562 347.286 33.0068C346.747 32.3096 345.726'
+ ' 31.7036 344.555 31.7036C343.352 31.7036 342.331 32.3345 341.791 33.0566C341.708'
+ ' 33.1895 341.741 33.3389 341.874 33.4634L343.891 35.4058C344.215 35.7129 344.373'
+ ' 35.8042 344.555 35.8042ZM339.7 31.2886C339.882 31.4629 340.106 31.438 340.272'
+ ' 31.2554C341.268 30.1514 342.895 29.3462 344.555 29.3545C346.232 29.3462 347.859'
+ ' 30.1763 348.872 31.2803C349.021 31.4546 349.229 31.4463 349.411 31.2803L350.698'
+ ' 30.002C350.831 29.8691 350.848 29.6865 350.723 29.5371C349.47 28.0015 347.145'
+ ' 26.8477 344.555 26.8477C341.966 26.8477 339.641 28.0015 338.388 29.5371C338.263'
+ ' 29.6865 338.272 29.8525 338.413 30.002L339.7 31.2886ZM336.255 27.8189C336.421'
+ ' 27.9766 336.653 27.9766 336.811 27.8106C338.853 25.644 341.542 24.4985 344.555'
+ ' 24.4985C347.585 24.4985 350.291 25.6523 352.317 27.8189C352.466 27.9683 352.69'
+ ' 27.96 352.856 27.8022L354.002 26.6567C354.151 26.5073 354.143 26.3247 354.027'
+ ' 26.1836C352.076 23.7764 348.407 22.0083 344.555 22.0083C340.712 22.0083 337.027'
+ ' 23.7764 335.084 26.1836C334.968 26.3247 334.968 26.5073 335.109 26.6567L336.255'
+ ' 27.8189Z"/></svg>'
+ '<svg style="left:333px;top:23px;width:27.3px;height:12.7px" viewBox="0 0 27.3 12.7">'
+ '<rect x=".6" y=".6" width="24.1" height="11.5" rx="4" fill="none" stroke="currentColor"'
+ ' stroke-opacity=".38"/><rect x="2" y="2" width="21.3" height="8.7" rx="2.6"/>'
+ '<path d="M26.1 4.3c.9.7.9 3 0 3.7V4.3Z" fill-opacity=".38"/></svg>')
+
+
+def statusbar(colour="var(--x-ink)", time="9:41"):
+    return ('<div class="sb" style="color:%s"><div class="island"></div>'
+            '<div class="time">%s</div>%s</div>' % (colour, time, SB_ICONS))
+
+
+def home(colour="var(--x-ink)"):
+    return '<div class="home" style="color:%s"></div>' % colour
+
+
+# ----------------------------------------------------------------- emit ----
+def page(title, body, extra_css=""):
+    html = ('<!DOCTYPE html>\n<html lang="en">\n<head>\n<meta charset="UTF-8">\n'
+            '<title>%s</title>\n<style>\n%s\n\n%s\n%s\n%s</style>\n</head>\n<body>\n%s\n</body>\n</html>\n'
+            % (title, TOKENS_CSS, BASE, PHONE, extra_css, body))
+    return html.replace("--x-", "--%s-" % P)
+
+
+def write(name, html):
+    (OUT / (name + ".html")).write_text(html)
+    print(name, len(html))
+
+
+# --------------------------------------------------- foundations boards ----
+SHEET = """body{padding:0;background:var(--x-bg);color:var(--x-ink)}
+.sheet{width:478px;height:980px;padding:20px;overflow:hidden}
+h1{font:var(--x-t-head);margin-bottom:2px}
+header p{font:var(--x-t-note);color:var(--x-ink-3);margin-bottom:14px}
+h2{font:600 9px/12px var(--x-font);letter-spacing:.8px;text-transform:uppercase;
+  color:var(--x-ink-3);margin:12px 0 5px}
+.grid{display:grid;grid-template-columns:repeat(4,1fr);gap:6px}
+.sw .chip{height:26px;border-radius:6px;border:1px solid var(--x-border)}
+.sw b{display:block;margin-top:3px;font:600 8.5px/11px ui-monospace,Menlo,monospace}
+.sw i{display:block;font:400 8px/11px ui-monospace,Menlo,monospace;
+  color:var(--x-ink-3);font-style:normal;word-break:break-all}
+.rad{display:flex;gap:9px}
+.rb{width:44px;height:26px;background:var(--x-card);border:1px solid var(--x-border)}
+.rad em{display:block;margin-top:2px;font:400 8.5px/11px var(--x-font);
+  color:var(--x-ink-3);font-style:normal;text-align:center}
+.tr{display:flex;align-items:baseline;justify-content:space-between;gap:10px;
+  padding-bottom:2px;border-bottom:1px solid var(--x-hairline)}
+.tr span{white-space:nowrap;overflow:hidden}
+.tr em{font:400 8px/11px ui-monospace,Menlo,monospace;color:var(--x-ink-3);
+  font-style:normal;white-space:nowrap;flex:none}
+.met{font:400 9px/13px ui-monospace,Menlo,monospace;color:var(--x-ink-2)}
+table.ev{width:100%;border-collapse:collapse}
+table.ev td{vertical-align:top;padding:2.5px 6px 2.5px 0;
+  border-bottom:1px solid var(--x-hairline);font:400 8.5px/11px var(--x-font)}
+td.t,td.v{font-family:ui-monospace,Menlo,monospace;white-space:nowrap}
+td.t{color:var(--x-accent)}
+td.v{color:var(--x-ink-2);max-width:150px;overflow:hidden;text-overflow:ellipsis}
+td.e{color:var(--x-ink-3)}"""
+
+
+def _of(group):
+    return [t for t in TOKENS if t[0] == group]
+
+
+def token_board():
+    swatches = "".join(
+        '<div class="sw"><div class="chip" style="background:var(--x-%s)"></div>'
+        '<b>--x-%s</b><i>%s</i></div>' % (n, n, v)
+        for g in ("Surface", "Line", "Ink", "Accent") for _, n, v, _ in _of(g))
+    radii = "".join(
+        '<div><div class="rb" style="border-radius:%s"></div><em>%s</em></div>' % (v, v)
+        for _, n, v, _ in _of("Radius") if n != "r-phone")
+    type_ = "".join(
+        '<div class="tr"><span style="font:var(--x-%s)">Grumpy wizards</span>'
+        '<em>--x-%s &middot; %s</em></div>' % (n, n, v.split(" var")[0])
+        for _, n, v, _ in _of("Type"))
+    met = "<br>".join("--x-%s: %s" % (n, v) for _, n, v, _ in _of("Metrics"))
+    return page(NAME + " - Design Tokens",
+                '<div class="sheet"><header><h1>%s</h1>'
+                '<p>Every value below is a placeholder. Replace each one, and its '
+                'evidence row, before the board means anything.</p></header>'
+                '<h2>Colour</h2><div class="grid">%s</div>'
+                '<h2>Radius</h2><div class="rad">%s</div>'
+                '<h2>Type</h2>%s'
+                '<h2>Metrics</h2><div class="met">%s</div></div>'
+                % (NAME, swatches, radii, type_, met), SHEET)
+
+
+EV_ROWS = 40   # rows that fit the 478 x 980 box; the table splits past this
+
+
+def evidence_boards():
+    """The evidence table, split across as many boards as it needs. It is the
+    deliverable of Phase 1: trim the board count, never the rows."""
+    pages = [TOKENS[i:i + EV_ROWS] for i in range(0, len(TOKENS), EV_ROWS)]
+    for i, chunk in enumerate(pages):
+        rows = "".join(
+            '<tr><td class="t">--x-%s</td><td class="v">%s</td><td class="e">%s</td></tr>'
+            % (n, v, e) for _, n, v, e in chunk)
+        of = " %d/%d" % (i + 1, len(pages)) if len(pages) > 1 else ""
+        yield ("00%s-evidence" % "bcdefgh"[i],
+               page(NAME + " - Evidence" + of,
+                    '<div class="sheet"><header><h1>Evidence%s</h1>'
+                    '<p>One row per token. A token with no evidence is a guess.</p>'
+                    '</header><table class="ev">%s</table></div>' % (of, rows), SHEET))
+
+
+# --------------------------------------------------------------- screens ----
+def demo():
+    """Replace me. An empty phone, to prove the frame and the tokens are wired."""
+    body = ('<div class="phone">%s'
+            '<div class="pad"><h1>Screen title</h1>'
+            '<div class="r">First row<span>Detail</span></div>'
+            '<div class="r">Second row<span>Detail</span></div>'
+            '<div class="r">Third row<span>Detail</span></div></div>'
+            '%s</div>' % (statusbar(), home()))
+    css = """.pad{position:absolute;left:var(--x-gutter);right:var(--x-gutter);
+  top:calc(var(--x-status) + 10px)}
+.pad h1{font:var(--x-t-title);margin-bottom:14px}
+.r{height:var(--x-row);display:flex;align-items:center;justify-content:space-between;
+  font:var(--x-t-row);border-bottom:1px solid var(--x-hairline)}
+.r span{font:var(--x-t-note);color:var(--x-ink-3)}"""
+    return page(NAME + " - Screen", body, css)
+
+
+SCREENS = [("01-screen", "Screen", demo)]
+
+# ------------------------------------------------- Phase 5: the reference ----
+# Each capture, unretouched and with its attribution watermark intact, on its
+# own board. Swap PLACEHOLDER_SHOT for the real base64 data: URI and keep the
+# rest: the caption is what makes the replica auditable a month from now.
+REF_CSS = """.rboard{width:430px;height:932px;background:#151311;border-radius:20px;
+  padding:14px 20px 12px;color:#fff;position:relative;overflow:hidden}
+.rboard h1{font:600 14px/18px var(--x-font);letter-spacing:-.1px}
+.rboard p{font:400 9.5px/13px ui-monospace,Menlo,monospace;color:rgba(255,255,255,.5);margin-top:2px}
+.rboard .shot{margin-top:9px;display:flex;justify-content:center}
+.rboard img{height:844px;width:auto;display:block;border-radius:6px}
+.rboard .near{color:#F1CD8A}"""
+
+PLACEHOLDER_SHOT = ("data:image/svg+xml;base64," + base64.b64encode(
+    b'<svg xmlns="http://www.w3.org/2000/svg" width="393" height="852">'
+    b'<rect width="393" height="852" fill="#221F1C"/>'
+    b'<rect x="8.5" y="8.5" width="376" height="835" rx="12" fill="none"'
+    b' stroke="#4A443E" stroke-width="1" stroke-dasharray="6 5"/>'
+    b'<text x="196" y="420" fill="#6E665D" text-anchor="middle"'
+    b' font-family="monospace" font-size="13">base64 capture goes here</text>'
+    b'</svg>').decode())
+
+# (screen file, label, note). The note is not decoration: state where a
+# reference is a *near* match -- a toast, another scroll position, one row
+# label off -- and never let a near-match pass as exact.
+REFS = [("01-screen", "Screen", "PLACEHOLDER - no capture yet")]
+
+
+def ref_boards():
+    for name, label, note in REFS:
+        cls = "" if note.startswith("exact") else ' class="near"'
+        body = ('<div class="rboard"><h1>%s &mdash; reference</h1>'
+                '<p>%s &middot; source &middot; 1179&times;2556 @3x &middot; '
+                '<span%s>%s</span></p>'
+                '<div class="shot"><img src="%s" alt="%s"></div></div>'
+                % (label, name, cls, note, PLACEHOLDER_SHOT, label))
+        yield "ref-" + name, page(NAME + " - reference: " + label, body, REF_CSS)
+
+
+# ------------------------------------------------------------------ run ----
+write("00-design-tokens", token_board())
+for name, html in evidence_boards():
+    write(name, html)
+for name, _, fn in SCREENS:
+    write(name, fn())
+for name, html in ref_boards():
+    write(name, html)
+
+LAYOUT = {
+ "name": NAME,
+ "rows": [
+  {"title": "Foundations",
+   "files": [{"file": "00-design-tokens", "label": "Design tokens"}]
+            + [{"file": n, "label": "Evidence"} for n, _ in evidence_boards()]},
+  {"title": "Screens", "numbered": True,
+   "files": [{"file": n, "label": l} for n, l, _ in SCREENS]},
+  # Same order as the row above: the canvas lays every row out from x = 0 at
+  # one pitch, so item N here lands column-for-column under item N up there.
+  {"title": "Source of truth: captures", "numbered": True,
+   "files": [{"file": "ref-" + n, "label": l} for n, l, _ in REFS]},
+ ],
+}
+(OUT / "layout.json").write_text(json.dumps(LAYOUT, indent=2) + "\n")
+print("layout.json", len(LAYOUT["rows"]), "rows")
+print("\nnext: python3 tools/refkit.py tokens", OUT)

--- a/mockups/canvases/templates/layout.json
+++ b/mockups/canvases/templates/layout.json
@@ -1,0 +1,38 @@
+{
+  "name": "Templates",
+  "rows": [
+    {
+      "title": "Foundations",
+      "files": [
+        {
+          "file": "00-design-tokens",
+          "label": "Design tokens"
+        },
+        {
+          "file": "00b-evidence",
+          "label": "Evidence"
+        }
+      ]
+    },
+    {
+      "title": "Screens",
+      "numbered": true,
+      "files": [
+        {
+          "file": "01-screen",
+          "label": "Screen"
+        }
+      ]
+    },
+    {
+      "title": "Source of truth: captures",
+      "numbered": true,
+      "files": [
+        {
+          "file": "ref-01-screen",
+          "label": "Screen"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Four board folders in, the same pieces were being rewritten each time: the
393×852 phone at 1pt = 1px, its 52pt corners and bezel, the 54pt status bar
with its 125×36 island and three glyphs, the home indicator, the token board,
the evidence table, the parked reference, and the `page()`/`write()` plumbing.

`mockups/canvases/templates/` is a real board, so you can open it on the canvas
and see the four boards a run always produces before copying anything.

```bash
cp -r mockups/canvases/templates mockups/canvases/<slug>
python3 mockups/canvases/<slug>/gen.py
```

## A template you copy, not a module you import

The bezel is byte-identical across boards, but the home indicator colour is
measured per **screen** (`luma-ios/gen.py` carries `hb='#F0F0F0'`, `'#E3E5E4'`,
`'#E4E5E5'`, `'#D8D5D6'`), and the island is 125×36 measured from a capture
against 126×37 measured from Figma. A shared frame edited for board five would
silently change four already-verified boards, in a repo that tracks per-screen
deltas to two decimals. Copying also keeps the existing invariant that a folder
regenerates itself byte-identically from its own `gen.py`.

## One structural change

The `:root` block and the evidence table are both generated from a single
`TOKENS` list of `(group, name, value, evidence)`. A value cannot drift from
the evidence behind it, and a token cannot ship without evidence at all. The
table paginates past `EV_ROWS`, which is the split onto `00b-evidence` the
skill currently asks for by hand.

CSS is written throughout with the placeholder prefix `--x-` and rewritten once
in `page()`, so the rules stay readable instead of `%s`-riddled.

## Verified

- `refkit tokens` passes on the folder, on a renamed copy, and on all six
  existing folders
- all four boards fit 478 × 980 under `shoot --check-overflow`
- the generator reproduces its own output byte-identically
- a copy with `NAME`/`P` changed emits zero `--x-` and the right `layout.json`
  page name
- `claude plugin validate .agents/skills` passes; `clone-prototype` is 492
  lines, under the 500-line guidance

## Note

This is the sixth board folder, and the welcome board is 1515px wide because
it was sized for exactly five cards (`5 × 239 + 4 × 80`). The card row is now
1834px, so it runs past the banner's right edge. Cosmetic and not addressed
here: the fix is `WELCOME_BOARD_SIZE` in `canvas/src/App.tsx` plus the body box
and banner height in `00-welcome/gen.py`, which also reflows that board.

🤖 Generated with [Claude Code](https://claude.com/claude-code)