### PR TITLE
Lock every library shape so readers cannot drag mockups

### DIFF
--- a/canvas/src/App.tsx
+++ b/canvas/src/App.tsx
@@ -6,6 +6,7 @@ import {
   toRichText,
   type Editor,
   type TLPageId,
+  type TLShapeId,
   type TLDefaultColorStyle,
   type TLTextShape,
   useEditor,
@@ -24,6 +25,7 @@ import {
   CANVAS_LINK_SHAPE_TYPE,
   type CanvasLinkShape,
   CanvasLinkShapeUtil,
+  installLockedLinkClicks,
 } from "./CanvasLinkShapeUtil";
 import {
   type CanvasLayoutLink,
@@ -85,9 +87,41 @@ const LIBRARY_LABEL_GAP = 12;
 const LIBRARY_LABEL_HEIGHT = 28;
 const LIBRARY_HEADING_HEIGHT = 44;
 
+/**
+ * Id prefixes of everything the library places: boards, row headings, captions, and the cards
+ * and buttons that open things. They are all created locked, and `lockLibraryShapes` locks any
+ * that a browser persisted before that was so. Locked, a shape cannot be selected, so a reader
+ * who means to pinch or scroll cannot drag a board out of its row by accident; the camera is the
+ * only thing that moves. The layout is declared in layout.json, so a board is never repositioned
+ * by hand anyway. Anything a person draws on top stays unlocked and editable.
+ */
+const LIBRARY_SHAPE_PREFIXES = [
+  "shape:canvas-file:",
+  "shape:canvas-row-heading:",
+  "shape:canvas-file-label:",
+  "shape:canvas-link:",
+];
+
+function isLibraryShapeId(id: string) {
+  return LIBRARY_SHAPE_PREFIXES.some((prefix) => id.startsWith(prefix));
+}
+
+/** Deletes library shapes, which are locked and would otherwise be skipped by `deleteShapes`. */
+function deleteLibraryShapes(editor: Editor, ids: TLShapeId[]) {
+  if (!ids.length) return;
+  editor.run(() => editor.deleteShapes(ids), { ignoreShapeLock: true });
+}
+
 function AgentBridge() {
   const editor = useEditor();
   useEffect(() => installAgentBridge(editor), [editor]);
+  return null;
+}
+
+/** Cards and buttons are locked like everything else the library places; this keeps them clickable. */
+function LockedLinkClicks() {
+  const editor = useEditor();
+  useEffect(() => installLockedLinkClicks(editor), [editor]);
   return null;
 }
 
@@ -135,6 +169,7 @@ function createAnnotation(
       type: "text",
       x: annotation.x,
       y: annotation.y,
+      isLocked: true,
       props: { richText: toRichText(annotation.text), w: annotation.w },
     });
     return;
@@ -146,6 +181,7 @@ function createAnnotation(
     x: annotation.x,
     y: annotation.y,
     parentId: annotation.parentId,
+    isLocked: true,
     props: {
       autoSize: false,
       color: annotation.color ?? "black",
@@ -202,6 +238,7 @@ function layoutRow(
         parentId: page.id,
         x: rowX(rowFiles.indexOf(file)),
         y: contentY,
+        isLocked: true,
         props: {
           ...size,
           name: file.title,
@@ -230,6 +267,7 @@ function layoutRow(
         parentId: page.id,
         x: index * (CANVAS_LINK_BUTTON_SIZE.w + LIBRARY_LABEL_GAP),
         y: linksY,
+        isLocked: true,
         props: {
           ...CANVAS_LINK_BUTTON_SIZE,
           label: link.label,
@@ -300,7 +338,7 @@ function layoutWelcomeExtras(
   // The repo CTA used to be a shape parked in the welcome board's header. It is chrome now
   // (canvasChrome.tsx, SharePanel), so a canvas saved before that still has to lose its copy.
   const starId = linkShapeId("star");
-  if (editor.getShape(starId)) editor.deleteShape(starId);
+  if (editor.getShape(starId)) deleteLibraryShapes(editor, [starId]);
   if (!targets.length) return;
 
   // Two rows, because twelve cards in one row read as a list of twelve unrelated things: the
@@ -330,7 +368,7 @@ function layoutWelcomeExtras(
   const orphans = [...editor.getPageShapeIds(page.id)].filter(
     (id) => id.startsWith("shape:canvas-row-heading:") && !kept.has(id),
   );
-  if (orphans.length) editor.deleteShapes(orphans);
+  deleteLibraryShapes(editor, orphans);
 
   const cardX = (index: number) =>
     index * (CANVAS_LINK_CARD_SIZE.w + LIBRARY_GAP);
@@ -351,6 +389,7 @@ function layoutWelcomeExtras(
         parentId: page.id,
         x: cardX(index),
         y: contentY,
+        isLocked: true,
         props: {
           ...CANVAS_LINK_CARD_SIZE,
           label: files[0].pageName,
@@ -382,6 +421,7 @@ function layoutWelcomeExtras(
           type: card.type,
           x: card.x,
           y: card.y,
+          isLocked: true,
           props: { ...card.props },
         });
       }
@@ -505,6 +545,7 @@ function initializeCanvasLibrary(editor: Editor) {
             id: fileShapeId(file),
             type: CANVAS_FILE_SHAPE_TYPE,
             parentId: page.id,
+            isLocked: true,
             x: columnX(index % LIBRARY_COLUMNS),
             y:
               rowTop +
@@ -525,8 +566,26 @@ function initializeCanvasLibrary(editor: Editor) {
     }
   }
 
+  lockLibraryShapes(editor);
   pruneEmptyOrphanPages(editor, libraryPages);
   orderPagesByLibrary(editor, libraryPages);
+}
+
+/**
+ * Locks every library shape that is not locked yet. New ones are created locked; this is for
+ * shapes a browser persisted before they were, and for any unlocked with "Unlock all" to be
+ * nudged in the meantime. They lock again on the next load, so the layout is not left movable
+ * for the next reader by accident.
+ */
+function lockLibraryShapes(editor: Editor) {
+  const unlocked = editor
+    .getPages()
+    .flatMap((page) => [...editor.getPageShapeIds(page.id)])
+    .filter(isLibraryShapeId)
+    .map((id) => editor.getShape(id))
+    .filter((shape) => shape && !shape.isLocked)
+    .map((shape) => ({ id: shape!.id, type: shape!.type, isLocked: true }));
+  if (unlocked.length) editor.updateShapes(unlocked);
 }
 
 /**
@@ -579,17 +638,11 @@ function pruneEmptyOrphanPages(editor: Editor, libraryPages: Set<TLPageId>) {
  * refresh that clears that drift. Hand-drawn shapes and notes are untouched.
  */
 function relayoutCanvasLibrary(editor: Editor) {
-  const prefixes = [
-    "shape:canvas-file:",
-    "shape:canvas-row-heading:",
-    "shape:canvas-file-label:",
-    "shape:canvas-link:",
-  ];
   for (const page of editor.getPages()) {
-    const staleIds = [...editor.getPageShapeIds(page.id)].filter((id) =>
-      prefixes.some((prefix) => id.startsWith(prefix)),
+    deleteLibraryShapes(
+      editor,
+      [...editor.getPageShapeIds(page.id)].filter(isLibraryShapeId),
     );
-    if (staleIds.length) editor.deleteShapes(staleIds);
   }
   initializeCanvasLibrary(editor);
 }
@@ -661,6 +714,7 @@ export default function App() {
           onMount={handleMount}
         >
           <AgentBridge />
+          <LockedLinkClicks />
           <WelcomeGround />
         </Tldraw>
       </main>

--- a/canvas/src/CanvasLinkShapeUtil.tsx
+++ b/canvas/src/CanvasLinkShapeUtil.tsx
@@ -1,8 +1,10 @@
 import {
   BaseBoxShapeUtil,
+  type Editor,
   HTMLContainer,
   T,
   type RecordProps,
+  type TLEventInfo,
   type TLShape,
 } from "tldraw";
 import { CANVAS_FILE_DEFAULT_SIZE } from "./CanvasFileShapeUtil";
@@ -96,6 +98,9 @@ function CanvasLink({ shape }: { shape: CanvasLinkShape }) {
     SCREEN.h,
   );
 
+  // `pointerEvents: "all"` is for the cursor alone: tldraw draws shapes with pointer-events off
+  // and does its own hit-testing on the canvas, which these events still bubble up to. A shape
+  // that never receives the pointer cannot show a hand over itself.
   const frame = {
     width: w,
     height: h,
@@ -104,6 +109,7 @@ function CanvasLink({ shape }: { shape: CanvasLinkShape }) {
     background: GROUND,
     border: EDGE,
     cursor: "pointer",
+    pointerEvents: "all",
   } as const;
 
   if (!path) {
@@ -139,6 +145,7 @@ function CanvasLink({ shape }: { shape: CanvasLinkShape }) {
         alignItems: "center",
         justifyContent: "center",
         cursor: "pointer",
+        pointerEvents: "all",
         position: "relative",
       }}
     >
@@ -206,12 +213,61 @@ function CanvasLink({ shape }: { shape: CanvasLinkShape }) {
 }
 
 /**
+ * Click handling for locked links. The library creates every card and button locked, like the
+ * boards, so a reader cannot drag one while trying to pan. tldraw treats a pointer that lands on
+ * a locked shape as one that landed on the canvas, though, so a locked shape's `onClick` never
+ * runs. This watches the editor's own pointer events instead: a press and a release over the
+ * same locked link, with no drag and no pinch in between, is a click, and runs that link's
+ * `onClick`. Links that are not locked keep tldraw's own handling, so nothing fires twice.
+ */
+export function installLockedLinkClicks(editor: Editor) {
+  const linkUnderPointer = () =>
+    editor.getShapeAtPoint(editor.inputs.getCurrentPagePoint(), {
+      hitInside: true,
+      hitLocked: true,
+      renderingOnly: true,
+      filter: (shape) => shape.type === CANVAS_LINK_SHAPE_TYPE && shape.isLocked,
+    }) as CanvasLinkShape | undefined;
+
+  let pressed: CanvasLinkShape | undefined;
+  const onEvent = (info: TLEventInfo) => {
+    if (info.type !== "pointer") {
+      // Two fingers arriving, or a wheel, in the middle of a press: a zoom, not a click.
+      if (info.type === "pinch" || info.type === "wheel") pressed = undefined;
+      return;
+    }
+    if (info.name === "pointer_down") {
+      // Only the select tool follows links, as with tldraw's own `onClick`; a click with the
+      // pen or the eraser over a card is a stroke or an erase, not a navigation.
+      pressed =
+        info.button === 0 &&
+        editor.getCurrentToolId() === "select" &&
+        !editor.menus.hasAnyOpenMenus()
+          ? linkUnderPointer()
+          : undefined;
+      return;
+    }
+    if (info.name !== "pointer_up") return;
+    const target = pressed;
+    pressed = undefined;
+    if (!target || editor.inputs.getIsDragging()) return;
+    if (linkUnderPointer()?.id !== target.id) return;
+    editor.getShapeUtil<CanvasLinkShape>(target).onClick?.(target);
+  };
+
+  editor.on("event", onEvent);
+  return () => {
+    editor.off("event", onEvent);
+  };
+}
+
+/**
  * A clickable card or button on the welcome page: `page` switches to another board's page,
  * `url` opens an address in a new tab. Boards themselves render in `<iframe srcDoc sandbox="">`,
  * where a link cannot navigate anything, so anything clickable has to be a shape out here.
  *
- * Defining `onClick` also stops tldraw selecting the shape on pointer down, so a single
- * click follows the link instead of putting a selection box around it.
+ * The shape is locked on the canvas (App.tsx, LIBRARY_SHAPE_PREFIXES), so clicks reach
+ * `onClick` through `installLockedLinkClicks` rather than through tldraw's select tool.
  */
 export class CanvasLinkShapeUtil extends BaseBoxShapeUtil<CanvasLinkShape> {
   static override type = CANVAS_LINK_SHAPE_TYPE;

--- a/docs/2026-09-03-mockups-locked.md
+++ b/docs/2026-09-03-mockups-locked.md
@@ -1,0 +1,39 @@
+# Mockups are locked on the canvas
+
+2026-09-03. Readers of prototyping.rescience.com were dragging boards out of their rows when
+they meant to pinch or scroll. A viewer should be able to move the camera and nothing else.
+
+## What changed
+
+- Every shape the library places is created with `isLocked: true`: the boards, the row
+  headings, the captions, and the cards and buttons on the welcome page. Locked, a shape cannot
+  be selected, dragged, resized or deleted by pointer; only the camera moves. The id prefixes
+  that count as library shapes are in one list, `LIBRARY_SHAPE_PREFIXES` in `App.tsx`.
+- `lockLibraryShapes` runs on every load and locks any library shape that is not, for canvases a
+  browser persisted before this change, and for anything unlocked by hand with "Unlock all".
+- tldraw treats a pointer that lands on a locked shape as one that landed on the canvas, so a
+  locked shape's `onClick` never runs and the welcome cards would have stopped opening pages.
+  `installLockedLinkClicks` in `CanvasLinkShapeUtil.tsx` listens to the editor's own pointer
+  events instead: press and release over the same locked link, with no drag and no pinch in
+  between, runs that link's `onClick`. Only the select tool follows links, as before. The card
+  and button containers take pointer events for the hand cursor alone; hit-testing stays with
+  the canvas.
+- Deleting a locked shape is a no-op in tldraw, so the force-refresh button and the welcome
+  page's stale-shape cleanup delete through `editor.run(fn, { ignoreShapeLock: true })`.
+
+## Not changed
+
+- Hand-drawn shapes and notes are still unlocked and editable. Only what the library places is
+  locked.
+- Positions are still declared by `layout.json`. A board unlocked with "Unlock all" and dragged
+  keeps its new position (creation is idempotent) and locks again on the next load; the
+  force-refresh button puts it back where the layout says.
+- Double-clicking a board no longer enters edit mode, so a board's own scrolling is not
+  reachable. No board in the library scrolls today.
+
+## Checked
+
+Headless Chrome with CDP against the dev server: mouse drag and touch drag on a board and on a
+card leave them where they are; a click or tap on a card opens its page; a URL button opens a
+new tab; a caption unlocked and moved through the agent bridge is locked again after reload,
+and put back by force refresh.


### PR DESCRIPTION
Readers of prototyping.rescience.com were dragging boards when they meant to pinch or scroll. Every shape the library places (boards, headings, captions, welcome cards and buttons) is now created \`isLocked: true\` and re-locked on load, so only the camera moves. Hand-drawn shapes stay editable.

- tldraw never runs \`onClick\` on a locked shape, so \`installLockedLinkClicks\` fires card/button clicks from the editor's pointer events (press and release on the same link, no drag, no pinch, select tool only).
- Force refresh and the welcome page's stale-shape cleanup delete through \`editor.run(fn, { ignoreShapeLock: true })\`.
- Decision note: \`docs/2026-09-03-mockups-locked.md\`.

Checked in headless Chrome via CDP (mouse and touch): drags on boards and cards leave them in place, taps/clicks on cards open their page, URL buttons open a tab, a shape unlocked and moved is locked again after reload and put back by force refresh. Build, oxlint and vitest pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)