### PR TITLE
Phone frames composite themselves so Safari clips their rounded corners

### DIFF
--- a/docs/2026-09-03-phone-corners-safari.md
+++ b/docs/2026-09-03-phone-corners-safari.md
@@ -1,0 +1,57 @@
+# Phone frames composite themselves so Safari clips their corners
+
+2026-09-03. Yilin opened the Luma canvas in Safari on an iPhone and the screens painted
+square: the olive screen background ran past the four rounded corners of the bezel, at a
+canvas zoom of roughly 0.4.
+
+## What happened
+
+Every phone frame is `.phone{border-radius:52px;overflow:hidden;box-shadow:<bezel rings>}`
+with the screen content inside. Some of that content is composited on its own layer: the
+Luma boards blur a background image (`filter:blur`) and put a glass nav bar over it
+(`backdrop-filter`); Raycast blurs rows and the home screen behind sheets; Apple Calendar and
+Settings use backdrop-filter for their bars and sheets. WebKit clips composited children of
+a *non-composited* ancestor through a rectangular ancestor clip, and in some versions and on
+some devices that path drops the corner radius. The straight edges still clip (the bezel
+rings stay visible along the sides) but the corners fill in square, which is exactly the
+screenshot.
+
+The iOS 26.3 simulator renders the corners correctly at every zoom tried (0.42, 0.8, 1,
+1.02, 1.5), inside tldraw and on the raw board, so the fault could not be reproduced here
+and is tied to the device or iOS build.
+
+## What changed
+
+`transform:translateZ(0)` on `.phone`, in the generators and the generated HTML:
+
+- `mockups/canvases/luma-ios` (gen.py BASE CSS and all 19 boards)
+- `mockups/canvases/apple-calendar`, `apple-settings` (gen.py PHONE and the boards that carry it)
+- `mockups/canvases/raycast-ios` (hand-written boards)
+- `mockups/canvases/templates` (gen.py PHONE and the template boards, so new folders inherit it)
+
+A composited frame clips its children with its own rounded mask rather than through the
+ancestor clip, which is the long-standing WebKit remedy for rounded `overflow:hidden` not
+clipping composited descendants. It is visually a no-op: headless Chrome and the iOS
+simulator render the Luma board pixel-for-pixel as before, including the 60px nav blur.
+
+## What was tried and rejected
+
+- A `.screen` wrapper with `clip-path:inset(0 round 52px)` (or a `-webkit-mask-image`)
+  around the content. It clips reliably, but a clip-path or mask on an ancestor turns it
+  into a backdrop root and the nav's `backdrop-filter:blur(60px)` degraded to a faint blur
+  in both Safari and Chrome: the Invite and More buttons showed through the nav.
+- `isolation:isolate` on the wrapper darkened the nav band on iOS.
+- `clip-path` on `.phone` itself would cut off the bezel rings and drop shadow, which are
+  box-shadows outside the border box.
+
+## How it was checked
+
+- Raw board (`05-host-stats.html`) before and after, headless Chrome and iPhone 17
+  simulator: identical, nav blur uniform, corners clean.
+- Dev canvas in the simulator at zoom 0.42 and 1 via a temporary camera hook (removed).
+- Folders without blur or backdrop-filter (Photos, Wallet, Claude, Duolingo, Notion,
+  SnapAction, Spotify, Welcome) were left alone: nothing in their frames is composited.
+
+Generation note: `luma-ios/gen.py` cannot run end to end in a fresh checkout because
+`refassets.json` and `walkassets.json` are uncommitted local files, so the HTML for this
+change was patched with the same string replacement as the source.

--- a/mockups/canvases/apple-calendar/01-today-events.html
+++ b/mockups/canvases/apple-calendar/01-today-events.html
@@ -111,7 +111,7 @@
 }
 *{box-sizing:border-box;margin:0;padding:0}
 body{font-family:var(--ac-font);background:#fff;-webkit-font-smoothing:antialiased;display:flex;justify-content:center;padding:24px}
-.phone{width:var(--ac-w);height:var(--ac-h);position:relative;flex:none;overflow:hidden;border-radius:var(--ac-r-phone);background:var(--ac-bg);color:var(--ac-ink);outline:1px solid rgba(0,0,0,.10);box-shadow:0 0 0 11px #1D191A,0 0 0 12.5px #3A3735,0 24px 60px rgba(29,25,26,.28)}
+.phone{width:var(--ac-w);height:var(--ac-h);position:relative;flex:none;overflow:hidden;border-radius:var(--ac-r-phone);background:var(--ac-bg);color:var(--ac-ink);transform:translateZ(0);outline:1px solid rgba(0,0,0,.10);box-shadow:0 0 0 11px #1D191A,0 0 0 12.5px #3A3735,0 24px 60px rgba(29,25,26,.28)}
 .sb{position:absolute;left:0;right:0;top:0;height:var(--ac-sb);z-index:8}
 .sb .t{position:absolute;left:10px;top:18px;width:123.5px;height:22px;text-align:center;font:var(--ac-t-b17)}
 .sb .island{position:absolute;left:133.5px;top:11px;width:var(--ac-island-w);height:var(--ac-island-h);border-radius:var(--ac-r-pill);background:var(--ac-black)}

--- a/mockups/canvases/apple-calendar/02-today-empty.html
+++ b/mockups/canvases/apple-calendar/02-today-empty.html
@@ -111,7 +111,7 @@
 }
 *{box-sizing:border-box;margin:0;padding:0}
 body{font-family:var(--ac-font);background:#fff;-webkit-font-smoothing:antialiased;display:flex;justify-content:center;padding:24px}
-.phone{width:var(--ac-w);height:var(--ac-h);position:relative;flex:none;overflow:hidden;border-radius:var(--ac-r-phone);background:var(--ac-bg);color:var(--ac-ink);outline:1px solid rgba(0,0,0,.10);box-shadow:0 0 0 11px #1D191A,0 0 0 12.5px #3A3735,0 24px 60px rgba(29,25,26,.28)}
+.phone{width:var(--ac-w);height:var(--ac-h);position:relative;flex:none;overflow:hidden;border-radius:var(--ac-r-phone);background:var(--ac-bg);color:var(--ac-ink);transform:translateZ(0);outline:1px solid rgba(0,0,0,.10);box-shadow:0 0 0 11px #1D191A,0 0 0 12.5px #3A3735,0 24px 60px rgba(29,25,26,.28)}
 .sb{position:absolute;left:0;right:0;top:0;height:var(--ac-sb);z-index:8}
 .sb .t{position:absolute;left:10px;top:18px;width:123.5px;height:22px;text-align:center;font:var(--ac-t-b17)}
 .sb .island{position:absolute;left:133.5px;top:11px;width:var(--ac-island-w);height:var(--ac-island-h);border-radius:var(--ac-r-pill);background:var(--ac-black)}

--- a/mockups/canvases/apple-calendar/03-month.html
+++ b/mockups/canvases/apple-calendar/03-month.html
@@ -111,7 +111,7 @@
 }
 *{box-sizing:border-box;margin:0;padding:0}
 body{font-family:var(--ac-font);background:#fff;-webkit-font-smoothing:antialiased;display:flex;justify-content:center;padding:24px}
-.phone{width:var(--ac-w);height:var(--ac-h);position:relative;flex:none;overflow:hidden;border-radius:var(--ac-r-phone);background:var(--ac-bg);color:var(--ac-ink);outline:1px solid rgba(0,0,0,.10);box-shadow:0 0 0 11px #1D191A,0 0 0 12.5px #3A3735,0 24px 60px rgba(29,25,26,.28)}
+.phone{width:var(--ac-w);height:var(--ac-h);position:relative;flex:none;overflow:hidden;border-radius:var(--ac-r-phone);background:var(--ac-bg);color:var(--ac-ink);transform:translateZ(0);outline:1px solid rgba(0,0,0,.10);box-shadow:0 0 0 11px #1D191A,0 0 0 12.5px #3A3735,0 24px 60px rgba(29,25,26,.28)}
 .sb{position:absolute;left:0;right:0;top:0;height:var(--ac-sb);z-index:8}
 .sb .t{position:absolute;left:10px;top:18px;width:123.5px;height:22px;text-align:center;font:var(--ac-t-b17)}
 .sb .island{position:absolute;left:133.5px;top:11px;width:var(--ac-island-w);height:var(--ac-island-h);border-radius:var(--ac-r-pill);background:var(--ac-black)}

--- a/mockups/canvases/apple-calendar/04-whats-new.html
+++ b/mockups/canvases/apple-calendar/04-whats-new.html
@@ -111,7 +111,7 @@
 }
 *{box-sizing:border-box;margin:0;padding:0}
 body{font-family:var(--ac-font);background:#fff;-webkit-font-smoothing:antialiased;display:flex;justify-content:center;padding:24px}
-.phone{width:var(--ac-w);height:var(--ac-h);position:relative;flex:none;overflow:hidden;border-radius:var(--ac-r-phone);background:var(--ac-bg);color:var(--ac-ink);outline:1px solid rgba(0,0,0,.10);box-shadow:0 0 0 11px #1D191A,0 0 0 12.5px #3A3735,0 24px 60px rgba(29,25,26,.28)}
+.phone{width:var(--ac-w);height:var(--ac-h);position:relative;flex:none;overflow:hidden;border-radius:var(--ac-r-phone);background:var(--ac-bg);color:var(--ac-ink);transform:translateZ(0);outline:1px solid rgba(0,0,0,.10);box-shadow:0 0 0 11px #1D191A,0 0 0 12.5px #3A3735,0 24px 60px rgba(29,25,26,.28)}
 .sb{position:absolute;left:0;right:0;top:0;height:var(--ac-sb);z-index:8}
 .sb .t{position:absolute;left:10px;top:18px;width:123.5px;height:22px;text-align:center;font:var(--ac-t-b17)}
 .sb .island{position:absolute;left:133.5px;top:11px;width:var(--ac-island-w);height:var(--ac-island-h);border-radius:var(--ac-r-pill);background:var(--ac-black)}

--- a/mockups/canvases/apple-calendar/05-location-permission.html
+++ b/mockups/canvases/apple-calendar/05-location-permission.html
@@ -111,7 +111,7 @@
 }
 *{box-sizing:border-box;margin:0;padding:0}
 body{font-family:var(--ac-font);background:#fff;-webkit-font-smoothing:antialiased;display:flex;justify-content:center;padding:24px}
-.phone{width:var(--ac-w);height:var(--ac-h);position:relative;flex:none;overflow:hidden;border-radius:var(--ac-r-phone);background:var(--ac-bg);color:var(--ac-ink);outline:1px solid rgba(0,0,0,.10);box-shadow:0 0 0 11px #1D191A,0 0 0 12.5px #3A3735,0 24px 60px rgba(29,25,26,.28)}
+.phone{width:var(--ac-w);height:var(--ac-h);position:relative;flex:none;overflow:hidden;border-radius:var(--ac-r-phone);background:var(--ac-bg);color:var(--ac-ink);transform:translateZ(0);outline:1px solid rgba(0,0,0,.10);box-shadow:0 0 0 11px #1D191A,0 0 0 12.5px #3A3735,0 24px 60px rgba(29,25,26,.28)}
 .sb{position:absolute;left:0;right:0;top:0;height:var(--ac-sb);z-index:8}
 .sb .t{position:absolute;left:10px;top:18px;width:123.5px;height:22px;text-align:center;font:var(--ac-t-b17)}
 .sb .island{position:absolute;left:133.5px;top:11px;width:var(--ac-island-w);height:var(--ac-island-h);border-radius:var(--ac-r-pill);background:var(--ac-black)}

--- a/mockups/canvases/apple-calendar/06-notifications-permission.html
+++ b/mockups/canvases/apple-calendar/06-notifications-permission.html
@@ -111,7 +111,7 @@
 }
 *{box-sizing:border-box;margin:0;padding:0}
 body{font-family:var(--ac-font);background:#fff;-webkit-font-smoothing:antialiased;display:flex;justify-content:center;padding:24px}
-.phone{width:var(--ac-w);height:var(--ac-h);position:relative;flex:none;overflow:hidden;border-radius:var(--ac-r-phone);background:var(--ac-bg);color:var(--ac-ink);outline:1px solid rgba(0,0,0,.10);box-shadow:0 0 0 11px #1D191A,0 0 0 12.5px #3A3735,0 24px 60px rgba(29,25,26,.28)}
+.phone{width:var(--ac-w);height:var(--ac-h);position:relative;flex:none;overflow:hidden;border-radius:var(--ac-r-phone);background:var(--ac-bg);color:var(--ac-ink);transform:translateZ(0);outline:1px solid rgba(0,0,0,.10);box-shadow:0 0 0 11px #1D191A,0 0 0 12.5px #3A3735,0 24px 60px rgba(29,25,26,.28)}
 .sb{position:absolute;left:0;right:0;top:0;height:var(--ac-sb);z-index:8}
 .sb .t{position:absolute;left:10px;top:18px;width:123.5px;height:22px;text-align:center;font:var(--ac-t-b17)}
 .sb .island{position:absolute;left:133.5px;top:11px;width:var(--ac-island-w);height:var(--ac-island-h);border-radius:var(--ac-r-pill);background:var(--ac-black)}

--- a/mockups/canvases/apple-calendar/07-new-event.html
+++ b/mockups/canvases/apple-calendar/07-new-event.html
@@ -111,7 +111,7 @@
 }
 *{box-sizing:border-box;margin:0;padding:0}
 body{font-family:var(--ac-font);background:#fff;-webkit-font-smoothing:antialiased;display:flex;justify-content:center;padding:24px}
-.phone{width:var(--ac-w);height:var(--ac-h);position:relative;flex:none;overflow:hidden;border-radius:var(--ac-r-phone);background:var(--ac-bg);color:var(--ac-ink);outline:1px solid rgba(0,0,0,.10);box-shadow:0 0 0 11px #1D191A,0 0 0 12.5px #3A3735,0 24px 60px rgba(29,25,26,.28)}
+.phone{width:var(--ac-w);height:var(--ac-h);position:relative;flex:none;overflow:hidden;border-radius:var(--ac-r-phone);background:var(--ac-bg);color:var(--ac-ink);transform:translateZ(0);outline:1px solid rgba(0,0,0,.10);box-shadow:0 0 0 11px #1D191A,0 0 0 12.5px #3A3735,0 24px 60px rgba(29,25,26,.28)}
 .sb{position:absolute;left:0;right:0;top:0;height:var(--ac-sb);z-index:8}
 .sb .t{position:absolute;left:10px;top:18px;width:123.5px;height:22px;text-align:center;font:var(--ac-t-b17)}
 .sb .island{position:absolute;left:133.5px;top:11px;width:var(--ac-island-w);height:var(--ac-island-h);border-radius:var(--ac-r-pill);background:var(--ac-black)}

--- a/mockups/canvases/apple-calendar/08-event-details.html
+++ b/mockups/canvases/apple-calendar/08-event-details.html
@@ -111,7 +111,7 @@
 }
 *{box-sizing:border-box;margin:0;padding:0}
 body{font-family:var(--ac-font);background:#fff;-webkit-font-smoothing:antialiased;display:flex;justify-content:center;padding:24px}
-.phone{width:var(--ac-w);height:var(--ac-h);position:relative;flex:none;overflow:hidden;border-radius:var(--ac-r-phone);background:var(--ac-bg);color:var(--ac-ink);outline:1px solid rgba(0,0,0,.10);box-shadow:0 0 0 11px #1D191A,0 0 0 12.5px #3A3735,0 24px 60px rgba(29,25,26,.28)}
+.phone{width:var(--ac-w);height:var(--ac-h);position:relative;flex:none;overflow:hidden;border-radius:var(--ac-r-phone);background:var(--ac-bg);color:var(--ac-ink);transform:translateZ(0);outline:1px solid rgba(0,0,0,.10);box-shadow:0 0 0 11px #1D191A,0 0 0 12.5px #3A3735,0 24px 60px rgba(29,25,26,.28)}
 .sb{position:absolute;left:0;right:0;top:0;height:var(--ac-sb);z-index:8}
 .sb .t{position:absolute;left:10px;top:18px;width:123.5px;height:22px;text-align:center;font:var(--ac-t-b17)}
 .sb .island{position:absolute;left:133.5px;top:11px;width:var(--ac-island-w);height:var(--ac-island-h);border-radius:var(--ac-r-pill);background:var(--ac-black)}

--- a/mockups/canvases/apple-calendar/09-video-call.html
+++ b/mockups/canvases/apple-calendar/09-video-call.html
@@ -111,7 +111,7 @@
 }
 *{box-sizing:border-box;margin:0;padding:0}
 body{font-family:var(--ac-font);background:#fff;-webkit-font-smoothing:antialiased;display:flex;justify-content:center;padding:24px}
-.phone{width:var(--ac-w);height:var(--ac-h);position:relative;flex:none;overflow:hidden;border-radius:var(--ac-r-phone);background:var(--ac-bg);color:var(--ac-ink);outline:1px solid rgba(0,0,0,.10);box-shadow:0 0 0 11px #1D191A,0 0 0 12.5px #3A3735,0 24px 60px rgba(29,25,26,.28)}
+.phone{width:var(--ac-w);height:var(--ac-h);position:relative;flex:none;overflow:hidden;border-radius:var(--ac-r-phone);background:var(--ac-bg);color:var(--ac-ink);transform:translateZ(0);outline:1px solid rgba(0,0,0,.10);box-shadow:0 0 0 11px #1D191A,0 0 0 12.5px #3A3735,0 24px 60px rgba(29,25,26,.28)}
 .sb{position:absolute;left:0;right:0;top:0;height:var(--ac-sb);z-index:8}
 .sb .t{position:absolute;left:10px;top:18px;width:123.5px;height:22px;text-align:center;font:var(--ac-t-b17)}
 .sb .island{position:absolute;left:133.5px;top:11px;width:var(--ac-island-w);height:var(--ac-island-h);border-radius:var(--ac-r-pill);background:var(--ac-black)}

--- a/mockups/canvases/apple-calendar/d01-today-events.html
+++ b/mockups/canvases/apple-calendar/d01-today-events.html
@@ -111,7 +111,7 @@
 }
 *{box-sizing:border-box;margin:0;padding:0}
 body{font-family:var(--ac-font);background:#fff;-webkit-font-smoothing:antialiased;display:flex;justify-content:center;padding:24px}
-.phone{width:var(--ac-w);height:var(--ac-h);position:relative;flex:none;overflow:hidden;border-radius:var(--ac-r-phone);background:var(--ac-bg);color:var(--ac-ink);outline:1px solid rgba(0,0,0,.10);box-shadow:0 0 0 11px #1D191A,0 0 0 12.5px #3A3735,0 24px 60px rgba(29,25,26,.28)}
+.phone{width:var(--ac-w);height:var(--ac-h);position:relative;flex:none;overflow:hidden;border-radius:var(--ac-r-phone);background:var(--ac-bg);color:var(--ac-ink);transform:translateZ(0);outline:1px solid rgba(0,0,0,.10);box-shadow:0 0 0 11px #1D191A,0 0 0 12.5px #3A3735,0 24px 60px rgba(29,25,26,.28)}
 .sb{position:absolute;left:0;right:0;top:0;height:var(--ac-sb);z-index:8}
 .sb .t{position:absolute;left:10px;top:18px;width:123.5px;height:22px;text-align:center;font:var(--ac-t-b17)}
 .sb .island{position:absolute;left:133.5px;top:11px;width:var(--ac-island-w);height:var(--ac-island-h);border-radius:var(--ac-r-pill);background:var(--ac-black)}

--- a/mockups/canvases/apple-calendar/d02-today-empty.html
+++ b/mockups/canvases/apple-calendar/d02-today-empty.html
@@ -111,7 +111,7 @@
 }
 *{box-sizing:border-box;margin:0;padding:0}
 body{font-family:var(--ac-font);background:#fff;-webkit-font-smoothing:antialiased;display:flex;justify-content:center;padding:24px}
-.phone{width:var(--ac-w);height:var(--ac-h);position:relative;flex:none;overflow:hidden;border-radius:var(--ac-r-phone);background:var(--ac-bg);color:var(--ac-ink);outline:1px solid rgba(0,0,0,.10);box-shadow:0 0 0 11px #1D191A,0 0 0 12.5px #3A3735,0 24px 60px rgba(29,25,26,.28)}
+.phone{width:var(--ac-w);height:var(--ac-h);position:relative;flex:none;overflow:hidden;border-radius:var(--ac-r-phone);background:var(--ac-bg);color:var(--ac-ink);transform:translateZ(0);outline:1px solid rgba(0,0,0,.10);box-shadow:0 0 0 11px #1D191A,0 0 0 12.5px #3A3735,0 24px 60px rgba(29,25,26,.28)}
 .sb{position:absolute;left:0;right:0;top:0;height:var(--ac-sb);z-index:8}
 .sb .t{position:absolute;left:10px;top:18px;width:123.5px;height:22px;text-align:center;font:var(--ac-t-b17)}
 .sb .island{position:absolute;left:133.5px;top:11px;width:var(--ac-island-w);height:var(--ac-island-h);border-radius:var(--ac-r-pill);background:var(--ac-black)}

--- a/mockups/canvases/apple-calendar/d03-month.html
+++ b/mockups/canvases/apple-calendar/d03-month.html
@@ -111,7 +111,7 @@
 }
 *{box-sizing:border-box;margin:0;padding:0}
 body{font-family:var(--ac-font);background:#fff;-webkit-font-smoothing:antialiased;display:flex;justify-content:center;padding:24px}
-.phone{width:var(--ac-w);height:var(--ac-h);position:relative;flex:none;overflow:hidden;border-radius:var(--ac-r-phone);background:var(--ac-bg);color:var(--ac-ink);outline:1px solid rgba(0,0,0,.10);box-shadow:0 0 0 11px #1D191A,0 0 0 12.5px #3A3735,0 24px 60px rgba(29,25,26,.28)}
+.phone{width:var(--ac-w);height:var(--ac-h);position:relative;flex:none;overflow:hidden;border-radius:var(--ac-r-phone);background:var(--ac-bg);color:var(--ac-ink);transform:translateZ(0);outline:1px solid rgba(0,0,0,.10);box-shadow:0 0 0 11px #1D191A,0 0 0 12.5px #3A3735,0 24px 60px rgba(29,25,26,.28)}
 .sb{position:absolute;left:0;right:0;top:0;height:var(--ac-sb);z-index:8}
 .sb .t{position:absolute;left:10px;top:18px;width:123.5px;height:22px;text-align:center;font:var(--ac-t-b17)}
 .sb .island{position:absolute;left:133.5px;top:11px;width:var(--ac-island-w);height:var(--ac-island-h);border-radius:var(--ac-r-pill);background:var(--ac-black)}

--- a/mockups/canvases/apple-calendar/d04-whats-new.html
+++ b/mockups/canvases/apple-calendar/d04-whats-new.html
@@ -111,7 +111,7 @@
 }
 *{box-sizing:border-box;margin:0;padding:0}
 body{font-family:var(--ac-font);background:#fff;-webkit-font-smoothing:antialiased;display:flex;justify-content:center;padding:24px}
-.phone{width:var(--ac-w);height:var(--ac-h);position:relative;flex:none;overflow:hidden;border-radius:var(--ac-r-phone);background:var(--ac-bg);color:var(--ac-ink);outline:1px solid rgba(0,0,0,.10);box-shadow:0 0 0 11px #1D191A,0 0 0 12.5px #3A3735,0 24px 60px rgba(29,25,26,.28)}
+.phone{width:var(--ac-w);height:var(--ac-h);position:relative;flex:none;overflow:hidden;border-radius:var(--ac-r-phone);background:var(--ac-bg);color:var(--ac-ink);transform:translateZ(0);outline:1px solid rgba(0,0,0,.10);box-shadow:0 0 0 11px #1D191A,0 0 0 12.5px #3A3735,0 24px 60px rgba(29,25,26,.28)}
 .sb{position:absolute;left:0;right:0;top:0;height:var(--ac-sb);z-index:8}
 .sb .t{position:absolute;left:10px;top:18px;width:123.5px;height:22px;text-align:center;font:var(--ac-t-b17)}
 .sb .island{position:absolute;left:133.5px;top:11px;width:var(--ac-island-w);height:var(--ac-island-h);border-radius:var(--ac-r-pill);background:var(--ac-black)}

--- a/mockups/canvases/apple-calendar/d05-location-permission.html
+++ b/mockups/canvases/apple-calendar/d05-location-permission.html
@@ -111,7 +111,7 @@
 }
 *{box-sizing:border-box;margin:0;padding:0}
 body{font-family:var(--ac-font);background:#fff;-webkit-font-smoothing:antialiased;display:flex;justify-content:center;padding:24px}
-.phone{width:var(--ac-w);height:var(--ac-h);position:relative;flex:none;overflow:hidden;border-radius:var(--ac-r-phone);background:var(--ac-bg);color:var(--ac-ink);outline:1px solid rgba(0,0,0,.10);box-shadow:0 0 0 11px #1D191A,0 0 0 12.5px #3A3735,0 24px 60px rgba(29,25,26,.28)}
+.phone{width:var(--ac-w);height:var(--ac-h);position:relative;flex:none;overflow:hidden;border-radius:var(--ac-r-phone);background:var(--ac-bg);color:var(--ac-ink);transform:translateZ(0);outline:1px solid rgba(0,0,0,.10);box-shadow:0 0 0 11px #1D191A,0 0 0 12.5px #3A3735,0 24px 60px rgba(29,25,26,.28)}
 .sb{position:absolute;left:0;right:0;top:0;height:var(--ac-sb);z-index:8}
 .sb .t{position:absolute;left:10px;top:18px;width:123.5px;height:22px;text-align:center;font:var(--ac-t-b17)}
 .sb .island{position:absolute;left:133.5px;top:11px;width:var(--ac-island-w);height:var(--ac-island-h);border-radius:var(--ac-r-pill);background:var(--ac-black)}

--- a/mockups/canvases/apple-calendar/d06-notifications-permission.html
+++ b/mockups/canvases/apple-calendar/d06-notifications-permission.html
@@ -111,7 +111,7 @@
 }
 *{box-sizing:border-box;margin:0;padding:0}
 body{font-family:var(--ac-font);background:#fff;-webkit-font-smoothing:antialiased;display:flex;justify-content:center;padding:24px}
-.phone{width:var(--ac-w);height:var(--ac-h);position:relative;flex:none;overflow:hidden;border-radius:var(--ac-r-phone);background:var(--ac-bg);color:var(--ac-ink);outline:1px solid rgba(0,0,0,.10);box-shadow:0 0 0 11px #1D191A,0 0 0 12.5px #3A3735,0 24px 60px rgba(29,25,26,.28)}
+.phone{width:var(--ac-w);height:var(--ac-h);position:relative;flex:none;overflow:hidden;border-radius:var(--ac-r-phone);background:var(--ac-bg);color:var(--ac-ink);transform:translateZ(0);outline:1px solid rgba(0,0,0,.10);box-shadow:0 0 0 11px #1D191A,0 0 0 12.5px #3A3735,0 24px 60px rgba(29,25,26,.28)}
 .sb{position:absolute;left:0;right:0;top:0;height:var(--ac-sb);z-index:8}
 .sb .t{position:absolute;left:10px;top:18px;width:123.5px;height:22px;text-align:center;font:var(--ac-t-b17)}
 .sb .island{position:absolute;left:133.5px;top:11px;width:var(--ac-island-w);height:var(--ac-island-h);border-radius:var(--ac-r-pill);background:var(--ac-black)}

--- a/mockups/canvases/apple-calendar/d07-new-event.html
+++ b/mockups/canvases/apple-calendar/d07-new-event.html
@@ -111,7 +111,7 @@
 }
 *{box-sizing:border-box;margin:0;padding:0}
 body{font-family:var(--ac-font);background:#fff;-webkit-font-smoothing:antialiased;display:flex;justify-content:center;padding:24px}
-.phone{width:var(--ac-w);height:var(--ac-h);position:relative;flex:none;overflow:hidden;border-radius:var(--ac-r-phone);background:var(--ac-bg);color:var(--ac-ink);outline:1px solid rgba(0,0,0,.10);box-shadow:0 0 0 11px #1D191A,0 0 0 12.5px #3A3735,0 24px 60px rgba(29,25,26,.28)}
+.phone{width:var(--ac-w);height:var(--ac-h);position:relative;flex:none;overflow:hidden;border-radius:var(--ac-r-phone);background:var(--ac-bg);color:var(--ac-ink);transform:translateZ(0);outline:1px solid rgba(0,0,0,.10);box-shadow:0 0 0 11px #1D191A,0 0 0 12.5px #3A3735,0 24px 60px rgba(29,25,26,.28)}
 .sb{position:absolute;left:0;right:0;top:0;height:var(--ac-sb);z-index:8}
 .sb .t{position:absolute;left:10px;top:18px;width:123.5px;height:22px;text-align:center;font:var(--ac-t-b17)}
 .sb .island{position:absolute;left:133.5px;top:11px;width:var(--ac-island-w);height:var(--ac-island-h);border-radius:var(--ac-r-pill);background:var(--ac-black)}

--- a/mockups/canvases/apple-calendar/d08-event-details.html
+++ b/mockups/canvases/apple-calendar/d08-event-details.html
@@ -111,7 +111,7 @@
 }
 *{box-sizing:border-box;margin:0;padding:0}
 body{font-family:var(--ac-font);background:#fff;-webkit-font-smoothing:antialiased;display:flex;justify-content:center;padding:24px}
-.phone{width:var(--ac-w);height:var(--ac-h);position:relative;flex:none;overflow:hidden;border-radius:var(--ac-r-phone);background:var(--ac-bg);color:var(--ac-ink);outline:1px solid rgba(0,0,0,.10);box-shadow:0 0 0 11px #1D191A,0 0 0 12.5px #3A3735,0 24px 60px rgba(29,25,26,.28)}
+.phone{width:var(--ac-w);height:var(--ac-h);position:relative;flex:none;overflow:hidden;border-radius:var(--ac-r-phone);background:var(--ac-bg);color:var(--ac-ink);transform:translateZ(0);outline:1px solid rgba(0,0,0,.10);box-shadow:0 0 0 11px #1D191A,0 0 0 12.5px #3A3735,0 24px 60px rgba(29,25,26,.28)}
 .sb{position:absolute;left:0;right:0;top:0;height:var(--ac-sb);z-index:8}
 .sb .t{position:absolute;left:10px;top:18px;width:123.5px;height:22px;text-align:center;font:var(--ac-t-b17)}
 .sb .island{position:absolute;left:133.5px;top:11px;width:var(--ac-island-w);height:var(--ac-island-h);border-radius:var(--ac-r-pill);background:var(--ac-black)}

--- a/mockups/canvases/apple-calendar/d09-video-call.html
+++ b/mockups/canvases/apple-calendar/d09-video-call.html
@@ -111,7 +111,7 @@
 }
 *{box-sizing:border-box;margin:0;padding:0}
 body{font-family:var(--ac-font);background:#fff;-webkit-font-smoothing:antialiased;display:flex;justify-content:center;padding:24px}
-.phone{width:var(--ac-w);height:var(--ac-h);position:relative;flex:none;overflow:hidden;border-radius:var(--ac-r-phone);background:var(--ac-bg);color:var(--ac-ink);outline:1px solid rgba(0,0,0,.10);box-shadow:0 0 0 11px #1D191A,0 0 0 12.5px #3A3735,0 24px 60px rgba(29,25,26,.28)}
+.phone{width:var(--ac-w);height:var(--ac-h);position:relative;flex:none;overflow:hidden;border-radius:var(--ac-r-phone);background:var(--ac-bg);color:var(--ac-ink);transform:translateZ(0);outline:1px solid rgba(0,0,0,.10);box-shadow:0 0 0 11px #1D191A,0 0 0 12.5px #3A3735,0 24px 60px rgba(29,25,26,.28)}
 .sb{position:absolute;left:0;right:0;top:0;height:var(--ac-sb);z-index:8}
 .sb .t{position:absolute;left:10px;top:18px;width:123.5px;height:22px;text-align:center;font:var(--ac-t-b17)}
 .sb .island{position:absolute;left:133.5px;top:11px;width:var(--ac-island-w);height:var(--ac-island-h);border-radius:var(--ac-r-pill);background:var(--ac-black)}

--- a/mockups/canvases/apple-calendar/gen.py
+++ b/mockups/canvases/apple-calendar/gen.py
@@ -241,7 +241,10 @@ DARK = _dark()
 BASE = """*{box-sizing:border-box;margin:0;padding:0}
 body{font-family:var(--ac-font);background:#fff;-webkit-font-smoothing:antialiased;display:flex;justify-content:center;padding:24px}"""
 
-PHONE = """.phone{width:var(--ac-w);height:var(--ac-h);position:relative;flex:none;overflow:hidden;border-radius:var(--ac-r-phone);background:var(--ac-bg);color:var(--ac-ink);outline:1px solid rgba(0,0,0,.10);box-shadow:0 0 0 11px #1D191A,0 0 0 12.5px #3A3735,0 24px 60px rgba(29,25,26,.28)}
+# translateZ(0) composites the frame itself. Safari on iPhone clips composited children (blur,
+# backdrop-filter) of a non-composited ancestor with a plain rectangle, so the screen painted
+# square past the bezel's corners; a composited frame clips them with its own rounded mask.
+PHONE = """.phone{width:var(--ac-w);height:var(--ac-h);position:relative;flex:none;overflow:hidden;border-radius:var(--ac-r-phone);background:var(--ac-bg);color:var(--ac-ink);transform:translateZ(0);outline:1px solid rgba(0,0,0,.10);box-shadow:0 0 0 11px #1D191A,0 0 0 12.5px #3A3735,0 24px 60px rgba(29,25,26,.28)}
 .sb{position:absolute;left:0;right:0;top:0;height:var(--ac-sb);z-index:8}
 .sb .t{position:absolute;left:10px;top:18px;width:123.5px;height:22px;text-align:center;font:var(--ac-t-b17)}
 .sb .island{position:absolute;left:133.5px;top:11px;width:var(--ac-island-w);height:var(--ac-island-h);border-radius:var(--ac-r-pill);background:var(--ac-black)}

--- a/mockups/canvases/apple-settings/01-settings.html
+++ b/mockups/canvases/apple-settings/01-settings.html
@@ -65,7 +65,7 @@
 }
 *{box-sizing:border-box;margin:0;padding:0}
 body{font-family:var(--as-font);background:#fff;-webkit-font-smoothing:antialiased;display:flex;justify-content:center;padding:24px}
-.phone{width:var(--as-w);height:var(--as-h);position:relative;flex:none;overflow:hidden;border-radius:var(--as-r-phone);background:var(--as-bg);color:var(--as-ink);outline:1px solid rgba(0,0,0,.10);box-shadow:0 0 0 11px #1D191A,0 0 0 12.5px #3A3735,0 24px 60px rgba(29,25,26,.28)}
+.phone{width:var(--as-w);height:var(--as-h);position:relative;flex:none;overflow:hidden;border-radius:var(--as-r-phone);background:var(--as-bg);color:var(--as-ink);transform:translateZ(0);outline:1px solid rgba(0,0,0,.10);box-shadow:0 0 0 11px #1D191A,0 0 0 12.5px #3A3735,0 24px 60px rgba(29,25,26,.28)}
 .sb{position:absolute;left:0;right:0;top:0;height:var(--as-sb);z-index:8}
 .sb .t{position:absolute;left:10px;top:18px;width:123.5px;height:22px;text-align:center;font:var(--as-t-b17)}
 .sb .island{position:absolute;left:133.5px;top:11px;width:var(--as-island-w);height:var(--as-island-h);border-radius:var(--as-r-pill);background:var(--as-black)}

--- a/mockups/canvases/apple-settings/02-developer.html
+++ b/mockups/canvases/apple-settings/02-developer.html
@@ -65,7 +65,7 @@
 }
 *{box-sizing:border-box;margin:0;padding:0}
 body{font-family:var(--as-font);background:#fff;-webkit-font-smoothing:antialiased;display:flex;justify-content:center;padding:24px}
-.phone{width:var(--as-w);height:var(--as-h);position:relative;flex:none;overflow:hidden;border-radius:var(--as-r-phone);background:var(--as-bg);color:var(--as-ink);outline:1px solid rgba(0,0,0,.10);box-shadow:0 0 0 11px #1D191A,0 0 0 12.5px #3A3735,0 24px 60px rgba(29,25,26,.28)}
+.phone{width:var(--as-w);height:var(--as-h);position:relative;flex:none;overflow:hidden;border-radius:var(--as-r-phone);background:var(--as-bg);color:var(--as-ink);transform:translateZ(0);outline:1px solid rgba(0,0,0,.10);box-shadow:0 0 0 11px #1D191A,0 0 0 12.5px #3A3735,0 24px 60px rgba(29,25,26,.28)}
 .sb{position:absolute;left:0;right:0;top:0;height:var(--as-sb);z-index:8}
 .sb .t{position:absolute;left:10px;top:18px;width:123.5px;height:22px;text-align:center;font:var(--as-t-b17)}
 .sb .island{position:absolute;left:133.5px;top:11px;width:var(--as-island-w);height:var(--as-island-h);border-radius:var(--as-r-pill);background:var(--as-black)}

--- a/mockups/canvases/apple-settings/03-display-zoom.html
+++ b/mockups/canvases/apple-settings/03-display-zoom.html
@@ -65,7 +65,7 @@
 }
 *{box-sizing:border-box;margin:0;padding:0}
 body{font-family:var(--as-font);background:#fff;-webkit-font-smoothing:antialiased;display:flex;justify-content:center;padding:24px}
-.phone{width:var(--as-w);height:var(--as-h);position:relative;flex:none;overflow:hidden;border-radius:var(--as-r-phone);background:var(--as-bg);color:var(--as-ink);outline:1px solid rgba(0,0,0,.10);box-shadow:0 0 0 11px #1D191A,0 0 0 12.5px #3A3735,0 24px 60px rgba(29,25,26,.28)}
+.phone{width:var(--as-w);height:var(--as-h);position:relative;flex:none;overflow:hidden;border-radius:var(--as-r-phone);background:var(--as-bg);color:var(--as-ink);transform:translateZ(0);outline:1px solid rgba(0,0,0,.10);box-shadow:0 0 0 11px #1D191A,0 0 0 12.5px #3A3735,0 24px 60px rgba(29,25,26,.28)}
 .sb{position:absolute;left:0;right:0;top:0;height:var(--as-sb);z-index:8}
 .sb .t{position:absolute;left:10px;top:18px;width:123.5px;height:22px;text-align:center;font:var(--as-t-b17)}
 .sb .island{position:absolute;left:133.5px;top:11px;width:var(--as-island-w);height:var(--as-island-h);border-radius:var(--as-r-pill);background:var(--as-black)}

--- a/mockups/canvases/apple-settings/d01-settings.html
+++ b/mockups/canvases/apple-settings/d01-settings.html
@@ -65,7 +65,7 @@
 }
 *{box-sizing:border-box;margin:0;padding:0}
 body{font-family:var(--as-font);background:#fff;-webkit-font-smoothing:antialiased;display:flex;justify-content:center;padding:24px}
-.phone{width:var(--as-w);height:var(--as-h);position:relative;flex:none;overflow:hidden;border-radius:var(--as-r-phone);background:var(--as-bg);color:var(--as-ink);outline:1px solid rgba(0,0,0,.10);box-shadow:0 0 0 11px #1D191A,0 0 0 12.5px #3A3735,0 24px 60px rgba(29,25,26,.28)}
+.phone{width:var(--as-w);height:var(--as-h);position:relative;flex:none;overflow:hidden;border-radius:var(--as-r-phone);background:var(--as-bg);color:var(--as-ink);transform:translateZ(0);outline:1px solid rgba(0,0,0,.10);box-shadow:0 0 0 11px #1D191A,0 0 0 12.5px #3A3735,0 24px 60px rgba(29,25,26,.28)}
 .sb{position:absolute;left:0;right:0;top:0;height:var(--as-sb);z-index:8}
 .sb .t{position:absolute;left:10px;top:18px;width:123.5px;height:22px;text-align:center;font:var(--as-t-b17)}
 .sb .island{position:absolute;left:133.5px;top:11px;width:var(--as-island-w);height:var(--as-island-h);border-radius:var(--as-r-pill);background:var(--as-black)}

--- a/mockups/canvases/apple-settings/d02-developer.html
+++ b/mockups/canvases/apple-settings/d02-developer.html
@@ -65,7 +65,7 @@
 }
 *{box-sizing:border-box;margin:0;padding:0}
 body{font-family:var(--as-font);background:#fff;-webkit-font-smoothing:antialiased;display:flex;justify-content:center;padding:24px}
-.phone{width:var(--as-w);height:var(--as-h);position:relative;flex:none;overflow:hidden;border-radius:var(--as-r-phone);background:var(--as-bg);color:var(--as-ink);outline:1px solid rgba(0,0,0,.10);box-shadow:0 0 0 11px #1D191A,0 0 0 12.5px #3A3735,0 24px 60px rgba(29,25,26,.28)}
+.phone{width:var(--as-w);height:var(--as-h);position:relative;flex:none;overflow:hidden;border-radius:var(--as-r-phone);background:var(--as-bg);color:var(--as-ink);transform:translateZ(0);outline:1px solid rgba(0,0,0,.10);box-shadow:0 0 0 11px #1D191A,0 0 0 12.5px #3A3735,0 24px 60px rgba(29,25,26,.28)}
 .sb{position:absolute;left:0;right:0;top:0;height:var(--as-sb);z-index:8}
 .sb .t{position:absolute;left:10px;top:18px;width:123.5px;height:22px;text-align:center;font:var(--as-t-b17)}
 .sb .island{position:absolute;left:133.5px;top:11px;width:var(--as-island-w);height:var(--as-island-h);border-radius:var(--as-r-pill);background:var(--as-black)}

--- a/mockups/canvases/apple-settings/d03-display-zoom.html
+++ b/mockups/canvases/apple-settings/d03-display-zoom.html
@@ -65,7 +65,7 @@
 }
 *{box-sizing:border-box;margin:0;padding:0}
 body{font-family:var(--as-font);background:#fff;-webkit-font-smoothing:antialiased;display:flex;justify-content:center;padding:24px}
-.phone{width:var(--as-w);height:var(--as-h);position:relative;flex:none;overflow:hidden;border-radius:var(--as-r-phone);background:var(--as-bg);color:var(--as-ink);outline:1px solid rgba(0,0,0,.10);box-shadow:0 0 0 11px #1D191A,0 0 0 12.5px #3A3735,0 24px 60px rgba(29,25,26,.28)}
+.phone{width:var(--as-w);height:var(--as-h);position:relative;flex:none;overflow:hidden;border-radius:var(--as-r-phone);background:var(--as-bg);color:var(--as-ink);transform:translateZ(0);outline:1px solid rgba(0,0,0,.10);box-shadow:0 0 0 11px #1D191A,0 0 0 12.5px #3A3735,0 24px 60px rgba(29,25,26,.28)}
 .sb{position:absolute;left:0;right:0;top:0;height:var(--as-sb);z-index:8}
 .sb .t{position:absolute;left:10px;top:18px;width:123.5px;height:22px;text-align:center;font:var(--as-t-b17)}
 .sb .island{position:absolute;left:133.5px;top:11px;width:var(--as-island-w);height:var(--as-island-h);border-radius:var(--as-r-pill);background:var(--as-black)}

--- a/mockups/canvases/apple-settings/gen.py
+++ b/mockups/canvases/apple-settings/gen.py
@@ -175,7 +175,10 @@ DARK = _dark()
 BASE = """*{box-sizing:border-box;margin:0;padding:0}
 body{font-family:var(--as-font);background:#fff;-webkit-font-smoothing:antialiased;display:flex;justify-content:center;padding:24px}"""
 
-PHONE = """.phone{width:var(--as-w);height:var(--as-h);position:relative;flex:none;overflow:hidden;border-radius:var(--as-r-phone);background:var(--as-bg);color:var(--as-ink);outline:1px solid rgba(0,0,0,.10);box-shadow:0 0 0 11px #1D191A,0 0 0 12.5px #3A3735,0 24px 60px rgba(29,25,26,.28)}
+# translateZ(0) composites the frame itself. Safari on iPhone clips composited children (blur,
+# backdrop-filter) of a non-composited ancestor with a plain rectangle, so the screen painted
+# square past the bezel's corners; a composited frame clips them with its own rounded mask.
+PHONE = """.phone{width:var(--as-w);height:var(--as-h);position:relative;flex:none;overflow:hidden;border-radius:var(--as-r-phone);background:var(--as-bg);color:var(--as-ink);transform:translateZ(0);outline:1px solid rgba(0,0,0,.10);box-shadow:0 0 0 11px #1D191A,0 0 0 12.5px #3A3735,0 24px 60px rgba(29,25,26,.28)}
 .sb{position:absolute;left:0;right:0;top:0;height:var(--as-sb);z-index:8}
 .sb .t{position:absolute;left:10px;top:18px;width:123.5px;height:22px;text-align:center;font:var(--as-t-b17)}
 .sb .island{position:absolute;left:133.5px;top:11px;width:var(--as-island-w);height:var(--as-island-h);border-radius:var(--as-r-pill);background:var(--as-black)}

--- a/mockups/canvases/luma-ios/00-design-tokens.html
+++ b/mockups/canvases/luma-ios/00-design-tokens.html
@@ -101,8 +101,12 @@
    lands on whatever the artboard is placed over instead of a cream rectangle. */
 body{font-family:var(--l-font);-webkit-font-smoothing:antialiased;
   display:flex;justify-content:center;padding:24px}
+/* translateZ(0) composites the frame itself. Its children are composited anyway (the blurred
+   .bg, the backdrop-filter nav), and Safari on iPhone clips composited children of a
+   non-composited ancestor with a plain rectangle: at some zoom levels the screen painted
+   square past the bezel's corners. A composited frame clips them with its own rounded mask. */
 .phone{width:393px;height:852px;position:relative;border-radius:var(--l-r-phone);overflow:hidden;
-  flex:none;background:#000;color:var(--l-ink);
+  flex:none;background:#000;color:var(--l-ink);transform:translateZ(0);
   box-shadow:0 0 0 11px #1D191A, 0 0 0 12.5px #3A3735, 0 24px 60px rgba(29,25,26,.28)}
 .bg{position:absolute;left:-8%;top:-8%;width:116%;height:116%;
   background-size:100% 100%;filter:blur(11px)}

--- a/mockups/canvases/luma-ios/00b-evidence.html
+++ b/mockups/canvases/luma-ios/00b-evidence.html
@@ -101,8 +101,12 @@
    lands on whatever the artboard is placed over instead of a cream rectangle. */
 body{font-family:var(--l-font);-webkit-font-smoothing:antialiased;
   display:flex;justify-content:center;padding:24px}
+/* translateZ(0) composites the frame itself. Its children are composited anyway (the blurred
+   .bg, the backdrop-filter nav), and Safari on iPhone clips composited children of a
+   non-composited ancestor with a plain rectangle: at some zoom levels the screen painted
+   square past the bezel's corners. A composited frame clips them with its own rounded mask. */
 .phone{width:393px;height:852px;position:relative;border-radius:var(--l-r-phone);overflow:hidden;
-  flex:none;background:#000;color:var(--l-ink);
+  flex:none;background:#000;color:var(--l-ink);transform:translateZ(0);
   box-shadow:0 0 0 11px #1D191A, 0 0 0 12.5px #3A3735, 0 24px 60px rgba(29,25,26,.28)}
 .bg{position:absolute;left:-8%;top:-8%;width:116%;height:116%;
   background-size:100% 100%;filter:blur(11px)}

--- a/mockups/canvases/luma-ios/00c-evidence.html
+++ b/mockups/canvases/luma-ios/00c-evidence.html
@@ -101,8 +101,12 @@
    lands on whatever the artboard is placed over instead of a cream rectangle. */
 body{font-family:var(--l-font);-webkit-font-smoothing:antialiased;
   display:flex;justify-content:center;padding:24px}
+/* translateZ(0) composites the frame itself. Its children are composited anyway (the blurred
+   .bg, the backdrop-filter nav), and Safari on iPhone clips composited children of a
+   non-composited ancestor with a plain rectangle: at some zoom levels the screen painted
+   square past the bezel's corners. A composited frame clips them with its own rounded mask. */
 .phone{width:393px;height:852px;position:relative;border-radius:var(--l-r-phone);overflow:hidden;
-  flex:none;background:#000;color:var(--l-ink);
+  flex:none;background:#000;color:var(--l-ink);transform:translateZ(0);
   box-shadow:0 0 0 11px #1D191A, 0 0 0 12.5px #3A3735, 0 24px 60px rgba(29,25,26,.28)}
 .bg{position:absolute;left:-8%;top:-8%;width:116%;height:116%;
   background-size:100% 100%;filter:blur(11px)}

--- a/mockups/canvases/luma-ios/00d-process.html
+++ b/mockups/canvases/luma-ios/00d-process.html
@@ -101,8 +101,12 @@
    lands on whatever the artboard is placed over instead of a cream rectangle. */
 body{font-family:var(--l-font);-webkit-font-smoothing:antialiased;
   display:flex;justify-content:center;padding:24px}
+/* translateZ(0) composites the frame itself. Its children are composited anyway (the blurred
+   .bg, the backdrop-filter nav), and Safari on iPhone clips composited children of a
+   non-composited ancestor with a plain rectangle: at some zoom levels the screen painted
+   square past the bezel's corners. A composited frame clips them with its own rounded mask. */
 .phone{width:393px;height:852px;position:relative;border-radius:var(--l-r-phone);overflow:hidden;
-  flex:none;background:#000;color:var(--l-ink);
+  flex:none;background:#000;color:var(--l-ink);transform:translateZ(0);
   box-shadow:0 0 0 11px #1D191A, 0 0 0 12.5px #3A3735, 0 24px 60px rgba(29,25,26,.28)}
 .bg{position:absolute;left:-8%;top:-8%;width:116%;height:116%;
   background-size:100% 100%;filter:blur(11px)}

--- a/mockups/canvases/luma-ios/00e-pipeline.html
+++ b/mockups/canvases/luma-ios/00e-pipeline.html
@@ -101,8 +101,12 @@
    lands on whatever the artboard is placed over instead of a cream rectangle. */
 body{font-family:var(--l-font);-webkit-font-smoothing:antialiased;
   display:flex;justify-content:center;padding:24px}
+/* translateZ(0) composites the frame itself. Its children are composited anyway (the blurred
+   .bg, the backdrop-filter nav), and Safari on iPhone clips composited children of a
+   non-composited ancestor with a plain rectangle: at some zoom levels the screen painted
+   square past the bezel's corners. A composited frame clips them with its own rounded mask. */
 .phone{width:393px;height:852px;position:relative;border-radius:var(--l-r-phone);overflow:hidden;
-  flex:none;background:#000;color:var(--l-ink);
+  flex:none;background:#000;color:var(--l-ink);transform:translateZ(0);
   box-shadow:0 0 0 11px #1D191A, 0 0 0 12.5px #3A3735, 0 24px 60px rgba(29,25,26,.28)}
 .bg{position:absolute;left:-8%;top:-8%;width:116%;height:116%;
   background-size:100% 100%;filter:blur(11px)}

--- a/mockups/canvases/luma-ios/00f-evidence-home.html
+++ b/mockups/canvases/luma-ios/00f-evidence-home.html
@@ -101,8 +101,12 @@
    lands on whatever the artboard is placed over instead of a cream rectangle. */
 body{font-family:var(--l-font);-webkit-font-smoothing:antialiased;
   display:flex;justify-content:center;padding:24px}
+/* translateZ(0) composites the frame itself. Its children are composited anyway (the blurred
+   .bg, the backdrop-filter nav), and Safari on iPhone clips composited children of a
+   non-composited ancestor with a plain rectangle: at some zoom levels the screen painted
+   square past the bezel's corners. A composited frame clips them with its own rounded mask. */
 .phone{width:393px;height:852px;position:relative;border-radius:var(--l-r-phone);overflow:hidden;
-  flex:none;background:#000;color:var(--l-ink);
+  flex:none;background:#000;color:var(--l-ink);transform:translateZ(0);
   box-shadow:0 0 0 11px #1D191A, 0 0 0 12.5px #3A3735, 0 24px 60px rgba(29,25,26,.28)}
 .bg{position:absolute;left:-8%;top:-8%;width:116%;height:116%;
   background-size:100% 100%;filter:blur(11px)}

--- a/mockups/canvases/luma-ios/00g-evidence-home.html
+++ b/mockups/canvases/luma-ios/00g-evidence-home.html
@@ -101,8 +101,12 @@
    lands on whatever the artboard is placed over instead of a cream rectangle. */
 body{font-family:var(--l-font);-webkit-font-smoothing:antialiased;
   display:flex;justify-content:center;padding:24px}
+/* translateZ(0) composites the frame itself. Its children are composited anyway (the blurred
+   .bg, the backdrop-filter nav), and Safari on iPhone clips composited children of a
+   non-composited ancestor with a plain rectangle: at some zoom levels the screen painted
+   square past the bezel's corners. A composited frame clips them with its own rounded mask. */
 .phone{width:393px;height:852px;position:relative;border-radius:var(--l-r-phone);overflow:hidden;
-  flex:none;background:#000;color:var(--l-ink);
+  flex:none;background:#000;color:var(--l-ink);transform:translateZ(0);
   box-shadow:0 0 0 11px #1D191A, 0 0 0 12.5px #3A3735, 0 24px 60px rgba(29,25,26,.28)}
 .bg{position:absolute;left:-8%;top:-8%;width:116%;height:116%;
   background-size:100% 100%;filter:blur(11px)}

--- a/mockups/canvases/luma-ios/01-guest-top.html
+++ b/mockups/canvases/luma-ios/01-guest-top.html
@@ -101,8 +101,12 @@
    lands on whatever the artboard is placed over instead of a cream rectangle. */
 body{font-family:var(--l-font);-webkit-font-smoothing:antialiased;
   display:flex;justify-content:center;padding:24px}
+/* translateZ(0) composites the frame itself. Its children are composited anyway (the blurred
+   .bg, the backdrop-filter nav), and Safari on iPhone clips composited children of a
+   non-composited ancestor with a plain rectangle: at some zoom levels the screen painted
+   square past the bezel's corners. A composited frame clips them with its own rounded mask. */
 .phone{width:393px;height:852px;position:relative;border-radius:var(--l-r-phone);overflow:hidden;
-  flex:none;background:#000;color:var(--l-ink);
+  flex:none;background:#000;color:var(--l-ink);transform:translateZ(0);
   box-shadow:0 0 0 11px #1D191A, 0 0 0 12.5px #3A3735, 0 24px 60px rgba(29,25,26,.28)}
 .bg{position:absolute;left:-8%;top:-8%;width:116%;height:116%;
   background-size:100% 100%;filter:blur(11px)}

--- a/mockups/canvases/luma-ios/02-guest-mid.html
+++ b/mockups/canvases/luma-ios/02-guest-mid.html
@@ -101,8 +101,12 @@
    lands on whatever the artboard is placed over instead of a cream rectangle. */
 body{font-family:var(--l-font);-webkit-font-smoothing:antialiased;
   display:flex;justify-content:center;padding:24px}
+/* translateZ(0) composites the frame itself. Its children are composited anyway (the blurred
+   .bg, the backdrop-filter nav), and Safari on iPhone clips composited children of a
+   non-composited ancestor with a plain rectangle: at some zoom levels the screen painted
+   square past the bezel's corners. A composited frame clips them with its own rounded mask. */
 .phone{width:393px;height:852px;position:relative;border-radius:var(--l-r-phone);overflow:hidden;
-  flex:none;background:#000;color:var(--l-ink);
+  flex:none;background:#000;color:var(--l-ink);transform:translateZ(0);
   box-shadow:0 0 0 11px #1D191A, 0 0 0 12.5px #3A3735, 0 24px 60px rgba(29,25,26,.28)}
 .bg{position:absolute;left:-8%;top:-8%;width:116%;height:116%;
   background-size:100% 100%;filter:blur(11px)}

--- a/mockups/canvases/luma-ios/03-guest-about.html
+++ b/mockups/canvases/luma-ios/03-guest-about.html
@@ -101,8 +101,12 @@
    lands on whatever the artboard is placed over instead of a cream rectangle. */
 body{font-family:var(--l-font);-webkit-font-smoothing:antialiased;
   display:flex;justify-content:center;padding:24px}
+/* translateZ(0) composites the frame itself. Its children are composited anyway (the blurred
+   .bg, the backdrop-filter nav), and Safari on iPhone clips composited children of a
+   non-composited ancestor with a plain rectangle: at some zoom levels the screen painted
+   square past the bezel's corners. A composited frame clips them with its own rounded mask. */
 .phone{width:393px;height:852px;position:relative;border-radius:var(--l-r-phone);overflow:hidden;
-  flex:none;background:#000;color:var(--l-ink);
+  flex:none;background:#000;color:var(--l-ink);transform:translateZ(0);
   box-shadow:0 0 0 11px #1D191A, 0 0 0 12.5px #3A3735, 0 24px 60px rgba(29,25,26,.28)}
 .bg{position:absolute;left:-8%;top:-8%;width:116%;height:116%;
   background-size:100% 100%;filter:blur(11px)}

--- a/mockups/canvases/luma-ios/04-host-top.html
+++ b/mockups/canvases/luma-ios/04-host-top.html
@@ -101,8 +101,12 @@
    lands on whatever the artboard is placed over instead of a cream rectangle. */
 body{font-family:var(--l-font);-webkit-font-smoothing:antialiased;
   display:flex;justify-content:center;padding:24px}
+/* translateZ(0) composites the frame itself. Its children are composited anyway (the blurred
+   .bg, the backdrop-filter nav), and Safari on iPhone clips composited children of a
+   non-composited ancestor with a plain rectangle: at some zoom levels the screen painted
+   square past the bezel's corners. A composited frame clips them with its own rounded mask. */
 .phone{width:393px;height:852px;position:relative;border-radius:var(--l-r-phone);overflow:hidden;
-  flex:none;background:#000;color:var(--l-ink);
+  flex:none;background:#000;color:var(--l-ink);transform:translateZ(0);
   box-shadow:0 0 0 11px #1D191A, 0 0 0 12.5px #3A3735, 0 24px 60px rgba(29,25,26,.28)}
 .bg{position:absolute;left:-8%;top:-8%;width:116%;height:116%;
   background-size:100% 100%;filter:blur(11px)}

--- a/mockups/canvases/luma-ios/05-host-stats.html
+++ b/mockups/canvases/luma-ios/05-host-stats.html
@@ -101,8 +101,12 @@
    lands on whatever the artboard is placed over instead of a cream rectangle. */
 body{font-family:var(--l-font);-webkit-font-smoothing:antialiased;
   display:flex;justify-content:center;padding:24px}
+/* translateZ(0) composites the frame itself. Its children are composited anyway (the blurred
+   .bg, the backdrop-filter nav), and Safari on iPhone clips composited children of a
+   non-composited ancestor with a plain rectangle: at some zoom levels the screen painted
+   square past the bezel's corners. A composited frame clips them with its own rounded mask. */
 .phone{width:393px;height:852px;position:relative;border-radius:var(--l-r-phone);overflow:hidden;
-  flex:none;background:#000;color:var(--l-ink);
+  flex:none;background:#000;color:var(--l-ink);transform:translateZ(0);
   box-shadow:0 0 0 11px #1D191A, 0 0 0 12.5px #3A3735, 0 24px 60px rgba(29,25,26,.28)}
 .bg{position:absolute;left:-8%;top:-8%;width:116%;height:116%;
   background-size:100% 100%;filter:blur(11px)}

--- a/mockups/canvases/luma-ios/06-host-manage.html
+++ b/mockups/canvases/luma-ios/06-host-manage.html
@@ -101,8 +101,12 @@
    lands on whatever the artboard is placed over instead of a cream rectangle. */
 body{font-family:var(--l-font);-webkit-font-smoothing:antialiased;
   display:flex;justify-content:center;padding:24px}
+/* translateZ(0) composites the frame itself. Its children are composited anyway (the blurred
+   .bg, the backdrop-filter nav), and Safari on iPhone clips composited children of a
+   non-composited ancestor with a plain rectangle: at some zoom levels the screen painted
+   square past the bezel's corners. A composited frame clips them with its own rounded mask. */
 .phone{width:393px;height:852px;position:relative;border-radius:var(--l-r-phone);overflow:hidden;
-  flex:none;background:#000;color:var(--l-ink);
+  flex:none;background:#000;color:var(--l-ink);transform:translateZ(0);
   box-shadow:0 0 0 11px #1D191A, 0 0 0 12.5px #3A3735, 0 24px 60px rgba(29,25,26,.28)}
 .bg{position:absolute;left:-8%;top:-8%;width:116%;height:116%;
   background-size:100% 100%;filter:blur(11px)}

--- a/mockups/canvases/luma-ios/07-invited-top.html
+++ b/mockups/canvases/luma-ios/07-invited-top.html
@@ -101,8 +101,12 @@
    lands on whatever the artboard is placed over instead of a cream rectangle. */
 body{font-family:var(--l-font);-webkit-font-smoothing:antialiased;
   display:flex;justify-content:center;padding:24px}
+/* translateZ(0) composites the frame itself. Its children are composited anyway (the blurred
+   .bg, the backdrop-filter nav), and Safari on iPhone clips composited children of a
+   non-composited ancestor with a plain rectangle: at some zoom levels the screen painted
+   square past the bezel's corners. A composited frame clips them with its own rounded mask. */
 .phone{width:393px;height:852px;position:relative;border-radius:var(--l-r-phone);overflow:hidden;
-  flex:none;background:#000;color:var(--l-ink);
+  flex:none;background:#000;color:var(--l-ink);transform:translateZ(0);
   box-shadow:0 0 0 11px #1D191A, 0 0 0 12.5px #3A3735, 0 24px 60px rgba(29,25,26,.28)}
 .bg{position:absolute;left:-8%;top:-8%;width:116%;height:116%;
   background-size:100% 100%;filter:blur(11px)}

--- a/mockups/canvases/luma-ios/08-invited-about.html
+++ b/mockups/canvases/luma-ios/08-invited-about.html
@@ -101,8 +101,12 @@
    lands on whatever the artboard is placed over instead of a cream rectangle. */
 body{font-family:var(--l-font);-webkit-font-smoothing:antialiased;
   display:flex;justify-content:center;padding:24px}
+/* translateZ(0) composites the frame itself. Its children are composited anyway (the blurred
+   .bg, the backdrop-filter nav), and Safari on iPhone clips composited children of a
+   non-composited ancestor with a plain rectangle: at some zoom levels the screen painted
+   square past the bezel's corners. A composited frame clips them with its own rounded mask. */
 .phone{width:393px;height:852px;position:relative;border-radius:var(--l-r-phone);overflow:hidden;
-  flex:none;background:#000;color:var(--l-ink);
+  flex:none;background:#000;color:var(--l-ink);transform:translateZ(0);
   box-shadow:0 0 0 11px #1D191A, 0 0 0 12.5px #3A3735, 0 24px 60px rgba(29,25,26,.28)}
 .bg{position:absolute;left:-8%;top:-8%;width:116%;height:116%;
   background-size:100% 100%;filter:blur(11px)}

--- a/mockups/canvases/luma-ios/09-home-empty.html
+++ b/mockups/canvases/luma-ios/09-home-empty.html
@@ -101,8 +101,12 @@
    lands on whatever the artboard is placed over instead of a cream rectangle. */
 body{font-family:var(--l-font);-webkit-font-smoothing:antialiased;
   display:flex;justify-content:center;padding:24px}
+/* translateZ(0) composites the frame itself. Its children are composited anyway (the blurred
+   .bg, the backdrop-filter nav), and Safari on iPhone clips composited children of a
+   non-composited ancestor with a plain rectangle: at some zoom levels the screen painted
+   square past the bezel's corners. A composited frame clips them with its own rounded mask. */
 .phone{width:393px;height:852px;position:relative;border-radius:var(--l-r-phone);overflow:hidden;
-  flex:none;background:#000;color:var(--l-ink);
+  flex:none;background:#000;color:var(--l-ink);transform:translateZ(0);
   box-shadow:0 0 0 11px #1D191A, 0 0 0 12.5px #3A3735, 0 24px 60px rgba(29,25,26,.28)}
 .bg{position:absolute;left:-8%;top:-8%;width:116%;height:116%;
   background-size:100% 100%;filter:blur(11px)}

--- a/mockups/canvases/luma-ios/10-home-events.html
+++ b/mockups/canvases/luma-ios/10-home-events.html
@@ -101,8 +101,12 @@
    lands on whatever the artboard is placed over instead of a cream rectangle. */
 body{font-family:var(--l-font);-webkit-font-smoothing:antialiased;
   display:flex;justify-content:center;padding:24px}
+/* translateZ(0) composites the frame itself. Its children are composited anyway (the blurred
+   .bg, the backdrop-filter nav), and Safari on iPhone clips composited children of a
+   non-composited ancestor with a plain rectangle: at some zoom levels the screen painted
+   square past the bezel's corners. A composited frame clips them with its own rounded mask. */
 .phone{width:393px;height:852px;position:relative;border-radius:var(--l-r-phone);overflow:hidden;
-  flex:none;background:#000;color:var(--l-ink);
+  flex:none;background:#000;color:var(--l-ink);transform:translateZ(0);
   box-shadow:0 0 0 11px #1D191A, 0 0 0 12.5px #3A3735, 0 24px 60px rgba(29,25,26,.28)}
 .bg{position:absolute;left:-8%;top:-8%;width:116%;height:116%;
   background-size:100% 100%;filter:blur(11px)}

--- a/mockups/canvases/luma-ios/11-home-nearby.html
+++ b/mockups/canvases/luma-ios/11-home-nearby.html
@@ -101,8 +101,12 @@
    lands on whatever the artboard is placed over instead of a cream rectangle. */
 body{font-family:var(--l-font);-webkit-font-smoothing:antialiased;
   display:flex;justify-content:center;padding:24px}
+/* translateZ(0) composites the frame itself. Its children are composited anyway (the blurred
+   .bg, the backdrop-filter nav), and Safari on iPhone clips composited children of a
+   non-composited ancestor with a plain rectangle: at some zoom levels the screen painted
+   square past the bezel's corners. A composited frame clips them with its own rounded mask. */
 .phone{width:393px;height:852px;position:relative;border-radius:var(--l-r-phone);overflow:hidden;
-  flex:none;background:#000;color:var(--l-ink);
+  flex:none;background:#000;color:var(--l-ink);transform:translateZ(0);
   box-shadow:0 0 0 11px #1D191A, 0 0 0 12.5px #3A3735, 0 24px 60px rgba(29,25,26,.28)}
 .bg{position:absolute;left:-8%;top:-8%;width:116%;height:116%;
   background-size:100% 100%;filter:blur(11px)}

--- a/mockups/canvases/luma-ios/12-home-later.html
+++ b/mockups/canvases/luma-ios/12-home-later.html
@@ -101,8 +101,12 @@
    lands on whatever the artboard is placed over instead of a cream rectangle. */
 body{font-family:var(--l-font);-webkit-font-smoothing:antialiased;
   display:flex;justify-content:center;padding:24px}
+/* translateZ(0) composites the frame itself. Its children are composited anyway (the blurred
+   .bg, the backdrop-filter nav), and Safari on iPhone clips composited children of a
+   non-composited ancestor with a plain rectangle: at some zoom levels the screen painted
+   square past the bezel's corners. A composited frame clips them with its own rounded mask. */
 .phone{width:393px;height:852px;position:relative;border-radius:var(--l-r-phone);overflow:hidden;
-  flex:none;background:#000;color:var(--l-ink);
+  flex:none;background:#000;color:var(--l-ink);transform:translateZ(0);
   box-shadow:0 0 0 11px #1D191A, 0 0 0 12.5px #3A3735, 0 24px 60px rgba(29,25,26,.28)}
 .bg{position:absolute;left:-8%;top:-8%;width:116%;height:116%;
   background-size:100% 100%;filter:blur(11px)}

--- a/mockups/canvases/luma-ios/gen.py
+++ b/mockups/canvases/luma-ios/gen.py
@@ -127,8 +127,12 @@ BASE = """*{box-sizing:border-box;margin:0;padding:0}
    lands on whatever the artboard is placed over instead of a cream rectangle. */
 body{font-family:var(--l-font);-webkit-font-smoothing:antialiased;
   display:flex;justify-content:center;padding:24px}
+/* translateZ(0) composites the frame itself. Its children are composited anyway (the blurred
+   .bg, the backdrop-filter nav), and Safari on iPhone clips composited children of a
+   non-composited ancestor with a plain rectangle: at some zoom levels the screen painted
+   square past the bezel's corners. A composited frame clips them with its own rounded mask. */
 .phone{width:393px;height:852px;position:relative;border-radius:var(--l-r-phone);overflow:hidden;
-  flex:none;background:#000;color:var(--l-ink);
+  flex:none;background:#000;color:var(--l-ink);transform:translateZ(0);
   box-shadow:0 0 0 11px #1D191A, 0 0 0 12.5px #3A3735, 0 24px 60px rgba(29,25,26,.28)}
 .bg{position:absolute;left:-8%;top:-8%;width:116%;height:116%;
   background-size:100% 100%;filter:blur(11px)}

--- a/mockups/canvases/raycast-ios/01-ask-anything.html
+++ b/mockups/canvases/raycast-ios/01-ask-anything.html
@@ -94,7 +94,7 @@
 body{font-family:var(--rc-font);background:#fff;-webkit-font-smoothing:antialiased;
   display:flex;justify-content:center;padding:24px}
 .phone{width:393px;height:852px;position:relative;border-radius:52px;overflow:hidden;flex:none;
-  background:var(--rc-bg);outline:1px solid rgba(0,0,0,.10);
+  background:var(--rc-bg);transform:translateZ(0);outline:1px solid rgba(0,0,0,.10);
   box-shadow:0 0 0 11px #1D191A, 0 0 0 12.5px #3A3735, 0 24px 60px rgba(29,25,26,.28);
   color:var(--rc-ink)}
 .statusbar{position:absolute;left:0;right:0;top:0;height:var(--rc-sb);z-index:1;

--- a/mockups/canvases/raycast-ios/02-prompt-typed.html
+++ b/mockups/canvases/raycast-ios/02-prompt-typed.html
@@ -94,7 +94,7 @@
 body{font-family:var(--rc-font);background:#fff;-webkit-font-smoothing:antialiased;
   display:flex;justify-content:center;padding:24px}
 .phone{width:393px;height:852px;position:relative;border-radius:52px;overflow:hidden;flex:none;
-  background:var(--rc-bg);outline:1px solid rgba(0,0,0,.10);
+  background:var(--rc-bg);transform:translateZ(0);outline:1px solid rgba(0,0,0,.10);
   box-shadow:0 0 0 11px #1D191A, 0 0 0 12.5px #3A3735, 0 24px 60px rgba(29,25,26,.28);
   color:var(--rc-ink)}
 .statusbar{position:absolute;left:0;right:0;top:0;height:var(--rc-sb);z-index:1;

--- a/mockups/canvases/raycast-ios/03-thinking.html
+++ b/mockups/canvases/raycast-ios/03-thinking.html
@@ -94,7 +94,7 @@
 body{font-family:var(--rc-font);background:#fff;-webkit-font-smoothing:antialiased;
   display:flex;justify-content:center;padding:24px}
 .phone{width:393px;height:852px;position:relative;border-radius:52px;overflow:hidden;flex:none;
-  background:var(--rc-bg);outline:1px solid rgba(0,0,0,.10);
+  background:var(--rc-bg);transform:translateZ(0);outline:1px solid rgba(0,0,0,.10);
   box-shadow:0 0 0 11px #1D191A, 0 0 0 12.5px #3A3735, 0 24px 60px rgba(29,25,26,.28);
   color:var(--rc-ink)}
 .statusbar{position:absolute;left:0;right:0;top:0;height:var(--rc-sb);z-index:1;

--- a/mockups/canvases/raycast-ios/04-streaming.html
+++ b/mockups/canvases/raycast-ios/04-streaming.html
@@ -94,7 +94,7 @@
 body{font-family:var(--rc-font);background:#fff;-webkit-font-smoothing:antialiased;
   display:flex;justify-content:center;padding:24px}
 .phone{width:393px;height:852px;position:relative;border-radius:52px;overflow:hidden;flex:none;
-  background:var(--rc-bg);outline:1px solid rgba(0,0,0,.10);
+  background:var(--rc-bg);transform:translateZ(0);outline:1px solid rgba(0,0,0,.10);
   box-shadow:0 0 0 11px #1D191A, 0 0 0 12.5px #3A3735, 0 24px 60px rgba(29,25,26,.28);
   color:var(--rc-ink)}
 .statusbar{position:absolute;left:0;right:0;top:0;height:var(--rc-sb);z-index:1;

--- a/mockups/canvases/raycast-ios/05-answer-actions.html
+++ b/mockups/canvases/raycast-ios/05-answer-actions.html
@@ -94,7 +94,7 @@
 body{font-family:var(--rc-font);background:#fff;-webkit-font-smoothing:antialiased;
   display:flex;justify-content:center;padding:24px}
 .phone{width:393px;height:852px;position:relative;border-radius:52px;overflow:hidden;flex:none;
-  background:var(--rc-bg);outline:1px solid rgba(0,0,0,.10);
+  background:var(--rc-bg);transform:translateZ(0);outline:1px solid rgba(0,0,0,.10);
   box-shadow:0 0 0 11px #1D191A, 0 0 0 12.5px #3A3735, 0 24px 60px rgba(29,25,26,.28);
   color:var(--rc-ink)}
 .statusbar{position:absolute;left:0;right:0;top:0;height:var(--rc-sb);z-index:1;

--- a/mockups/canvases/raycast-ios/06-answer-scrolled.html
+++ b/mockups/canvases/raycast-ios/06-answer-scrolled.html
@@ -94,7 +94,7 @@
 body{font-family:var(--rc-font);background:#fff;-webkit-font-smoothing:antialiased;
   display:flex;justify-content:center;padding:24px}
 .phone{width:393px;height:852px;position:relative;border-radius:52px;overflow:hidden;flex:none;
-  background:var(--rc-bg);outline:1px solid rgba(0,0,0,.10);
+  background:var(--rc-bg);transform:translateZ(0);outline:1px solid rgba(0,0,0,.10);
   box-shadow:0 0 0 11px #1D191A, 0 0 0 12.5px #3A3735, 0 24px 60px rgba(29,25,26,.28);
   color:var(--rc-ink)}
 .statusbar{position:absolute;left:0;right:0;top:0;height:var(--rc-sb);z-index:1;

--- a/mockups/canvases/raycast-ios/07-models-sheet.html
+++ b/mockups/canvases/raycast-ios/07-models-sheet.html
@@ -94,7 +94,7 @@
 body{font-family:var(--rc-font);background:#fff;-webkit-font-smoothing:antialiased;
   display:flex;justify-content:center;padding:24px}
 .phone{width:393px;height:852px;position:relative;border-radius:52px;overflow:hidden;flex:none;
-  background:var(--rc-bg);outline:1px solid rgba(0,0,0,.10);
+  background:var(--rc-bg);transform:translateZ(0);outline:1px solid rgba(0,0,0,.10);
   box-shadow:0 0 0 11px #1D191A, 0 0 0 12.5px #3A3735, 0 24px 60px rgba(29,25,26,.28);
   color:var(--rc-ink)}
 .statusbar{position:absolute;left:0;right:0;top:0;height:var(--rc-sb);z-index:1;

--- a/mockups/canvases/raycast-ios/08-home-composer.html
+++ b/mockups/canvases/raycast-ios/08-home-composer.html
@@ -94,7 +94,7 @@
 body{font-family:var(--rc-font);background:#fff;-webkit-font-smoothing:antialiased;
   display:flex;justify-content:center;padding:24px}
 .phone{width:393px;height:852px;position:relative;border-radius:52px;overflow:hidden;flex:none;
-  background:var(--rc-bg);outline:1px solid rgba(0,0,0,.10);
+  background:var(--rc-bg);transform:translateZ(0);outline:1px solid rgba(0,0,0,.10);
   box-shadow:0 0 0 11px #1D191A, 0 0 0 12.5px #3A3735, 0 24px 60px rgba(29,25,26,.28);
   color:var(--rc-ink)}
 .statusbar{position:absolute;left:0;right:0;top:0;height:var(--rc-sb);z-index:1;

--- a/mockups/canvases/raycast-ios/09-presets-opening.html
+++ b/mockups/canvases/raycast-ios/09-presets-opening.html
@@ -94,7 +94,7 @@
 body{font-family:var(--rc-font);background:#fff;-webkit-font-smoothing:antialiased;
   display:flex;justify-content:center;padding:24px}
 .phone{width:393px;height:852px;position:relative;border-radius:52px;overflow:hidden;flex:none;
-  background:var(--rc-bg);outline:1px solid rgba(0,0,0,.10);
+  background:var(--rc-bg);transform:translateZ(0);outline:1px solid rgba(0,0,0,.10);
   box-shadow:0 0 0 11px #1D191A, 0 0 0 12.5px #3A3735, 0 24px 60px rgba(29,25,26,.28);
   color:var(--rc-ink)}
 .statusbar{position:absolute;left:0;right:0;top:0;height:var(--rc-sb);z-index:1;

--- a/mockups/canvases/raycast-ios/10-presets-list.html
+++ b/mockups/canvases/raycast-ios/10-presets-list.html
@@ -94,7 +94,7 @@
 body{font-family:var(--rc-font);background:#fff;-webkit-font-smoothing:antialiased;
   display:flex;justify-content:center;padding:24px}
 .phone{width:393px;height:852px;position:relative;border-radius:52px;overflow:hidden;flex:none;
-  background:var(--rc-bg);outline:1px solid rgba(0,0,0,.10);
+  background:var(--rc-bg);transform:translateZ(0);outline:1px solid rgba(0,0,0,.10);
   box-shadow:0 0 0 11px #1D191A, 0 0 0 12.5px #3A3735, 0 24px 60px rgba(29,25,26,.28);
   color:var(--rc-ink)}
 .statusbar{position:absolute;left:0;right:0;top:0;height:var(--rc-sb);z-index:1;

--- a/mockups/canvases/raycast-ios/11-home-perplexity.html
+++ b/mockups/canvases/raycast-ios/11-home-perplexity.html
@@ -94,7 +94,7 @@
 body{font-family:var(--rc-font);background:#fff;-webkit-font-smoothing:antialiased;
   display:flex;justify-content:center;padding:24px}
 .phone{width:393px;height:852px;position:relative;border-radius:52px;overflow:hidden;flex:none;
-  background:var(--rc-bg);outline:1px solid rgba(0,0,0,.10);
+  background:var(--rc-bg);transform:translateZ(0);outline:1px solid rgba(0,0,0,.10);
   box-shadow:0 0 0 11px #1D191A, 0 0 0 12.5px #3A3735, 0 24px 60px rgba(29,25,26,.28);
   color:var(--rc-ink)}
 .statusbar{position:absolute;left:0;right:0;top:0;height:var(--rc-sb);z-index:1;

--- a/mockups/canvases/templates/00-design-tokens.html
+++ b/mockups/canvases/templates/00-design-tokens.html
@@ -53,7 +53,7 @@
 body{font-family:var(--x-font);-webkit-font-smoothing:antialiased;
   display:flex;justify-content:center;padding:24px}
 .phone{position:relative;flex:none;width:var(--x-w);height:var(--x-h);
-  border-radius:var(--x-r-phone);overflow:hidden;background:var(--x-bg);color:var(--x-ink);
+  border-radius:var(--x-r-phone);overflow:hidden;background:var(--x-bg);color:var(--x-ink);transform:translateZ(0);
   box-shadow:0 0 0 11px #1D191A,0 0 0 12.5px #3A3735,0 24px 60px rgba(29,25,26,.28)}
 .sb{position:absolute;left:0;top:0;width:var(--x-w);height:var(--x-status);z-index:6}
 .sb .time{position:absolute;left:0;top:18.2px;width:142.4px;text-align:center;font:var(--x-t-time)}

--- a/mockups/canvases/templates/00b-evidence.html
+++ b/mockups/canvases/templates/00b-evidence.html
@@ -53,7 +53,7 @@
 body{font-family:var(--x-font);-webkit-font-smoothing:antialiased;
   display:flex;justify-content:center;padding:24px}
 .phone{position:relative;flex:none;width:var(--x-w);height:var(--x-h);
-  border-radius:var(--x-r-phone);overflow:hidden;background:var(--x-bg);color:var(--x-ink);
+  border-radius:var(--x-r-phone);overflow:hidden;background:var(--x-bg);color:var(--x-ink);transform:translateZ(0);
   box-shadow:0 0 0 11px #1D191A,0 0 0 12.5px #3A3735,0 24px 60px rgba(29,25,26,.28)}
 .sb{position:absolute;left:0;top:0;width:var(--x-w);height:var(--x-status);z-index:6}
 .sb .time{position:absolute;left:0;top:18.2px;width:142.4px;text-align:center;font:var(--x-t-time)}

--- a/mockups/canvases/templates/01-screen.html
+++ b/mockups/canvases/templates/01-screen.html
@@ -53,7 +53,7 @@
 body{font-family:var(--x-font);-webkit-font-smoothing:antialiased;
   display:flex;justify-content:center;padding:24px}
 .phone{position:relative;flex:none;width:var(--x-w);height:var(--x-h);
-  border-radius:var(--x-r-phone);overflow:hidden;background:var(--x-bg);color:var(--x-ink);
+  border-radius:var(--x-r-phone);overflow:hidden;background:var(--x-bg);color:var(--x-ink);transform:translateZ(0);
   box-shadow:0 0 0 11px #1D191A,0 0 0 12.5px #3A3735,0 24px 60px rgba(29,25,26,.28)}
 .sb{position:absolute;left:0;top:0;width:var(--x-w);height:var(--x-status);z-index:6}
 .sb .time{position:absolute;left:0;top:18.2px;width:142.4px;text-align:center;font:var(--x-t-time)}

--- a/mockups/canvases/templates/02-device-cosmic-orange.html
+++ b/mockups/canvases/templates/02-device-cosmic-orange.html
@@ -53,7 +53,7 @@
 body{font-family:var(--x-font);-webkit-font-smoothing:antialiased;
   display:flex;justify-content:center;padding:24px}
 .phone{position:relative;flex:none;width:var(--x-w);height:var(--x-h);
-  border-radius:var(--x-r-phone);overflow:hidden;background:var(--x-bg);color:var(--x-ink);
+  border-radius:var(--x-r-phone);overflow:hidden;background:var(--x-bg);color:var(--x-ink);transform:translateZ(0);
   box-shadow:0 0 0 11px #1D191A,0 0 0 12.5px #3A3735,0 24px 60px rgba(29,25,26,.28)}
 .sb{position:absolute;left:0;top:0;width:var(--x-w);height:var(--x-status);z-index:6}
 .sb .time{position:absolute;left:0;top:18.2px;width:142.4px;text-align:center;font:var(--x-t-time)}

--- a/mockups/canvases/templates/03-device-deep-blue.html
+++ b/mockups/canvases/templates/03-device-deep-blue.html
@@ -53,7 +53,7 @@
 body{font-family:var(--x-font);-webkit-font-smoothing:antialiased;
   display:flex;justify-content:center;padding:24px}
 .phone{position:relative;flex:none;width:var(--x-w);height:var(--x-h);
-  border-radius:var(--x-r-phone);overflow:hidden;background:var(--x-bg);color:var(--x-ink);
+  border-radius:var(--x-r-phone);overflow:hidden;background:var(--x-bg);color:var(--x-ink);transform:translateZ(0);
   box-shadow:0 0 0 11px #1D191A,0 0 0 12.5px #3A3735,0 24px 60px rgba(29,25,26,.28)}
 .sb{position:absolute;left:0;top:0;width:var(--x-w);height:var(--x-status);z-index:6}
 .sb .time{position:absolute;left:0;top:18.2px;width:142.4px;text-align:center;font:var(--x-t-time)}

--- a/mockups/canvases/templates/04-device-silver.html
+++ b/mockups/canvases/templates/04-device-silver.html
@@ -53,7 +53,7 @@
 body{font-family:var(--x-font);-webkit-font-smoothing:antialiased;
   display:flex;justify-content:center;padding:24px}
 .phone{position:relative;flex:none;width:var(--x-w);height:var(--x-h);
-  border-radius:var(--x-r-phone);overflow:hidden;background:var(--x-bg);color:var(--x-ink);
+  border-radius:var(--x-r-phone);overflow:hidden;background:var(--x-bg);color:var(--x-ink);transform:translateZ(0);
   box-shadow:0 0 0 11px #1D191A,0 0 0 12.5px #3A3735,0 24px 60px rgba(29,25,26,.28)}
 .sb{position:absolute;left:0;top:0;width:var(--x-w);height:var(--x-status);z-index:6}
 .sb .time{position:absolute;left:0;top:18.2px;width:142.4px;text-align:center;font:var(--x-t-time)}

--- a/mockups/canvases/templates/05-device-blue-titanium.html
+++ b/mockups/canvases/templates/05-device-blue-titanium.html
@@ -53,7 +53,7 @@
 body{font-family:var(--x-font);-webkit-font-smoothing:antialiased;
   display:flex;justify-content:center;padding:24px}
 .phone{position:relative;flex:none;width:var(--x-w);height:var(--x-h);
-  border-radius:var(--x-r-phone);overflow:hidden;background:var(--x-bg);color:var(--x-ink);
+  border-radius:var(--x-r-phone);overflow:hidden;background:var(--x-bg);color:var(--x-ink);transform:translateZ(0);
   box-shadow:0 0 0 11px #1D191A,0 0 0 12.5px #3A3735,0 24px 60px rgba(29,25,26,.28)}
 .sb{position:absolute;left:0;top:0;width:var(--x-w);height:var(--x-status);z-index:6}
 .sb .time{position:absolute;left:0;top:18.2px;width:142.4px;text-align:center;font:var(--x-t-time)}

--- a/mockups/canvases/templates/06-device-natural-titanium.html
+++ b/mockups/canvases/templates/06-device-natural-titanium.html
@@ -53,7 +53,7 @@
 body{font-family:var(--x-font);-webkit-font-smoothing:antialiased;
   display:flex;justify-content:center;padding:24px}
 .phone{position:relative;flex:none;width:var(--x-w);height:var(--x-h);
-  border-radius:var(--x-r-phone);overflow:hidden;background:var(--x-bg);color:var(--x-ink);
+  border-radius:var(--x-r-phone);overflow:hidden;background:var(--x-bg);color:var(--x-ink);transform:translateZ(0);
   box-shadow:0 0 0 11px #1D191A,0 0 0 12.5px #3A3735,0 24px 60px rgba(29,25,26,.28)}
 .sb{position:absolute;left:0;top:0;width:var(--x-w);height:var(--x-status);z-index:6}
 .sb .time{position:absolute;left:0;top:18.2px;width:142.4px;text-align:center;font:var(--x-t-time)}

--- a/mockups/canvases/templates/07-device-white-titanium.html
+++ b/mockups/canvases/templates/07-device-white-titanium.html
@@ -53,7 +53,7 @@
 body{font-family:var(--x-font);-webkit-font-smoothing:antialiased;
   display:flex;justify-content:center;padding:24px}
 .phone{position:relative;flex:none;width:var(--x-w);height:var(--x-h);
-  border-radius:var(--x-r-phone);overflow:hidden;background:var(--x-bg);color:var(--x-ink);
+  border-radius:var(--x-r-phone);overflow:hidden;background:var(--x-bg);color:var(--x-ink);transform:translateZ(0);
   box-shadow:0 0 0 11px #1D191A,0 0 0 12.5px #3A3735,0 24px 60px rgba(29,25,26,.28)}
 .sb{position:absolute;left:0;top:0;width:var(--x-w);height:var(--x-status);z-index:6}
 .sb .time{position:absolute;left:0;top:18.2px;width:142.4px;text-align:center;font:var(--x-t-time)}

--- a/mockups/canvases/templates/08-device-desert-titanium.html
+++ b/mockups/canvases/templates/08-device-desert-titanium.html
@@ -53,7 +53,7 @@
 body{font-family:var(--x-font);-webkit-font-smoothing:antialiased;
   display:flex;justify-content:center;padding:24px}
 .phone{position:relative;flex:none;width:var(--x-w);height:var(--x-h);
-  border-radius:var(--x-r-phone);overflow:hidden;background:var(--x-bg);color:var(--x-ink);
+  border-radius:var(--x-r-phone);overflow:hidden;background:var(--x-bg);color:var(--x-ink);transform:translateZ(0);
   box-shadow:0 0 0 11px #1D191A,0 0 0 12.5px #3A3735,0 24px 60px rgba(29,25,26,.28)}
 .sb{position:absolute;left:0;top:0;width:var(--x-w);height:var(--x-status);z-index:6}
 .sb .time{position:absolute;left:0;top:18.2px;width:142.4px;text-align:center;font:var(--x-t-time)}

--- a/mockups/canvases/templates/gen.py
+++ b/mockups/canvases/templates/gen.py
@@ -126,8 +126,11 @@ BASE = """*{box-sizing:border-box;margin:0;padding:0}
 body{font-family:var(--x-font);-webkit-font-smoothing:antialiased;
   display:flex;justify-content:center;padding:24px}"""
 
+# translateZ(0) composites the frame itself. Safari on iPhone clips composited children (blur,
+# backdrop-filter) of a non-composited ancestor with a plain rectangle, so the screen painted
+# square past the bezel's corners; a composited frame clips them with its own rounded mask.
 PHONE = """.phone{position:relative;flex:none;width:var(--x-w);height:var(--x-h);
-  border-radius:var(--x-r-phone);overflow:hidden;background:var(--x-bg);color:var(--x-ink);
+  border-radius:var(--x-r-phone);overflow:hidden;background:var(--x-bg);color:var(--x-ink);transform:translateZ(0);
   box-shadow:0 0 0 11px #1D191A,0 0 0 12.5px #3A3735,0 24px 60px rgba(29,25,26,.28)}
 .sb{position:absolute;left:0;top:0;width:var(--x-w);height:var(--x-status);z-index:6}
 .sb .time{position:absolute;left:0;top:18.2px;width:142.4px;text-align:center;font:var(--x-t-time)}


### PR DESCRIPTION
## Summary
- Yilin saw the Luma screens paint square past the four rounded corners of the bezel in Safari on iPhone (canvas zoom ≈ 0.4).
- WebKit clips composited children (`filter:blur`, `backdrop-filter`) of a non-composited ancestor with a plain rectangle, dropping the radius. `transform:translateZ(0)` on `.phone` makes the frame clip them through its own rounded mask.
- Applied in the generators and generated HTML for luma-ios, apple-calendar, apple-settings, raycast-ios, and templates (so new folders inherit it). Folders with no composited content inside the frame are untouched.
- Decision note in `docs/2026-09-03-phone-corners-safari.md`, including the rejected clip-path wrapper (it degraded the 60px nav backdrop blur in both Safari and Chrome).

## Test plan
- [x] Raw Luma board 05 before/after in headless Chrome and the iPhone 17 simulator (iOS 26.3): identical, nav blur intact.
- [x] Dev canvas in the simulator at zoom 0.42 and 1: corners clean, no visual change.
- [x] Calendar sheet and Raycast models sheet before/after in the simulator: identical.
- [ ] Not reproducible on the simulator; confirm on the affected iPhone after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)