### PR TITLE
Review fixes: README wording, stale thumbs steps, useCanvasFileHtml reads the cache

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,7 +5,7 @@
 ## Checklist
 
 - [ ] No `ref-*.html`, `assets/refs/` or other third-party captures are in this PR.
-- [ ] If a canvas folder changed: `gen.py` was edited and re-run, the `NN-*.html` boards were not hand-edited, and `python3 tools/refkit.py thumbs mockups/canvases/<slug>` was run afterwards.
+- [ ] If a canvas folder changed: `gen.py` was edited and re-run, and the `NN-*.html` boards were not hand-edited.
 - [ ] If a canvas folder changed: `layout.json`, `probes.json`, `crops.json` and `assets.json` are committed alongside the boards.
 - [ ] Every new folder has a `README.md` and no folder has its own `.gitignore`.
 - [ ] If `canvas/` changed: `bun test` and `bun run build` pass in `canvas/`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,8 +29,8 @@ Rules inside a canvas folder:
 - Put everything else a run makes in `scratch/`. The root `.gitignore`
   ignores it at any depth. Do not use the repo root or a dot directory.
 - Give every folder a `README.md`. Do not give any folder a `.gitignore`.
-  The one exception is `.github/`: GitHub shows `.github/README.md` instead
-  of the root README, so its guide lives in `CONTRIBUTING.md`.
+  Except `.github/`: GitHub shows `.github/README.md` instead of the root
+  README, so its guide lives in `CONTRIBUTING.md`.
 
 A decision worth rereading goes in `docs/YYYY-MM-DD-slug.md`. Create `docs/`
 with the first one.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,9 +27,7 @@ registry to edit and no build step per board.
 
 - **`gen.py` is the only source of truth** for a canvas folder. Edit the
   generator and re-run it. Never hand-edit the `NN-*.html` boards.
-- **Regenerate thumbnails** after `gen.py`:
-  `python3 tools/refkit.py thumbs mockups/canvases/<slug>`.
-- **Commit the evidence**: `layout.json`, `icon.png`, `thumbs/`, `assets/`,
+- **Commit the evidence**: `layout.json`, `icon.png`, `assets/`,
   `probes.json`, `crops.json`, `assets.json`.
 - **Never commit third-party captures.** `ref-*.html` and `assets/refs/` are
   ignored by git for a reason. Do not work around the ignore.
@@ -64,8 +62,8 @@ Everything under `.github/`:
 Branch and tag protection, secret scanning, CodeQL and Actions permissions are
 repository settings, not files; see `SECURITY.md`.
 
-`.github/` is the one folder without a `README.md`: GitHub renders
-`.github/README.md` in place of the root README on the repository page.
+`.github/` must not get a `README.md`: GitHub renders `.github/README.md` in
+place of the root README on the repository page.
 
 ## Decisions
 

--- a/canvas/src/canvasLibrary.test.ts
+++ b/canvas/src/canvasLibrary.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { readCanvasLibrary } from './canvasLibrary'
+import { canvasFileHtml, loadCanvasFileHtml, readCanvasLibrary } from './canvasLibrary'
 import { WELCOME_PAGE_SLUG } from './canvasUrl'
 
 describe('readCanvasLibrary', () => {
@@ -9,5 +9,21 @@ describe('readCanvasLibrary', () => {
     expect(slugs.slice(0, 2)).toEqual([WELCOME_PAGE_SLUG, 'snapaction-ios'])
     const rest = slugs.slice(2)
     expect(rest).toEqual([...rest].sort((a, b) => a.localeCompare(b, undefined, { numeric: true })))
+  })
+})
+
+describe('loadCanvasFileHtml', () => {
+  it('fills the cache useCanvasFileHtml reads from, and leaves non-boards out of it', async () => {
+    const path = readCanvasLibrary()[0][0].path
+    expect(canvasFileHtml.has(path)).toBe(false)
+    const html = await loadCanvasFileHtml(path)
+    expect(html).toContain('<')
+    expect(canvasFileHtml.get(path)).toBe(html)
+    // A second load resolves from the cache with the same string.
+    expect(await loadCanvasFileHtml(path)).toBe(html)
+
+    const missing = '/mockups/canvases/nope/00-nope.html'
+    expect(await loadCanvasFileHtml(missing)).toBeUndefined()
+    expect(canvasFileHtml.has(missing)).toBe(false)
   })
 })

--- a/canvas/src/canvasLibrary.ts
+++ b/canvas/src/canvasLibrary.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useReducer } from "react";
 import { WELCOME_PAGE_SLUG } from "./canvasUrl";
 
 // Auto-discovers the boards dropped under mockups/canvases/<slug>/*.html, one folder per board
@@ -153,26 +153,23 @@ export function loadCanvasFileHtml(path: string): Promise<string | undefined> {
 /**
  * A rendering shape's board HTML: undefined until its chunk arrives, then the string. Every shape
  * on the page mounts (culling only hides the off-screen ones), so a page fetches its own boards
- * and nothing else.
+ * and nothing else. The cache is the source of truth and state is only a re-render tick, so a
+ * shape whose path changes reads the new path's HTML on the same render instead of showing the
+ * old board for a frame.
  */
 export function useCanvasFileHtml(path: string): string | undefined {
-  const [html, setHtml] = useState(() => canvasFileHtml.get(path));
+  const [, rerender] = useReducer((n: number) => n + 1, 0);
   useEffect(() => {
+    if (canvasFileHtml.has(path)) return;
     let live = true;
-    const cached = canvasFileHtml.get(path);
-    if (cached !== undefined) {
-      setHtml(cached);
-      return;
-    }
-    setHtml(undefined);
-    loadCanvasFileHtml(path).then((loaded) => {
-      if (live) setHtml(loaded);
+    loadCanvasFileHtml(path).then(() => {
+      if (live) rerender();
     });
     return () => {
       live = false;
     };
   }, [path]);
-  return html;
+  return canvasFileHtml.get(path);
 }
 
 const LAYOUT_PATTERN = /canvases\/([^/]+)\/layout\.json$/;


### PR DESCRIPTION
Follow-ups from a review of #30–#34.

- **Docs**: `CONTRIBUTING.md` / `AGENTS.md` said `.github/` is the one folder without a README; many folders have none. Now: it must not get one, because GitHub renders it in place of the root README.
- **Docs**: drop the `refkit.py thumbs` step and `thumbs/` from `CONTRIBUTING.md` and the PR template. The subcommand does not exist and thumbnails were reverted in #28.
- **canvas**: `useCanvasFileHtml` reads the HTML cache directly and uses state only as a re-render tick. Removes the oxlint 1.81 `react(set-state-in-effect)` warning and a one-frame flash of the previous board when a mounted link card's path changes.
- **test**: `canvasLibrary.test.ts` covers the cache contract the hook relies on.

## Checklist

- [x] No `ref-*.html`, `assets/refs/` or other third-party captures are in this PR.
- [x] No canvas folder changed.
- [x] Every new folder has a `README.md` and no folder has its own `.gitignore`.
- [x] `bun test` (8 passed) and `bun run build` pass in `canvas/`; `bun run lint` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)