### PR TITLE
The address follows the open page, so the URL bar is the share link

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ registry, no build step and no design tool.
 Five of the ten app folders in `mockups/canvases/`. That folder's own
 `README.md` lists them all. Each is a real `clone-prototype` run, rebuilt
 from measured samples with the evidence recorded for every token. Open any
-of them with `?canvas=<slug>`.
+of them with `?canvas=<slug>`; the address follows whichever page is open, so
+the URL in the bar is always the link to share.
 
 ### `duolingo-ios`, eight screens that are mostly picture
 

--- a/canvas/src/App.tsx
+++ b/canvas/src/App.tsx
@@ -3,6 +3,7 @@ import {
   Tldraw,
   createShapeId,
   getIndices,
+  react,
   toRichText,
   type Editor,
   type TLPageId,
@@ -14,6 +15,7 @@ import {
 } from "tldraw";
 import "tldraw/tldraw.css";
 import { installAgentBridge } from "./agentBridge";
+import { WELCOME_PAGE_SLUG, slugFromUrl, urlForSlug } from "./canvasUrl";
 import {
   CANVAS_FILE_DEFAULT_SIZE,
   CANVAS_FILE_SHAPE_TYPE,
@@ -65,7 +67,6 @@ try {
 }
 
 /** The onboarding folder. Sorts first, and the bare URL opens it. */
-const WELCOME_PAGE_SLUG = "00-welcome";
 
 /**
  * The artboard box, which is 478 x 980 unless the folder's layout.json declares its own `w`/`h`
@@ -648,19 +649,44 @@ function relayoutCanvasLibrary(editor: Editor) {
 }
 
 /**
- * Opens `?canvas=<slug>` (the canvases/<slug> folder name) on the matching page, so a specific
- * round can be linked to or scripted against instead of relying on whichever page tldraw last
- * persisted.
- *
- * With no slug the bare URL opens the welcome page every time, so that page is the way in:
- * keep a board open across reloads by deep-linking it, not by leaving it on screen.
+ * Opens the page the address names (canvasUrl.ts): `?canvas=<slug>` for a board, the bare URL
+ * for the welcome page. So a specific round can be linked to or scripted against instead of
+ * relying on whichever page tldraw last persisted, and the bare URL is always the way in: keep
+ * a board open across reloads by deep-linking it, not by leaving it on screen.
  */
 function applyCanvasFromUrl(editor: Editor) {
-  const slug =
-    new URLSearchParams(window.location.search).get("canvas") ??
-    WELCOME_PAGE_SLUG;
+  const slug = slugFromUrl(window.location.href);
   const page = editor.getPages().find((c) => c.meta.canvasSlug === slug);
   if (page) editor.setCurrentPage(page.id);
+}
+
+/**
+ * Keeps the address on the page being looked at, so whatever is on screen can be shared by
+ * copying the URL. Each page change (a welcome card, tldraw's page menu) pushes a history
+ * entry, so Back returns to the previous board and, from a board, to the welcome page; a
+ * popstate opens the page that entry names. Installed after applyCanvasFromUrl so the first
+ * run finds the address already applied and only corrects it, without a new entry, when it
+ * named no folder. Pages tldraw persisted but no folder claims have no slug and leave the
+ * address as it is.
+ */
+function installCanvasUrlSync(editor: Editor) {
+  let first = true;
+  const stopSync = react("canvas page in the address", () => {
+    const slug = editor.getCurrentPage().meta.canvasSlug;
+    const push = !first;
+    first = false;
+    if (typeof slug !== "string") return;
+    const href = urlForSlug(window.location.href, slug);
+    if (href === window.location.href) return;
+    if (push) window.history.pushState(null, "", href);
+    else window.history.replaceState(null, "", href);
+  });
+  const onPopState = () => applyCanvasFromUrl(editor);
+  window.addEventListener("popstate", onPopState);
+  return () => {
+    stopSync();
+    window.removeEventListener("popstate", onPopState);
+  };
 }
 
 /**
@@ -693,6 +719,7 @@ export default function App() {
     editorRef.current = editor;
     initializeCanvas(editor);
     applyCanvasFromUrl(editor);
+    return installCanvasUrlSync(editor);
   }
 
   return (

--- a/canvas/src/canvasUrl.test.ts
+++ b/canvas/src/canvasUrl.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+import { WELCOME_PAGE_SLUG, slugFromUrl, urlForSlug } from './canvasUrl'
+
+// The address is what people paste to each other, so both directions have to agree: the URL a
+// page writes must open that page, and the welcome page must write the bare URL back.
+describe('canvas URLs', () => {
+  const root = 'https://prototyping.rescience.com/'
+
+  it('reads a board slug and falls back to the welcome page', () => {
+    expect(slugFromUrl(root + '?canvas=luma-ios')).toBe('luma-ios')
+    expect(slugFromUrl(root)).toBe(WELCOME_PAGE_SLUG)
+    expect(slugFromUrl(root + '?other=1')).toBe(WELCOME_PAGE_SLUG)
+  })
+
+  it('writes a board as ?canvas= and the welcome page as the bare URL', () => {
+    expect(urlForSlug(root, 'luma-ios')).toBe(root + '?canvas=luma-ios')
+    expect(urlForSlug(root + '?canvas=luma-ios', 'notion-ios')).toBe(root + '?canvas=notion-ios')
+    expect(urlForSlug(root + '?canvas=luma-ios', WELCOME_PAGE_SLUG)).toBe(root)
+  })
+
+  it('round-trips and keeps unrelated parameters', () => {
+    const href = urlForSlug(root + '?other=1', 'raycast-ios')
+    expect(slugFromUrl(href)).toBe('raycast-ios')
+    expect(new URL(href).searchParams.get('other')).toBe('1')
+    expect(new URL(urlForSlug(href, WELCOME_PAGE_SLUG)).search).toBe('?other=1')
+  })
+})

--- a/canvas/src/canvasUrl.ts
+++ b/canvas/src/canvasUrl.ts
@@ -1,0 +1,20 @@
+// The address of a page. A board is `?canvas=<slug>`, the canvases/<slug> folder name; the
+// welcome page is the bare URL, so the way in stays the shortest link there is. Anything else
+// in the query string is left alone.
+
+export const WELCOME_PAGE_SLUG = "00-welcome";
+
+const CANVAS_PARAM = "canvas";
+
+/** The page slug an address opens: its `canvas` parameter, else the welcome page. */
+export function slugFromUrl(href: string) {
+  return new URL(href).searchParams.get(CANVAS_PARAM) ?? WELCOME_PAGE_SLUG;
+}
+
+/** The address for a page slug, built on `href` so the origin, path and other parameters stay. */
+export function urlForSlug(href: string, slug: string) {
+  const url = new URL(href);
+  if (slug === WELCOME_PAGE_SLUG) url.searchParams.delete(CANVAS_PARAM);
+  else url.searchParams.set(CANVAS_PARAM, slug);
+  return url.href;
+}


### PR DESCRIPTION
## Summary
- Clicking a welcome card or switching pages in tldraw's page menu now updates the address to `?canvas=<slug>`; the welcome page writes the bare URL back. Copying the URL bar shares whatever is on screen.
- Each page change pushes a history entry, so Back returns to the previous board and, from a board, to the welcome page. A popstate reopens the page that entry names.
- The existing `?canvas=<slug>` deep links keep working unchanged; unrelated query parameters are preserved.
- New `canvasUrl.ts` holds the two pure directions with tests.

## Test plan
- [x] `bun run test`, `tsc -b`, `oxlint` clean
- [x] Headless Chrome against the dev server: bare load `/` → welcome; click Luma card → `/?canvas=luma-ios` on the Luma page; `history.back()` → `/` welcome; `history.forward()` → Luma; `/?canvas=notion-ios&x=1` opens Notion with the URL untouched; `/?canvas=no-such-folder` opens the persisted page and replaces the address without an extra history entry.
- [ ] Production after the Pages deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)