### PR TITLE
canvas: fit a phone, load boards on demand

### DIFF
--- a/canvas/index.html
+++ b/canvas/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <meta name="theme-color" content="#f0eeec" />
     <link rel="icon" href="/favicon.ico" sizes="16x16 32x32 48x48" />
     <link rel="icon" type="image/png" href="/favicon-32.png" sizes="32x32" />

--- a/canvas/src/CanvasFileShapeUtil.tsx
+++ b/canvas/src/CanvasFileShapeUtil.tsx
@@ -6,7 +6,7 @@ import {
   type TLShape,
   useIsEditing,
 } from "tldraw";
-import { canvasFileHtml } from "./canvasLibrary";
+import { hasCanvasFile, useCanvasFileHtml } from "./canvasLibrary";
 
 export const CANVAS_FILE_SHAPE_TYPE = "canvas-file" as const;
 // Matches the v1.14+ phone mockups' own canvas: .phone{430x932} + body{padding:24px}.
@@ -28,7 +28,7 @@ export type CanvasFileShape = TLShape<typeof CANVAS_FILE_SHAPE_TYPE>;
 // oxlint-disable-next-line react/only-export-components
 function CanvasFile({ shape }: { shape: CanvasFileShape }) {
   const isEditing = useIsEditing(shape.id);
-  const html = canvasFileHtml.get(shape.props.path);
+  const html = useCanvasFileHtml(shape.props.path);
 
   return (
     <HTMLContainer
@@ -54,7 +54,9 @@ function CanvasFile({ shape }: { shape: CanvasFileShape }) {
             pointerEvents: isEditing ? "auto" : "none",
           }}
         />
-      ) : (
+      ) : hasCanvasFile(shape.props.path) ? null : (
+        // A board that exists but is not in yet renders nothing, so the frame fills in when its
+        // chunk arrives rather than flashing an error first.
         <div style={{ padding: 16, font: "13px sans-serif", color: "#a33" }}>
           Missing source: {shape.props.path}
         </div>

--- a/canvas/src/CanvasLinkShapeUtil.tsx
+++ b/canvas/src/CanvasLinkShapeUtil.tsx
@@ -6,7 +6,7 @@ import {
   type TLShape,
 } from "tldraw";
 import { CANVAS_FILE_DEFAULT_SIZE } from "./CanvasFileShapeUtil";
-import { canvasFileHtml, canvasIconUrl, readCanvasLayout } from "./canvasLibrary";
+import { canvasIconUrl, readCanvasLayout, useCanvasFileHtml } from "./canvasLibrary";
 
 export const CANVAS_LINK_SHAPE_TYPE = "canvas-link" as const;
 
@@ -88,7 +88,7 @@ export function fitCover(
 // oxlint-disable-next-line react/only-export-components
 function CanvasLink({ shape }: { shape: CanvasLinkShape }) {
   const { w, h, label, page, path } = shape.props;
-  const html = canvasFileHtml.get(path);
+  const html = useCanvasFileHtml(path);
   const icon = canvasIconUrl(page);
   const cover = fitCover(
     readCanvasLayout(page)?.coverBox ?? DEFAULT_COVER_BOX,

--- a/canvas/src/canvasChrome.tsx
+++ b/canvas/src/canvasChrome.tsx
@@ -14,21 +14,6 @@ const REPO_URL = "https://github.com/ReScienceLab/super-prototyping";
 /** The app the snapaction-ios boards are cloned from: its own site, not the App Store listing. */
 const SNAPACTION_URL = "https://snapaction.ai/";
 
-/** Both top-right CTAs are the same pill; only the fill and the icons differ. */
-const CTA = {
-  pointerEvents: "all",
-  display: "flex",
-  alignItems: "center",
-  gap: 9,
-  height: 46,
-  padding: "0 20px",
-  borderRadius: 12,
-  color: "#FFFFFF",
-  font: '700 15px/18px "Inter", ui-sans-serif, system-ui, -apple-system, sans-serif',
-  textDecoration: "none",
-  whiteSpace: "nowrap",
-} as const;
-
 const GITHUB_PATH =
   "M12 0c6.63 0 12 5.276 12 11.79-.001 5.067-3.29 9.567-8.175 11.187-.6.118-.825-.25-.825-.56 0-.398.015-1.665.015-3.242 0-1.105-.375-1.813-.81-2.181 2.67-.295 5.475-1.297 5.475-5.822 0-1.297-.465-2.344-1.23-3.169.12-.295.54-1.503-.12-3.125 0 0-1.005-.324-3.3 1.209a11.32 11.32 0 00-3-.398c-1.02 0-2.04.133-3 .398-2.295-1.518-3.3-1.209-3.3-1.209-.66 1.622-.24 2.83-.12 3.125-.765.825-1.23 1.887-1.23 3.169 0 4.51 2.79 5.527 5.46 5.822-.345.294-.66.81-.765 1.577-.69.31-2.415.81-3.495-.973-.225-.354-.9-1.223-1.845-1.209-1.005.015-.405.56.015.781.51.28 1.095 1.327 1.23 1.666.24.663 1.02 1.93 4.035 1.385 0 .988.015 1.916.015 2.196 0 .31-.225.664-.825.56C3.303 21.374-.003 16.867 0 11.791 0 5.276 5.37 0 12 0z";
 
@@ -46,7 +31,9 @@ export const canvasChromeComponents: TLComponents = {
    * style panel, which is where a tldraw app puts its share and account controls.
    */
   SharePanel: () => (
-    <div style={{ display: "flex", gap: 10, margin: "10px 12px 0 0" }}>
+    // The pill itself (size, type, the shimmer, and how it collapses to its mark on a phone)
+    // is .canvas-cta in index.css; what stays here is each one's own colour.
+    <div className="canvas-cta-group">
       <a
         href={SNAPACTION_URL}
         target="_blank"
@@ -54,7 +41,6 @@ export const canvasChromeComponents: TLComponents = {
         title="Try SnapAction, the app the example boards are cloned from"
         className="canvas-cta"
         style={{
-          ...CTA,
           border: "1px solid #4A4A56",
           background: "linear-gradient(180deg,#2A2A32,#17171C)",
           boxShadow: "0 6px 18px rgba(0,0,0,.45), inset 0 1px 0 rgba(255,255,255,.10)",
@@ -62,8 +48,10 @@ export const canvasChromeComponents: TLComponents = {
       >
         {/* The app's own mark, cut from its symbolset by snapaction-ios/gen.py. */}
         <img src="/snapaction.svg" width={23} height={18} alt="" />
-        <span>Try SnapAction</span>
-        <span style={{ color: "#8A8781", font: "inherit" }}>&#8599;</span>
+        <span className="canvas-cta__label">Try SnapAction</span>
+        <span className="canvas-cta__arrow" style={{ color: "#8A8781" }}>
+          &#8599;
+        </span>
       </a>
       <a
         href={REPO_URL}
@@ -72,7 +60,6 @@ export const canvasChromeComponents: TLComponents = {
         title="Star super-prototyping on GitHub"
         className="canvas-cta"
         style={{
-          ...CTA,
           border: "1px solid #6E9BFF",
           background: "linear-gradient(180deg,#4A85FF,#1B47D2)",
           // The glow is the point: this is the one thing on the canvas asking for something,
@@ -84,7 +71,7 @@ export const canvasChromeComponents: TLComponents = {
         <svg viewBox="0 0 24 24" width="19" height="19" fill="#FFD666" aria-hidden>
           <path d="M12 2.6l2.9 5.9 6.5.95-4.7 4.6 1.1 6.45L12 17.45 6.2 20.5l1.1-6.45-4.7-4.6 6.5-.95z" />
         </svg>
-        <span>Star on GitHub</span>
+        <span className="canvas-cta__label">Star on GitHub</span>
         <svg viewBox="0 0 24 24" width="18" height="18" fill="#FFFFFF" fillRule="evenodd" aria-hidden>
           <path d={GITHUB_PATH} />
         </svg>

--- a/canvas/src/canvasLibrary.ts
+++ b/canvas/src/canvasLibrary.ts
@@ -1,12 +1,16 @@
+import { useEffect, useState } from "react";
+
 // Auto-discovers the boards dropped under mockups/canvases/<slug>/*.html, one folder per board
 // (a cloned app, a feature round, a design-system sheet). Each folder becomes a tldraw page; each
 // HTML file in it becomes one shape. Add or edit files there; nothing here needs to change.
-// `eager: true` keeps the HTML live through Vite HMR, so saving a mockup reloads it on the canvas.
-const rawFiles = import.meta.glob("../../mockups/canvases/*/*.html", {
-  eager: true,
+// Each file is its own lazy module, fetched the first time a shape on screen asks for it, so
+// opening the welcome page pulls a dozen covers rather than every board in the repo (the full
+// set is 25 MB of HTML, which a phone should not download to look at one page). Vite still
+// reloads the page when a mockup is saved, so the edit shows up on the canvas the same as before.
+const fileLoaders = import.meta.glob("../../mockups/canvases/*/*.html", {
   query: "?raw",
   import: "default",
-}) as Record<string, string>;
+}) as Record<string, () => Promise<string>>;
 
 // Optional mockups/canvases/<slug>/layout.json alongside the HTML files declares that board's
 // themed rows, so this tool's code never has to know one board's design content from another's.
@@ -115,8 +119,57 @@ function parse(path: string): CanvasLibraryFile | null {
   };
 }
 
-/** path -> raw HTML, read by CanvasFileShapeUtil at render time. */
-export const canvasFileHtml = new Map(Object.entries(rawFiles));
+/** path -> raw HTML for every file fetched so far. Filled by loadCanvasFileHtml. */
+export const canvasFileHtml = new Map<string, string>();
+const canvasFileLoads = new Map<string, Promise<string | undefined>>();
+
+/** Whether a discovered board exists at this path, loaded or not. */
+export function hasCanvasFile(path: string) {
+  return path in fileLoaders;
+}
+
+/** Fetches a board's HTML once and caches it; resolves undefined for a path that is not a board. */
+export function loadCanvasFileHtml(path: string): Promise<string | undefined> {
+  const cached = canvasFileHtml.get(path);
+  if (cached !== undefined) return Promise.resolve(cached);
+  const loader = fileLoaders[path];
+  if (!loader) return Promise.resolve(undefined);
+  let load = canvasFileLoads.get(path);
+  if (!load) {
+    load = loader().then((html) => {
+      canvasFileHtml.set(path, html);
+      canvasFileLoads.delete(path);
+      return html;
+    });
+    canvasFileLoads.set(path, load);
+  }
+  return load;
+}
+
+/**
+ * A rendering shape's board HTML: undefined until its chunk arrives, then the string. tldraw only
+ * mounts components for shapes near the viewport, so this is what makes a page cost its own
+ * boards and nothing else.
+ */
+export function useCanvasFileHtml(path: string): string | undefined {
+  const [html, setHtml] = useState(() => canvasFileHtml.get(path));
+  useEffect(() => {
+    let live = true;
+    const cached = canvasFileHtml.get(path);
+    if (cached !== undefined) {
+      setHtml(cached);
+      return;
+    }
+    setHtml(undefined);
+    loadCanvasFileHtml(path).then((loaded) => {
+      if (live) setHtml(loaded);
+    });
+    return () => {
+      live = false;
+    };
+  }, [path]);
+  return html;
+}
 
 const LAYOUT_PATTERN = /canvases\/([^/]+)\/layout\.json$/;
 
@@ -143,7 +196,7 @@ export function canvasIconUrl(pageSlug: string) {
 /** Every discovered board, grouped by page and sorted by filename within it. */
 export function readCanvasLibrary(): CanvasLibraryFile[][] {
   const byPage = new Map<string, CanvasLibraryFile[]>();
-  for (const path of Object.keys(rawFiles)) {
+  for (const path of Object.keys(fileLoaders)) {
     const file = parse(path);
     if (!file) continue;
     const list = byPage.get(file.pageSlug) ?? [];

--- a/canvas/src/index.css
+++ b/canvas/src/index.css
@@ -31,14 +31,32 @@ button {
 }
 
 /*
- * The two top-right CTAs (canvasChrome.tsx). A shimmer sweeps across each one every few
- * seconds: they are the only things on the canvas asking for something, so they get the only
- * motion on it. The second is offset so the pair does not flash in lockstep. Each pill's own
- * fill, border and glow stay inline over there, next to the copy they belong to.
+ * The two top-right CTAs (canvasChrome.tsx). The pill is one shape shared by both; each one's
+ * fill, border and glow stay inline over there, next to the copy they belong to. A shimmer
+ * sweeps across each one every few seconds: they are the only things on the canvas asking for
+ * something, so they get the only motion on it. The second is offset so the pair does not
+ * flash in lockstep.
  */
+.canvas-cta-group {
+  display: flex;
+  gap: 10px;
+  margin: 10px 12px 0 0;
+}
+
 .canvas-cta {
   position: relative;
   overflow: hidden;
+  pointer-events: all;
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  height: 46px;
+  padding: 0 20px;
+  border-radius: 12px;
+  color: #ffffff;
+  font: 700 15px/18px Inter, ui-sans-serif, system-ui, -apple-system, sans-serif;
+  text-decoration: none;
+  white-space: nowrap;
 }
 
 .canvas-cta::after {
@@ -57,6 +75,28 @@ button {
 
 .canvas-cta + .canvas-cta::after {
   animation-delay: 0.7s;
+}
+
+/*
+ * On a phone the two pills with their labels are wider than the screen, and the second one
+ * was cut off at the right edge. Down to the marks alone they fit beside the page menu and
+ * still read: the app's own icon and the star.
+ */
+@media (max-width: 720px) {
+  .canvas-cta-group {
+    gap: 8px;
+    margin: 8px 8px 0 0;
+  }
+
+  .canvas-cta {
+    height: 40px;
+    padding: 0 12px;
+  }
+
+  .canvas-cta__label,
+  .canvas-cta__arrow {
+    display: none;
+  }
 }
 
 @keyframes canvas-cta-shimmer {

--- a/canvas/vite.config.ts
+++ b/canvas/vite.config.ts
@@ -25,32 +25,18 @@ function repoRootMeta(): Plugin {
   };
 }
 
-/**
- * One chunk per board folder. Every board's HTML is inlined as a string, and the biggest
- * folders run to several MB each; in one bundle they push past the 25 MiB per-file limit
- * Cloudflare Pages enforces, so each `mockups/canvases/<slug>/` becomes its own `board-<slug>`
- * chunk instead.
- */
-const BOARD_FOLDER = /\/mockups\/canvases\/([^/]+)\//;
-
 export default defineConfig({
   plugins: [react(), repoRootMeta()],
+  server: {
+    // The boards sit one level up from this app. The eager glob used to pull every file into
+    // the module graph at startup, which is what let the dev server hand them out; now that
+    // they load on demand the folder has to be allowed outright.
+    fs: { allow: [repoRoot] },
+  },
   build: {
-    chunkSizeWarningLimit: 8_000,
-    rolldownOptions: {
-      output: {
-        advancedChunks: {
-          groups: [
-            {
-              name: (id) => {
-                const slug = BOARD_FOLDER.exec(id)?.[1];
-                return slug ? `board-${slug}` : undefined;
-              },
-              test: BOARD_FOLDER,
-            },
-          ],
-        },
-      },
-    },
+    // Every board under mockups/canvases is its own lazy chunk (canvasLibrary.ts), fetched when
+    // a shape first shows it. The largest single board is a few MB of inlined images, which is
+    // the size of the thing and not a bundling mistake, so the warning starts above it.
+    chunkSizeWarningLimit: 4_000,
   },
 });

--- a/docs/2026-09-03-boards-load-on-demand.md
+++ b/docs/2026-09-03-boards-load-on-demand.md
@@ -1,0 +1,32 @@
+# Boards load on demand, and the canvas fits a phone
+
+2026-09-03. The canvas is public at prototyping.rescience.com now, so it has to work on a
+phone, not only on the laptop it was built on.
+
+## What was wrong
+
+- The board HTML was bundled eagerly: every file under `mockups/canvases` (25 MB) came down
+  before the first page drew. On a phone that is the whole visit.
+- The two top-right pills with their labels were wider than a 393 px screen; the second one
+  was cut off.
+- The viewport meta lacked `viewport-fit=cover`, which tldraw's own CSS needs to keep the
+  toolbar clear of the home indicator.
+
+## What changed
+
+- `canvas/src/canvasLibrary.ts` globs the boards lazily. Each file is its own chunk, fetched
+  the first time a shape on screen asks for it through `useCanvasFileHtml`. tldraw only mounts
+  shapes near the viewport, so a page costs its own boards and nothing else: the welcome page
+  fetches 13 covers, the SnapAction page fetches its 13 boards (2.8 MB) instead of all 25 MB.
+- The per-folder `advancedChunks` grouping in `vite.config.ts` is gone; per-file chunks fall
+  out of the dynamic imports. `server.fs.allow` now includes the repo root, because the boards
+  sit outside the Vite root and the eager glob was the only thing that had let the dev server
+  hand them out.
+- The CTA pill is a CSS class in `index.css`. Under 720 px the labels hide and each pill is
+  just its mark (the SnapAction icon, the star and GitHub logo).
+
+## Not changed
+
+- `zoomToFit` on open is kept. On a portrait phone a 2153 px wide board is small, but the
+  overview is the point of the page, and pinch-zoom is tldraw's own.
+- Real iOS Safari was not available here. The checks ran under Chrome's iPhone emulation.


### PR DESCRIPTION
## Summary
- Board HTML loads lazily per file (`useCanvasFileHtml`), so a page fetches only the boards on it. Welcome page: 13 covers. SnapAction page: 2.8 MB instead of the full 25 MB bundle.
- Top-right CTAs collapse to icon-only under 720 px; they overflowed a 393 px screen before.
- `viewport-fit=cover` on the viewport meta for tldraw's safe-area CSS.
- Dev server `fs.allow` includes the repo root; the eager glob was what had let `/@fs/` serve the boards.
- Drops the per-folder `advancedChunks` grouping; per-file chunks come from the dynamic imports.
- Decision note in `docs/2026-09-03-boards-load-on-demand.md`.

## Test plan
- [x] `bun run build`, `bun run lint`, `bun run test`
- [x] Chrome iPhone emulation on the dev server: CTAs fit, welcome page loads 13 covers, SnapAction page loads only `snapaction-ios/*`
- [ ] Real iOS Safari once the hosted site has a tldraw license key

🤖 Generated with [Claude Code](https://claude.com/claude-code)