### PR TITLE
Add security policy, contributing guide, Dependabot and templates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# Pull requests that touch these paths request a review from the owner
+# automatically. The last matching line wins.
+*                     @Jing-yilin
+/canvas/              @Jing-yilin
+/.agents/skills/      @Jing-yilin
+/tools/               @Jing-yilin
+/.github/             @Jing-yilin

--- a/.github/ISSUE_TEMPLATE/README.md
+++ b/.github/ISSUE_TEMPLATE/README.md
@@ -1,0 +1,5 @@
+# Issue templates
+
+`bug_report.md` and `feature_request.md` are the two forms offered when
+someone opens an issue. `config.yml` adds the links shown above them and keeps
+blank issues enabled.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,24 @@
+---
+name: Bug report
+about: Something renders wrong, a skill misbehaves, or the canvas breaks
+labels: bug
+---
+
+## What happened
+
+<!-- What you did, what you expected, what you saw instead. -->
+
+## Where
+
+- Canvas or skill: <!-- e.g. mockups/canvases/luma-ios, clone-prototype -->
+- Hosted (prototyping.rescience.com) or local dev server:
+- Browser / device / OS:
+
+## How to reproduce
+
+1.
+2.
+
+## Screenshots
+
+<!-- Drop a screenshot of the board and, if relevant, the browser console. Do not attach third-party app captures you do not have the right to share. -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Report a security vulnerability
+    url: https://github.com/ReScienceLab/super-prototyping/security/advisories/new
+    about: Please use private vulnerability reporting instead of a public issue.
+  - name: Hosted canvas
+    url: https://prototyping.rescience.com
+    about: Open the example canvases in the browser before filing a rendering bug.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,15 @@
+---
+name: Feature request
+about: A new canvas, a skill improvement, or a change to the viewer
+labels: enhancement
+---
+
+## Problem
+
+<!-- What you are trying to do and where the current workflow gets in the way. -->
+
+## Proposal
+
+<!-- What you would like to see. For a new example canvas, name the app and the screens. -->
+
+## Alternatives considered

--- a/.github/README.md
+++ b/.github/README.md
@@ -1,0 +1,13 @@
+# .github
+
+Repository automation and templates.
+
+- `CODEOWNERS`: who is asked to review pull requests, by path.
+- `dependabot.yml`: weekly dependency updates for `canvas/` (bun) and for any
+  GitHub Actions workflows.
+- `pull_request_template.md`: the checklist every pull request starts with.
+- `ISSUE_TEMPLATE/`: bug and feature forms, plus links to private
+  vulnerability reporting and the hosted canvas.
+
+Branch and tag protection, secret scanning, CodeQL and Actions permissions are
+repository settings, not files; see `SECURITY.md` at the root.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  - package-ecosystem: "bun"
+    directory: "/canvas"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    groups:
+      minor-and-patch:
+        update-types: ["minor", "patch"]
+    labels: ["dependencies"]
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels: ["dependencies"]

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+## What this changes
+
+<!-- One or two sentences. Link the issue if there is one. -->
+
+## Checklist
+
+- [ ] No `ref-*.html`, `assets/refs/` or other third-party captures are in this PR.
+- [ ] If a canvas folder changed: `gen.py` was edited and re-run, the `NN-*.html` boards were not hand-edited, and `python3 tools/refkit.py thumbs mockups/canvases/<slug>` was run afterwards.
+- [ ] If a canvas folder changed: `layout.json`, `probes.json`, `crops.json` and `assets.json` are committed alongside the boards.
+- [ ] Every new folder has a `README.md` and no folder has its own `.gitignore`.
+- [ ] If `canvas/` changed: `bun test` and `bun run build` pass in `canvas/`.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,84 @@
+# Code of Conduct
+
+## Our pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our standards
+
+Examples of behavior that contributes to a positive environment:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior:
+
+- The use of sexualized language or imagery, and sexual attention or advances
+  of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, issues, and other contributions that are not aligned
+to this Code of Conduct, and will communicate reasons for moderation decisions
+when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the maintainers at yilin.jing@rescience.com. All complaints will be
+reviewed and investigated promptly and fairly. All community leaders are
+obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+1. **Correction.** A private, written warning, providing clarity around the
+   nature of the violation and an explanation of why the behavior was
+   inappropriate. A public apology may be requested.
+2. **Warning.** A warning with consequences for continued behavior. No
+   interaction with the people involved for a specified period of time.
+   Violating these terms may lead to a temporary or permanent ban.
+3. **Temporary ban.** A temporary ban from any sort of interaction or public
+   communication with the community for a specified period of time.
+4. **Permanent ban.** A permanent ban from any sort of public interaction
+   within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.
+
+[homepage]: https://www.contributor-covenant.org

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,65 @@
+# Contributing
+
+Thanks for helping. This file covers the mechanics; `CLAUDE.md` and
+`mockups/canvases/README.md` cover the conventions inside a canvas folder in
+detail, and the pull request template repeats the ones that matter most.
+
+## Setup
+
+```bash
+git clone https://github.com/ReScienceLab/super-prototyping.git
+cd super-prototyping/canvas && bun install --frozen-lockfile && bun run dev
+```
+
+The viewer discovers `mockups/canvases/*/*.html` on its own. There is no
+registry to edit and no build step per board.
+
+## Making a change
+
+1. Branch from `main`. Direct pushes to `main` are blocked; every change lands
+   through a pull request.
+2. Keep the pull request to one topic: one canvas folder, one skill, or one
+   viewer change.
+3. Fill in the checklist in the pull request template. Reviews are requested
+   automatically through `CODEOWNERS`.
+
+## Rules that reviews will check
+
+- **`gen.py` is the only source of truth** for a canvas folder. Edit the
+  generator and re-run it. Never hand-edit the `NN-*.html` boards.
+- **Regenerate thumbnails** after `gen.py`:
+  `python3 tools/refkit.py thumbs mockups/canvases/<slug>`.
+- **Commit the evidence**: `layout.json`, `icon.png`, `thumbs/`, `assets/`,
+  `probes.json`, `crops.json`, `assets.json`.
+- **Never commit third-party captures.** `ref-*.html` and `assets/refs/` are
+  ignored by git for a reason. Do not work around the ignore.
+- **Scratch output goes in `scratch/`** inside the folder, never in the repo
+  root or a dot directory.
+- **Every folder has a `README.md`. No folder has its own `.gitignore`.**
+- **Viewer changes** in `canvas/` need `bun test` and `bun run build` to pass.
+  Add a test next to the module you touched.
+
+## Adding an example canvas
+
+```bash
+cp -r mockups/canvases/templates mockups/canvases/<slug>
+```
+
+Then run the `clone-prototype` skill (measured from your own captures) or
+`new-ui-mock` (no reference). A new example should reproduce screens you have
+the right to capture, record the measurements behind every token, and ship
+with a `README.md` that says what was measured and what was excluded.
+
+## Decisions
+
+A decision worth rereading goes in `docs/YYYY-MM-DD-slug.md`.
+
+## Reporting problems
+
+Bugs and feature requests go through the issue templates. Security problems go
+through private vulnerability reporting; see `SECURITY.md`.
+
+## License
+
+By contributing you agree that your contribution is licensed under the
+Apache License 2.0, the same as the rest of the repository.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,40 @@
+# Security policy
+
+## Reporting a vulnerability
+
+Please do not open a public issue for a security problem.
+
+Use GitHub's private vulnerability reporting:
+https://github.com/ReScienceLab/super-prototyping/security/advisories/new
+
+If that is not possible, email yilin.jing@rescience.com with "super-prototyping
+security" in the subject.
+
+You will get an acknowledgement within three business days. We aim to confirm
+and fix a valid report within 30 days and will credit you in the advisory
+unless you prefer otherwise.
+
+## Scope
+
+- The `canvas/` viewer (the code behind https://prototyping.rescience.com).
+- The measuring tools in `tools/` and the agent skills in `.agents/skills/`.
+- The generators (`gen.py`) and boards under `mockups/canvases/`.
+
+Boards render inside sandboxed `<iframe srcdoc>` shapes. A report that shows a
+board escaping that sandbox, reading another origin, or executing code in the
+viewer's context is in scope. Visual differences between a replica and the app
+it reproduces are not security issues.
+
+## Supported versions
+
+Only the `main` branch is supported. There are no tagged releases yet.
+
+## What the repository already does
+
+- `main` requires a pull request; force pushes and deletion are blocked.
+  Tags cannot be deleted or overwritten.
+- Secret scanning with push protection is on, so credentials cannot be pushed.
+- Dependabot opens pull requests for vulnerable and outdated dependencies.
+- CodeQL scans JavaScript, TypeScript and Python on every pull request.
+- Third-party captures (`ref-*.html`, `assets/refs/`) are ignored by git and
+  never committed.


### PR DESCRIPTION
Companion to the repository settings enabled today (branch and tag rulesets, secret scanning with push protection, Dependabot security updates, private vulnerability reporting, CodeQL default setup, restricted Actions).

- `SECURITY.md`: how to report, scope, what is already enforced.
- `CONTRIBUTING.md`: setup, PR flow, the canvas folder rules reviews check.
- `CODE_OF_CONDUCT.md`: Contributor Covenant 2.1.
- `.github/dependabot.yml`: weekly bun updates for `canvas/`, grouped minor and patch; weekly Actions updates.
- `.github/CODEOWNERS`: reviews routed to @Jing-yilin.
- `.github/pull_request_template.md`, `ISSUE_TEMPLATE/`: bug and feature forms, security link, capture checklist.
- `README.md` in `.github/` and `ISSUE_TEMPLATE/` per the every-folder rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)