### PR TITLE
Inspect a board from the canvas

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,8 +43,13 @@ Rules inside a canvas folder:
   output. Edit the generator and re-run, never the HTML.
 - Commit `layout.json`, `icon.png` and `assets/`. `gen.py` inlines the
   images in `assets/` as `data:` URIs.
-- Commit `probes.json`, `crops.json` and `assets.json`. They are the
-  measurement evidence behind the tokens.
+- Commit `probes.json` and `crops.json`. They are the measurement evidence
+  behind the tokens.
+- Commit `assets.json` where a folder has one (three do). It is a
+  `name → data URI` map of pre-encoded images the generator inlines, not
+  evidence. The canvas's inspector names a board's images by content, from
+  `assets/` first and `assets.json` second, so a re-encoded image that
+  matches neither falls back to its `alt`.
 - Never commit `ref-*.html` or `assets/refs/`. They hold third-party
   captures, the root `.gitignore` already excludes them, and the
   clone-prototype skill rebuilds them. `spotify-ios` is the one exception:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,8 @@ registry to edit and no build step per board.
 - **`gen.py` is the only source of truth** for a canvas folder. Edit the
   generator and re-run it. Never hand-edit the `NN-*.html` boards.
 - **Commit the evidence**: `layout.json`, `icon.png`, `assets/`,
-  `probes.json`, `crops.json`, `assets.json`.
+  `probes.json`, `crops.json` — and `assets.json` where a folder has one:
+  a `name → data URI` map of pre-encoded images the generator inlines.
 - **Never commit third-party captures.** `ref-*.html` and `assets/refs/` are
   ignored by git for a reason. Do not work around the ignore.
 - **Scratch output goes in `scratch/`** inside the folder, never in the repo

--- a/canvas/src/App.tsx
+++ b/canvas/src/App.tsx
@@ -764,6 +764,8 @@ export default function App() {
   } | null>(null);
   const editorRef = useRef<Editor | null>(null);
 
+  // Stable, so the panel's Escape listener is not torn down and rebound on every App render.
+  const onCloseInspector = useCallback(() => setInspecting(null), []);
   const onPick = useCallback((shape: CanvasFileShape) => {
     const { path, name, w, h } = shape.props;
     setInspecting({ path, name, w, h });
@@ -810,7 +812,7 @@ export default function App() {
             path={inspecting.path}
             name={inspecting.name}
             size={{ w: inspecting.w, h: inspecting.h }}
-            onClose={() => setInspecting(null)}
+            onClose={onCloseInspector}
           />
         ) : null}
       </div>

--- a/canvas/src/App.tsx
+++ b/canvas/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import {
   Tldraw,
   createShapeId,
@@ -19,8 +19,10 @@ import { WELCOME_PAGE_SLUG, slugFromUrl, urlForSlug } from "./canvasUrl";
 import {
   CANVAS_FILE_DEFAULT_SIZE,
   CANVAS_FILE_SHAPE_TYPE,
+  type CanvasFileShape,
   CanvasFileShapeUtil,
 } from "./CanvasFileShapeUtil";
+import { InspectorClicks, InspectorPanel } from "./InspectorPanel";
 import {
   CANVAS_LINK_BUTTON_SIZE,
   CANVAS_LINK_CARD_SIZE,
@@ -753,7 +755,19 @@ function initializeCanvas(editor: Editor) {
 
 export default function App() {
   const [stylesVisible, setStylesVisible] = useState(false);
+  /** The board open in the inspector: click any board on the canvas to open it, Escape or × to close. */
+  const [inspecting, setInspecting] = useState<{
+    path: string;
+    name: string;
+    w: number;
+    h: number;
+  } | null>(null);
   const editorRef = useRef<Editor | null>(null);
+
+  const onPick = useCallback((shape: CanvasFileShape) => {
+    const { path, name, w, h } = shape.props;
+    setInspecting({ path, name, w, h });
+  }, []);
 
   function handleMount(editor: Editor) {
     editorRef.current = editor;
@@ -772,20 +786,34 @@ export default function App() {
         },
       }}
     >
-      <main className="tldraw__editor" aria-label="Prototype design canvas">
-        <Tldraw
-          assetUrls={canvasChromeAssetUrls}
-          components={canvasChromeComponents}
-          persistenceKey={PERSISTENCE_KEY}
-          shapeUtils={shapeUtils}
-          onMount={handleMount}
-        >
-          <AgentBridge />
-          <LockedLinkClicks />
-          <WelcomeGround />
-          <EmptyLibraryNotice />
-        </Tldraw>
-      </main>
+      <div className="canvas-shell">
+        <main className="tldraw__editor" aria-label="Prototype design canvas">
+          <Tldraw
+            assetUrls={canvasChromeAssetUrls}
+            components={canvasChromeComponents}
+            persistenceKey={PERSISTENCE_KEY}
+            shapeUtils={shapeUtils}
+            onMount={handleMount}
+          >
+            <AgentBridge />
+            <LockedLinkClicks />
+            <InspectorClicks onPick={onPick} />
+            <WelcomeGround />
+            <EmptyLibraryNotice />
+          </Tldraw>
+        </main>
+        {inspecting ? (
+          // Keyed by path: a different board is a fresh panel, with its own selection and
+          // report, rather than one that resets its state in an effect.
+          <InspectorPanel
+            key={inspecting.path}
+            path={inspecting.path}
+            name={inspecting.name}
+            size={{ w: inspecting.w, h: inspecting.h }}
+            onClose={() => setInspecting(null)}
+          />
+        ) : null}
+      </div>
     </CanvasChromeContext.Provider>
   );
 }

--- a/canvas/src/InspectorPanel.tsx
+++ b/canvas/src/InspectorPanel.tsx
@@ -24,19 +24,22 @@ import {
   formatBytes,
   initialLayersH,
   isColorValue,
+  layersBounds,
   layerKind,
   layerName,
   layerSelector,
   nextLayersH,
   nextPanelW,
   nextRailW,
+  panelBounds,
+  railBounds,
   tokenGroups,
   tokenVia,
 } from "./inspectorModel";
 
 /**
- * The docked inspector: a large preview of the clicked board on the left, a fixed rail on the
- * right with layers and properties, the board's images, and its design tokens. The board is
+ * The docked inspector: a large preview of the clicked board on the left, a resizable and
+ * collapsible rail on the right with layers and properties, the board's images, and its design tokens. The board is
  * loaded a second time into a scripted frame (inspectorAgent.ts), which is how the panel reads
  * what the canvas's own sandboxed frames cannot.
  */
@@ -56,14 +59,21 @@ function divider(
   apply: (start: number, delta: number) => void,
 ) {
   return (e: React.PointerEvent<HTMLElement>) => {
+    // Left button only, and only one pointer at a time: a second finger on the same grip would
+    // otherwise run two drags off two origins and thrash the pane between them, and a right
+    // button drag can lose its pointerup to the context menu and leave the listener bound.
+    if (e.button !== 0 || !e.isPrimary) return;
     e.preventDefault();
     const el = e.currentTarget;
     const origin = axis === "x" ? e.clientX : e.clientY;
     const start = from();
     el.setPointerCapture(e.pointerId);
-    const move = (m: PointerEvent) =>
+    const move = (m: PointerEvent) => {
+      if (m.pointerId !== e.pointerId) return;
       apply(start, (axis === "x" ? m.clientX : m.clientY) - origin);
-    const up = () => {
+    };
+    const up = (m: PointerEvent) => {
+      if (m.pointerId !== e.pointerId) return;
       el.removeEventListener("pointermove", move);
       el.removeEventListener("pointerup", up);
       el.removeEventListener("pointercancel", up);
@@ -71,6 +81,21 @@ function divider(
     el.addEventListener("pointermove", move);
     el.addEventListener("pointerup", up);
     el.addEventListener("pointercancel", up);
+  };
+}
+
+/** The same move by arrow key, so a focused grip does what its label says it does. */
+function dividerKeys(
+  axis: "x" | "y",
+  from: () => number,
+  apply: (start: number, delta: number) => void,
+) {
+  const [less, more] = axis === "x" ? ["ArrowLeft", "ArrowRight"] : ["ArrowUp", "ArrowDown"];
+  return (e: React.KeyboardEvent<HTMLElement>) => {
+    const step = e.key === less ? -1 : e.key === more ? 1 : 0;
+    if (!step) return;
+    e.preventDefault();
+    apply(from(), step * (e.shiftKey ? 64 : 8));
   };
 }
 
@@ -110,23 +135,17 @@ export function InspectorPanel({
   const [panelW, setPanelW] = useState(PANEL_W);
   const [railW, setRailW] = useState(RAIL_W);
   const [layersH, setLayersH] = useState(() => initialLayersH(window.innerHeight));
+  const [win, setWin] = useState(() => ({ w: window.innerWidth, h: window.innerHeight }));
   const [railOpen, setRailOpen] = useState(true);
   const stage = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const onResize = () => setWin({ w: window.innerWidth, h: window.innerHeight });
+    window.addEventListener("resize", onResize);
+    return () => window.removeEventListener("resize", onResize);
+  }, []);
   const [scale, setScale] = useState(1);
   const { w: boardW, h: boardH } = size;
-
-  /**
-   * App's own comment has said "Escape or × to close" since the panel landed, but nothing bound
-   * the key. It matters more now: collapsing the rail takes the × with it, so without this a
-   * collapsed panel has no way out but expanding it again.
-   */
-  useEffect(() => {
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
-    };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [onClose]);
 
   /**
    * The board is scaled to fit the stage rather than pinned at a constant, because every one of
@@ -180,10 +199,11 @@ export function InspectorPanel({
     frame.current?.contentWindow?.postMessage({ type: "sp:hover", i: hov }, "*");
   }, [hov]);
 
-  // Escape clears the selection, and with nothing selected closes the panel.
+  // Escape clears the selection, and with nothing selected closes the panel. `defaultPrevented`
+  // skips the ones a tldraw menu or a Radix layer has already dismissed itself on.
   useEffect(() => {
     const onKey = (event: KeyboardEvent) => {
-      if (event.key !== "Escape") return;
+      if (event.key !== "Escape" || event.defaultPrevented) return;
       if (sel !== null) setSel(null);
       else onClose();
     };
@@ -200,6 +220,25 @@ export function InspectorPanel({
 
   const node = data && sel !== null ? data.nodes[sel] : undefined;
   const selAsset = assetForNode(assets, sel);
+
+  // Clamped here, not only where they are set: see the note on `nextPanelW`. The raw state is
+  // what a drag started from, these are what is rendered and what the next drag reads back.
+  const panel = nextPanelW(panelW, 0, win.w);
+  const rail = nextRailW(railW, 0, panel);
+  const layers = nextLayersH(layersH, 0, win.h);
+
+  const setPanel = {
+    from: () => panel,
+    apply: (w0: number, dx: number) => setPanelW(nextPanelW(w0, dx, win.w)),
+  };
+  const setRail = {
+    from: () => rail,
+    apply: (w0: number, dx: number) => setRailW(nextRailW(w0, dx, panel)),
+  };
+  const setLayers = {
+    from: () => layers,
+    apply: (h0: number, dy: number) => setLayersH(nextLayersH(h0, dy, win.h)),
+  };
   const usedTokens = data ? data.tokens.filter((t) => t.usedBy.length).length : 0;
 
   const jumpToToken = (token: string) => {
@@ -208,16 +247,19 @@ export function InspectorPanel({
   };
 
   return (
-    <aside className="sp-panel" style={{ width: panelW }}>
+    <aside className="sp-panel" style={{ width: panel }}>
       {/* The panel is docked right, so its left edge is the one that resizes it: drag left, wider. */}
       <div
         className="sp-grip sp-grip--x"
         role="separator"
         aria-orientation="vertical"
         aria-label="Resize inspector"
-        onPointerDown={divider("x", () => panelW, (w0, dx) =>
-          setPanelW(nextPanelW(w0, dx, window.innerWidth)),
-        )}
+        aria-valuenow={panel}
+        aria-valuemin={panelBounds(win.w)[0]}
+        aria-valuemax={panelBounds(win.w)[1]}
+        tabIndex={0}
+        onPointerDown={divider("x", setPanel.from, setPanel.apply)}
+        onKeyDown={dividerKeys("x", setPanel.from, setPanel.apply)}
       />
       <div className="sp-stage" ref={stage}>
         <div
@@ -246,7 +288,8 @@ export function InspectorPanel({
         <span className="sp-zoom">{Math.round(scale * 100)}%</span>
         {/*
           Lives on the stage, not in the rail, so that collapsing the rail does not also hide the
-          only way back. Escape still closes the whole inspector either way.
+          only way back — Escape does not help here, because clicking the preview moves focus into
+          the frame and the agent forwards no keys.
         */}
         <button
           type="button"
@@ -268,13 +311,16 @@ export function InspectorPanel({
           role="separator"
           aria-orientation="vertical"
           aria-label="Resize details"
-          onPointerDown={divider("x", () => railW, (w0, dx) =>
-            setRailW(nextRailW(w0, dx, panelW)),
-          )}
+          aria-valuenow={rail}
+          aria-valuemin={railBounds(panel)[0]}
+          aria-valuemax={railBounds(panel)[1]}
+          tabIndex={0}
+          onPointerDown={divider("x", setRail.from, setRail.apply)}
+          onKeyDown={dividerKeys("x", setRail.from, setRail.apply)}
         />
       ) : null}
 
-      <div className="sp-rail" style={{ width: railW, display: railOpen ? undefined : "none" }}>
+      <div className="sp-rail" style={{ width: rail, display: railOpen ? undefined : "none" }}>
         <header className="sp-head">
           <span className="sp-head-name" title={path}>
             {name}
@@ -307,7 +353,7 @@ export function InspectorPanel({
           <section className="sp-tab">
             <Layers
               nodes={data?.nodes ?? []}
-              height={layersH}
+              height={layers}
               sel={sel}
               hov={hov}
               names={assetNameByNode}
@@ -320,9 +366,12 @@ export function InspectorPanel({
               role="separator"
               aria-orientation="horizontal"
               aria-label="Resize layers"
-              onPointerDown={divider("y", () => layersH, (h0, dy) =>
-                setLayersH(nextLayersH(h0, dy, window.innerHeight)),
-              )}
+              aria-valuenow={layers}
+              aria-valuemin={layersBounds(win.h)[0]}
+              aria-valuemax={layersBounds(win.h)[1]}
+              tabIndex={0}
+              onPointerDown={divider("y", setLayers.from, setLayers.apply)}
+              onKeyDown={dividerKeys("y", setLayers.from, setLayers.apply)}
             />
             {/* The image the selected layer draws, on its own, pinned under the row that named it. */}
             {selAsset ? (

--- a/canvas/src/InspectorPanel.tsx
+++ b/canvas/src/InspectorPanel.tsx
@@ -1,0 +1,721 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useEditor } from "tldraw";
+import type { CanvasFileShape } from "./CanvasFileShapeUtil";
+import { readCanvasAssetNames, useCanvasFileHtml } from "./canvasLibrary";
+import {
+  injectAgent,
+  type SpBinding,
+  type SpBindings,
+  type SpGroup,
+  type SpMessage,
+  type SpNode,
+  type SpReady,
+  type SpToken,
+} from "./inspectorAgent";
+import { installInspectorClicks } from "./inspectorClicks";
+import {
+  type AssetRow,
+  VISIBLE_PROPS,
+  assetRows,
+  formatBytes,
+  isColorValue,
+  layerKind,
+  layerName,
+  layerSelector,
+  tokenGroups,
+  tokenVia,
+} from "./inspectorModel";
+
+/**
+ * The docked inspector: a large preview of the clicked board on the left, a fixed rail on the
+ * right with layers and properties, the board's images, and its design tokens. The board is
+ * loaded a second time into a scripted frame (inspectorAgent.ts), which is how the panel reads
+ * what the canvas's own sandboxed frames cannot.
+ */
+
+export const INSPECTOR_WIDTH = 736;
+const RAIL_WIDTH = 280;
+
+/**
+ * A constant for now. Fit-to-height from the stage is the obvious replacement — at 85% a phone
+ * board overflows a 768px-tall window and wastes space on a tall one, and a landscape evidence
+ * board overflows either way — but how the stage should cope with a non-phone board is not
+ * decided, so the number stays until it is.
+ */
+const PREVIEW_SCALE = 0.85;
+
+type Tab = "inspect" | "assets" | "tokens";
+
+const fmt = (n: number) => String(Math.round(n * 100) / 100);
+const cx = (...parts: (string | false | null | undefined)[]) => parts.filter(Boolean).join(" ");
+
+/** Wiring component: lives inside <Tldraw> so it can reach the editor. */
+export function InspectorClicks({ onPick }: { onPick: (shape: CanvasFileShape) => void }) {
+  const editor = useEditor();
+  useEffect(() => installInspectorClicks(editor, onPick), [editor, onPick]);
+  return null;
+}
+
+export function InspectorPanel({
+  path,
+  name,
+  size,
+  onClose,
+}: {
+  path: string;
+  name: string;
+  /** The shape's own size, which is the artboard's: the frame is created at it. */
+  size: { w: number; h: number };
+  onClose: () => void;
+}) {
+  const html = useCanvasFileHtml(path);
+  const srcDoc = useMemo(() => (html ? injectAgent(html) : ""), [html]);
+  const frame = useRef<HTMLIFrameElement>(null);
+  const [data, setData] = useState<SpReady | null>(null);
+  const [sel, setSel] = useState<number | null>(null);
+  const [hov, setHov] = useState<number | null>(null);
+  const [bindings, setBindings] = useState<SpBindings | null>(null);
+  const [tab, setTab] = useState<Tab>("inspect");
+  const [focusToken, setFocusToken] = useState<string | null>(null);
+
+  const slug = /canvases\/([^/]+)\//.exec(path)?.[1] ?? "";
+  const names = useMemo(() => readCanvasAssetNames(slug), [slug]);
+
+  // `sp:ready` is fire-and-forget, so it is lost for good if it arrives before this listener is
+  // attached — and when the board is already in the library's cache, `srcDoc` is real on the very
+  // first render and the frame can run the agent before this effect does. The frame's `onLoad`
+  // asks again, and that is ordered after the frame's own script, so the handshake cannot race.
+  useEffect(() => {
+    const onMessage = (event: MessageEvent) => {
+      // The frame has no origin to check — `allow-scripts` without `allow-same-origin` puts it in
+      // an opaque origin, so `event.origin` is the string "null" for every such frame on the page.
+      // Identity is the check that means anything: this message came from this frame's window.
+      if (!frame.current || event.source !== frame.current.contentWindow) return;
+      const message = event.data as SpMessage | null;
+      if (!message || typeof message !== "object") return;
+      if (message.type === "sp:ready") setData(message);
+      else if (message.type === "sp:bindings") setBindings(message);
+      else if (message.type === "sp:pick") setSel(message.i);
+      else if (message.type === "sp:hover") setHov(message.i);
+    };
+    window.addEventListener("message", onMessage);
+    return () => window.removeEventListener("message", onMessage);
+  }, []);
+
+  useEffect(() => {
+    frame.current?.contentWindow?.postMessage({ type: "sp:sel", i: sel }, "*");
+  }, [sel]);
+
+  useEffect(() => {
+    frame.current?.contentWindow?.postMessage({ type: "sp:hover", i: hov }, "*");
+  }, [hov]);
+
+  // Escape clears the selection, and with nothing selected closes the panel.
+  useEffect(() => {
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") return;
+      if (sel !== null) setSel(null);
+      else onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [sel, onClose]);
+
+  const assets = useMemo(() => (data ? assetRows(data.assets, names) : []), [data, names]);
+  const assetNameByNode = useMemo(() => {
+    const map = new Map<number, string>();
+    for (const row of assets) for (const i of row.uses) if (!map.has(i)) map.set(i, row.name);
+    return map;
+  }, [assets]);
+
+  const node = data && sel !== null ? data.nodes[sel] : undefined;
+  const usedTokens = data ? data.tokens.filter((t) => t.usedBy.length).length : 0;
+
+  const jumpToToken = (token: string) => {
+    setTab("tokens");
+    setFocusToken(token);
+  };
+
+  return (
+    <aside className="sp-panel" style={{ width: INSPECTOR_WIDTH }}>
+      <div className="sp-stage">
+        <div
+          className="sp-board"
+          style={{ width: size.w, height: size.h, transform: `scale(${PREVIEW_SCALE})` }}
+        >
+          {/*
+            Mounted only once the HTML is here, and keyed by path so a different board is a
+            different element. A board arrives asynchronously, so rendering the frame eagerly
+            gives it `srcdoc=""` and then mutates the attribute a tick later — and Chrome drops
+            that second navigation while the first is still pending, leaving a frame that is
+            permanently blank. Creating the element with its final srcdoc avoids the mutation.
+          */}
+          {srcDoc ? (
+            <iframe
+              key={path}
+              ref={frame}
+              title={name}
+              srcDoc={srcDoc}
+              sandbox="allow-scripts"
+              onLoad={() =>
+                frame.current?.contentWindow?.postMessage({ type: "sp:hello" }, "*")
+              }
+              style={{ width: size.w, height: size.h, border: 0, display: "block" }}
+            />
+          ) : null}
+        </div>
+        <span className="sp-zoom">{Math.round(PREVIEW_SCALE * 100)}%</span>
+      </div>
+
+      <div className="sp-rail" style={{ width: RAIL_WIDTH }}>
+        <header className="sp-head">
+          <span className="sp-head-name" title={path}>
+            {name}
+          </span>
+          <span className="sp-head-dim">
+            {data ? `${fmt(data.size.w)} × ${fmt(data.size.h)}` : "reading board…"}
+          </span>
+          <button type="button" className="sp-head-x" onClick={onClose} aria-label="Close inspector">
+            <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.2">
+              <path d="M2.5 2.5l7 7M9.5 2.5l-7 7" />
+            </svg>
+          </button>
+        </header>
+
+        <nav className="sp-tabs" aria-label="Inspector sections">
+          {(["inspect", "assets", "tokens"] as Tab[]).map((t) => (
+            <button
+              key={t}
+              type="button"
+              className={cx(tab === t && "on")}
+              aria-pressed={tab === t}
+              onClick={() => setTab(t)}
+            >
+              {t === "inspect" ? "Inspect" : t === "assets" ? "Assets" : "Tokens"}
+            </button>
+          ))}
+        </nav>
+
+        {tab === "inspect" ? (
+          <section className="sp-tab">
+            <Layers
+              nodes={data?.nodes ?? []}
+              sel={sel}
+              hov={hov}
+              names={assetNameByNode}
+              onSelect={setSel}
+              onHover={setHov}
+            />
+            <div className="sp-props">
+              {node ? (
+                <Properties
+                  node={node}
+                  bindings={bindings && bindings.i === node.i ? bindings : null}
+                  tokens={data?.tokens ?? []}
+                  onToken={jumpToToken}
+                  onSelect={setSel}
+                />
+              ) : data ? (
+                <Summary
+                  name={name}
+                  path={path}
+                  data={data}
+                  assets={assets.length}
+                  usedTokens={usedTokens}
+                />
+              ) : (
+                <div className="sp-empty">reading board…</div>
+              )}
+            </div>
+          </section>
+        ) : tab === "assets" ? (
+          <section className="sp-tab">
+            <Assets rows={assets} sel={sel} hov={hov} onSelect={setSel} onHover={setHov} />
+          </section>
+        ) : (
+          <section className="sp-tab">
+            <Tokens
+              tokens={data?.tokens ?? []}
+              groups={data?.groups ?? []}
+              used={usedTokens}
+              sel={sel}
+              focus={focusToken}
+              onSelect={setSel}
+            />
+          </section>
+        )}
+      </div>
+    </aside>
+  );
+}
+
+function LayerIcon({ kind }: { kind: ReturnType<typeof layerKind> }) {
+  if (kind === "text")
+    return (
+      <svg width="12" height="12" viewBox="0 0 12 12" fill="currentColor">
+        <path d="M2 2h8v2H7v6H5V4H2z" />
+      </svg>
+    );
+  if (kind === "image")
+    return (
+      <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor">
+        <rect x="1.5" y="1.5" width="9" height="9" rx="1" />
+        <path d="M2 9l2.5-3 2 2 1.5-1.5L10 9" />
+      </svg>
+    );
+  if (kind === "frame")
+    return (
+      <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor">
+        <path d="M3.5 1v10M8.5 1v10M1 3.5h10M1 8.5h10" />
+      </svg>
+    );
+  return (
+    <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor">
+      <rect x="1.5" y="1.5" width="9" height="9" rx="1" />
+    </svg>
+  );
+}
+
+/**
+ * A flat list in document order, indented by depth. It does not scale to the biggest boards
+ * (352 elements on `luma-ios/11-home-nearby`); a collapsing tree or a text-and-image filter
+ * is the open question, not taken up here.
+ */
+function Layers({
+  nodes,
+  sel,
+  hov,
+  names,
+  onSelect,
+  onHover,
+}: {
+  nodes: SpNode[];
+  sel: number | null;
+  hov: number | null;
+  names: Map<number, string>;
+  onSelect: (i: number) => void;
+  onHover: (i: number | null) => void;
+}) {
+  const list = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    if (sel === null) return;
+    list.current?.querySelector(`[data-i="${sel}"]`)?.scrollIntoView({ block: "nearest" });
+  }, [sel]);
+  return (
+    <div className="sp-layers" ref={list} onMouseLeave={() => onHover(null)}>
+      <div className="sp-sh">
+        <span className="sp-sh-t">Layers</span>
+        <span className="sp-sh-s">{Math.max(0, nodes.length - 1)}</span>
+      </div>
+      {nodes.map((n) => (
+        <button
+          key={n.i}
+          type="button"
+          data-i={n.i}
+          className={cx("sp-layer", n.i === sel && "on", n.i === hov && n.i !== sel && "hov")}
+          style={{ paddingLeft: 12 + n.depth * 12 }}
+          title={layerSelector(n)}
+          onClick={() => onSelect(n.i)}
+          onMouseEnter={() => onHover(n.i)}
+        >
+          <LayerIcon kind={layerKind(n)} />
+          <span className="sp-layer-n">{layerName(n, names.get(n.i))}</span>
+          {n.i === 0 && n.box ? (
+            <span className="sp-layer-d">
+              {fmt(n.box.w)} × {fmt(n.box.h)}
+            </span>
+          ) : null}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function Summary({
+  name,
+  path,
+  data,
+  assets,
+  usedTokens,
+}: {
+  name: string;
+  path: string;
+  data: SpReady;
+  assets: number;
+  usedTokens: number;
+}) {
+  const file = path.slice(path.lastIndexOf("/") + 1);
+  const root = data.nodes[0];
+  return (
+    <div className="sp-sec">
+      <div className="sp-sh">
+        <span className="sp-sh-t">{name}</span>
+        <span className="sp-sh-s">{file}</span>
+      </div>
+      <Row k="Frame" v={root?.box ? `${fmt(root.box.w)} × ${fmt(root.box.h)}` : "–"} />
+      <Row k="Layers" v={String(Math.max(0, data.nodes.length - 1))} />
+      <Row k="Images" v={String(assets)} />
+      <Row k="Tokens" v={`${usedTokens} used of ${data.tokens.length}`} />
+      <div className="sp-hint">Click a layer, or an element in the preview.</div>
+    </div>
+  );
+}
+
+function Row({ k, v }: { k: string; v: string }) {
+  return (
+    <div className="sp-row">
+      <span className="sp-k">{k}</span>
+      <span className="sp-v">{v}</span>
+    </div>
+  );
+}
+
+function TokenPill({
+  name,
+  value,
+  kind,
+  lost,
+  onClick,
+}: {
+  name: string;
+  value: string;
+  kind: SpToken["kind"] | undefined;
+  lost: boolean;
+  onClick: () => void;
+}) {
+  const swatch = isColorValue(value, kind);
+  return (
+    <button
+      type="button"
+      className={cx("sp-pill", !swatch && "plain", lost && "lost")}
+      title={value}
+      onClick={onClick}
+    >
+      {swatch ? <span className="sp-sw" style={{ background: value }} /> : null}
+      {name}
+    </button>
+  );
+}
+
+/** The declaration with its tokens substituted, which is what the author would read back. */
+function resolvedText(b: SpBinding) {
+  return b.value.replace(/var\(\s*(--[\w-]+)\s*(?:,[^()]*)?\)/g, (m, n: string) => b.resolved[n] ?? m);
+}
+
+function stateText(b: SpBinding) {
+  if (b.state === "overridden") return `overridden by ${b.by}`;
+  if (b.state === "partial") {
+    const lost = b.longhands.filter((l) => !l.ok).map((l) => l.p);
+    return `partial — ${lost.join(", ")} from ${b.by}`;
+  }
+  if (b.state === "invalid") return "invalid declaration";
+  return "unconfirmed — the probe could not reproduce this value";
+}
+
+/** The sources a selected element's declarations came from, in cascade order. */
+function styleGroups(bindings: SpBinding[]) {
+  const groups: { label: string; rows: SpBinding[] }[] = [];
+  const index = new Map<string, (typeof groups)[number]>();
+  for (const b of bindings) {
+    // A declaration without a token earns a row only when it is visible and actually won, and
+    // not when it is the universal reset (`* { padding: 0 }`), which every element would repeat.
+    if (!b.tokens.length && (b.src === "*" || !VISIBLE_PROPS.has(b.prop) || b.state !== "applied"))
+      continue;
+    const from = b.inheritedFrom;
+    const label =
+      (b.src || "inline") +
+      b.pseudo +
+      (from ? ` · inherited from ${from.tag}${from.cls ? `.${from.cls.split(/\s+/)[0]}` : ""}` : "");
+    let group = index.get(label);
+    if (!group) {
+      group = { label, rows: [] };
+      index.set(label, group);
+      groups.push(group);
+    }
+    group.rows.push(b);
+  }
+  return groups;
+}
+
+function Properties({
+  node,
+  bindings,
+  tokens,
+  onToken,
+  onSelect,
+}: {
+  node: SpNode;
+  bindings: SpBindings | null;
+  tokens: SpToken[];
+  onToken: (name: string) => void;
+  onSelect: (i: number) => void;
+}) {
+  const kinds = useMemo(() => new Map(tokens.map((t) => [t.name, t.kind])), [tokens]);
+  const groups = bindings ? styleGroups(bindings.bindings) : [];
+  return (
+    <>
+      <div className="sp-sec">
+        <div className="sp-sh">
+          <span className="sp-sh-t">{layerName(node)}</span>
+          <span className="sp-sh-s">{layerSelector(node)}</span>
+        </div>
+        <div className="sp-fields">
+          <Field label="X" value={node.box ? fmt(node.box.x) : "–"} />
+          <Field label="Y" value={node.box ? fmt(node.box.y) : "–"} />
+          <Field label="W" value={node.box ? fmt(node.box.w) : "–"} />
+          <Field label="H" value={node.box ? fmt(node.box.h) : "–"} />
+        </div>
+      </div>
+
+      <div className="sp-sec">
+        <div className="sp-sh">
+          <span className="sp-sh-t">Styles</span>
+          {bindings ? (
+            <span className="sp-sh-s">
+              {bindings.bindings.filter((b) => b.tokens.length).length} tokens
+            </span>
+          ) : null}
+        </div>
+        {!bindings ? (
+          <div className="sp-empty">resolving…</div>
+        ) : !groups.length ? (
+          <div className="sp-empty">No declarations reach this element.</div>
+        ) : (
+          groups.map((g) => (
+            <div key={g.label} className="sp-src-group">
+              <div className="sp-src">
+                <span className="sp-src-l" title={g.label}>
+                  {g.label}
+                </span>
+                {g.rows[0].inheritedFrom?.i != null ? (
+                  <button
+                    type="button"
+                    className="sp-link"
+                    onClick={() => onSelect(Number(g.rows[0].inheritedFrom!.i))}
+                  >
+                    select
+                  </button>
+                ) : null}
+              </div>
+              {g.rows.map((b, n) => (
+                <div key={`${b.prop}-${n}`} className={cx("sp-decl", b.state)}>
+                  <div className="sp-row">
+                    <span className="sp-k">{b.prop}</span>
+                    <span className="sp-vv">
+                      {b.tokens.length ? (
+                        b.tokens.map((t) => (
+                          <TokenPill
+                            key={t}
+                            name={t}
+                            value={b.resolved[t] ?? ""}
+                            kind={kinds.get(t)}
+                            lost={b.state === "overridden"}
+                            onClick={() => onToken(t)}
+                          />
+                        ))
+                      ) : (
+                        <span className="sp-v plain" title={b.value}>
+                          {b.value}
+                        </span>
+                      )}
+                    </span>
+                  </div>
+                  {b.tokens.length ? (
+                    <div className="sp-sub" title={resolvedText(b)}>
+                      {resolvedText(b)}
+                    </div>
+                  ) : null}
+                  {b.prop === "font" && b.state !== "overridden" && b.longhands.length > 1 ? (
+                    <div className="sp-sub sp-longs">
+                      {b.longhands
+                        .filter((l) => /^font-(weight|size|family)$|^line-height$/.test(l.p))
+                        .map((l) => `${l.p.replace(/^font-/, "")} ${l.v}`)
+                        .join(" · ")}
+                    </div>
+                  ) : null}
+                  {b.state !== "applied" ? (
+                    <div className={cx("sp-state", b.state)} title={b.by ?? undefined}>
+                      {stateText(b)}
+                    </div>
+                  ) : null}
+                </div>
+              ))}
+            </div>
+          ))
+        )}
+      </div>
+
+      {bindings ? (
+        <div className="sp-sec">
+          <div className="sp-sh">
+            <span className="sp-sh-t">Computed</span>
+          </div>
+          {Object.entries(bindings.computed).map(([k, v]) => (
+            <div key={k} className="sp-row">
+              <span className="sp-k">{k}</span>
+              <span className="sp-v" title={v}>
+                {isColorValue(v) ? <span className="sp-sw" style={{ background: v }} /> : null}
+                {v}
+              </span>
+            </div>
+          ))}
+        </div>
+      ) : null}
+    </>
+  );
+}
+
+function Field({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="sp-field">
+      <span>{label}</span>
+      <b>{value}</b>
+    </div>
+  );
+}
+
+function Assets({
+  rows,
+  sel,
+  hov,
+  onSelect,
+  onHover,
+}: {
+  rows: AssetRow[];
+  sel: number | null;
+  hov: number | null;
+  onSelect: (i: number) => void;
+  onHover: (i: number | null) => void;
+}) {
+  if (!rows.length) return <div className="sp-empty">No images on this board.</div>;
+  return (
+    <div className="sp-scroll" onMouseLeave={() => onHover(null)}>
+      <div className="sp-sh sp-sh--pad">
+        <span className="sp-sh-t">Assets</span>
+        <span className="sp-sh-s">{rows.length}</span>
+      </div>
+      {rows.map((a) => {
+        const on = sel !== null && a.uses.includes(sel);
+        const hovered = !on && hov !== null && a.uses.includes(hov);
+        return (
+          <button
+            key={a.key}
+            type="button"
+            className={cx("sp-asset", on && "on", hovered && "hov")}
+            title={`${a.name}\n${a.mime} · ${formatBytes(a.bytes)} · ${a.via === "css" ? "background" : "img"}`}
+            onClick={() => onSelect(a.uses[0])}
+            onMouseEnter={() => onHover(a.uses[0])}
+          >
+            <span className="sp-th">
+              <img src={a.uri} alt="" />
+            </span>
+            <span className="sp-asset-n">
+              {a.source === "file" ? a.name : <i>{a.name}</i>}
+              {a.source === "alt" ? <small>alt</small> : null}
+            </span>
+            <span className="sp-asset-d">
+              {a.w && a.h ? `${a.w} × ${a.h}` : formatBytes(a.bytes)}
+              {a.uses.length > 1 ? ` · ×${a.uses.length}` : ""}
+            </span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function Tokens({
+  tokens,
+  groups,
+  used,
+  sel,
+  focus,
+  onSelect,
+}: {
+  tokens: SpToken[];
+  groups: SpGroup[];
+  used: number;
+  sel: number | null;
+  focus: string | null;
+  onSelect: (i: number) => void;
+}) {
+  const list = useRef<HTMLDivElement>(null);
+  const views = useMemo(() => tokenGroups(tokens, groups), [tokens, groups]);
+  useEffect(() => {
+    if (!focus) return;
+    list.current
+      ?.querySelector(`[data-token="${CSS.escape(focus)}"]`)
+      ?.scrollIntoView({ block: "center" });
+  }, [focus]);
+  if (!tokens.length) return <div className="sp-empty">No tokens on this board.</div>;
+  return (
+    <div className="sp-scroll" ref={list}>
+      <div className="sp-sh sp-sh--pad">
+        <span className="sp-sh-t">Tokens</span>
+        <span className="sp-sh-s">
+          {used} used of {tokens.length}
+        </span>
+      </div>
+      {views.map((g, gi) => (
+        <div key={`${g.name}-${gi}`} className="sp-token-group">
+          {g.name ? <div className="sp-sh sp-sh--group">{g.name}</div> : null}
+          {g.tokens.map((t) => {
+            const via = tokenVia(t, tokens);
+            const swatch = isColorValue(t.value, t.kind);
+            const unused = !t.usedBy.length && !via.length;
+            const here = sel !== null && t.usedBy.includes(sel);
+            // Clicking the count walks the elements that use the token, one per click.
+            const next = () => {
+              if (!t.usedBy.length) return;
+              const at = sel === null ? -1 : t.usedBy.indexOf(sel);
+              onSelect(t.usedBy[(at + 1) % t.usedBy.length]);
+            };
+            return (
+              <div
+                key={t.name}
+                data-token={t.name}
+                className={cx("sp-token", unused && "unused", here && "on", t.name === focus && "focus")}
+              >
+                <div className="sp-token-row">
+                  {swatch ? (
+                    <span className="sp-sw" style={{ background: t.canon || t.value }} />
+                  ) : (
+                    <span className="sp-sw sp-sw--none" />
+                  )}
+                  <span className="sp-token-n" title={t.decl || t.name}>
+                    {t.name}
+                  </span>
+                  <span className="sp-token-v" title={t.value}>
+                    {t.value || "—"}
+                  </span>
+                  <button
+                    type="button"
+                    className="sp-token-u"
+                    title={
+                      t.usedBy.length
+                        ? `used by ${t.usedBy.length} element${t.usedBy.length === 1 ? "" : "s"} — click to select`
+                        : via.length
+                          ? `used only through ${via.join(", ")}`
+                          : "unused on this board"
+                    }
+                    disabled={!t.usedBy.length}
+                    onClick={next}
+                  >
+                    {t.usedBy.length ? `×${t.usedBy.length}` : via.length ? "via" : "–"}
+                  </button>
+                </div>
+                {t.note ? <div className="sp-token-note">{t.note}</div> : null}
+                {via.length ? <div className="sp-token-note">via {via.join(", ")}</div> : null}
+                {t.overrides.map((o) => (
+                  <div key={o.sel} className="sp-token-note">
+                    <code>{o.sel}</code> {o.decl}
+                  </div>
+                ))}
+              </div>
+            );
+          })}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/canvas/src/InspectorPanel.tsx
+++ b/canvas/src/InspectorPanel.tsx
@@ -15,13 +15,21 @@ import {
 import { installInspectorClicks } from "./inspectorClicks";
 import {
   type AssetRow,
+  PANEL_W,
+  RAIL_W,
   VISIBLE_PROPS,
+  assetForNode,
   assetRows,
+  fitScale,
   formatBytes,
+  initialLayersH,
   isColorValue,
   layerKind,
   layerName,
   layerSelector,
+  nextLayersH,
+  nextPanelW,
+  nextRailW,
   tokenGroups,
   tokenVia,
 } from "./inspectorModel";
@@ -33,16 +41,38 @@ import {
  * what the canvas's own sandboxed frames cannot.
  */
 
-export const INSPECTOR_WIDTH = 736;
-const RAIL_WIDTH = 280;
-
 /**
- * A constant for now. Fit-to-height from the stage is the obvious replacement — at 85% a phone
- * board overflows a 768px-tall window and wastes space on a tall one, and a landscape evidence
- * board overflows either way — but how the stage should cope with a non-phone board is not
- * decided, so the number stays until it is.
+ * A divider drag. `from` is read at pointerdown, so the handler works off the value the drag
+ * started at rather than accumulating rounding error, and `apply` gets that value with the
+ * pointer delta along one axis.
+ *
+ * Pointer capture is the whole trick: the preview is an iframe, and without capture the first
+ * move over it delivers the event to the frame's document instead, which ends the drag the
+ * moment the pointer crosses into the board.
  */
-const PREVIEW_SCALE = 0.85;
+function divider(
+  axis: "x" | "y",
+  from: () => number,
+  apply: (start: number, delta: number) => void,
+) {
+  return (e: React.PointerEvent<HTMLElement>) => {
+    e.preventDefault();
+    const el = e.currentTarget;
+    const origin = axis === "x" ? e.clientX : e.clientY;
+    const start = from();
+    el.setPointerCapture(e.pointerId);
+    const move = (m: PointerEvent) =>
+      apply(start, (axis === "x" ? m.clientX : m.clientY) - origin);
+    const up = () => {
+      el.removeEventListener("pointermove", move);
+      el.removeEventListener("pointerup", up);
+      el.removeEventListener("pointercancel", up);
+    };
+    el.addEventListener("pointermove", move);
+    el.addEventListener("pointerup", up);
+    el.addEventListener("pointercancel", up);
+  };
+}
 
 type Tab = "inspect" | "assets" | "tokens";
 
@@ -77,6 +107,46 @@ export function InspectorPanel({
   const [bindings, setBindings] = useState<SpBindings | null>(null);
   const [tab, setTab] = useState<Tab>("inspect");
   const [focusToken, setFocusToken] = useState<string | null>(null);
+  const [panelW, setPanelW] = useState(PANEL_W);
+  const [railW, setRailW] = useState(RAIL_W);
+  const [layersH, setLayersH] = useState(() => initialLayersH(window.innerHeight));
+  const [railOpen, setRailOpen] = useState(true);
+  const stage = useRef<HTMLDivElement>(null);
+  const [scale, setScale] = useState(1);
+  const { w: boardW, h: boardH } = size;
+
+  /**
+   * App's own comment has said "Escape or × to close" since the panel landed, but nothing bound
+   * the key. It matters more now: collapsing the rail takes the × with it, so without this a
+   * collapsed panel has no way out but expanding it again.
+   */
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  /**
+   * The board is scaled to fit the stage rather than pinned at a constant, because every one of
+   * the three controls below changes how much stage there is. Contain, never past 1:1 — a phone
+   * board blown up past its own pixels is a blurrier board, not a bigger one — and a landscape
+   * evidence board fits by width and leaves the height alone.
+   */
+  useEffect(() => {
+    const el = stage.current;
+    if (!el) return;
+    const fit = () => {
+      setScale(fitScale({ w: el.clientWidth, h: el.clientHeight }, { w: boardW, h: boardH }));
+    };
+    fit();
+    const ro = new ResizeObserver(fit);
+    ro.observe(el);
+    return () => ro.disconnect();
+    // Not `size`: App builds that object fresh every render, so depending on it would tear the
+    // observer down and rebuild it on each one.
+  }, [boardW, boardH]);
 
   const slug = /canvases\/([^/]+)\//.exec(path)?.[1] ?? "";
   const names = useMemo(() => readCanvasAssetNames(slug), [slug]);
@@ -129,6 +199,7 @@ export function InspectorPanel({
   }, [assets]);
 
   const node = data && sel !== null ? data.nodes[sel] : undefined;
+  const selAsset = assetForNode(assets, sel);
   const usedTokens = data ? data.tokens.filter((t) => t.usedBy.length).length : 0;
 
   const jumpToToken = (token: string) => {
@@ -137,11 +208,21 @@ export function InspectorPanel({
   };
 
   return (
-    <aside className="sp-panel" style={{ width: INSPECTOR_WIDTH }}>
-      <div className="sp-stage">
+    <aside className="sp-panel" style={{ width: panelW }}>
+      {/* The panel is docked right, so its left edge is the one that resizes it: drag left, wider. */}
+      <div
+        className="sp-grip sp-grip--x"
+        role="separator"
+        aria-orientation="vertical"
+        aria-label="Resize inspector"
+        onPointerDown={divider("x", () => panelW, (w0, dx) =>
+          setPanelW(nextPanelW(w0, dx, window.innerWidth)),
+        )}
+      />
+      <div className="sp-stage" ref={stage}>
         <div
           className="sp-board"
-          style={{ width: size.w, height: size.h, transform: `scale(${PREVIEW_SCALE})` }}
+          style={{ width: size.w, height: size.h, transform: `scale(${scale})` }}
         >
           {/*
             Mounted only once the HTML is here, and keyed by path so a different board is a
@@ -157,17 +238,43 @@ export function InspectorPanel({
               title={name}
               srcDoc={srcDoc}
               sandbox="allow-scripts"
-              onLoad={() =>
-                frame.current?.contentWindow?.postMessage({ type: "sp:hello" }, "*")
-              }
+              onLoad={() => frame.current?.contentWindow?.postMessage({ type: "sp:hello" }, "*")}
               style={{ width: size.w, height: size.h, border: 0, display: "block" }}
             />
           ) : null}
         </div>
-        <span className="sp-zoom">{Math.round(PREVIEW_SCALE * 100)}%</span>
+        <span className="sp-zoom">{Math.round(scale * 100)}%</span>
+        {/*
+          Lives on the stage, not in the rail, so that collapsing the rail does not also hide the
+          only way back. Escape still closes the whole inspector either way.
+        */}
+        <button
+          type="button"
+          className="sp-collapse"
+          aria-expanded={railOpen}
+          title={railOpen ? "Hide details" : "Show details"}
+          aria-label={railOpen ? "Hide details" : "Show details"}
+          onClick={() => setRailOpen((v) => !v)}
+        >
+          <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.2">
+            <path d={railOpen ? "M7.5 2l4 4-4 4M4.5 2l-4 4 4 4" : "M2 2l4 4-4 4M7.5 2l4 4-4 4"} />
+          </svg>
+        </button>
       </div>
 
-      <div className="sp-rail" style={{ width: RAIL_WIDTH }}>
+      {railOpen ? (
+        <div
+          className="sp-grip sp-grip--x"
+          role="separator"
+          aria-orientation="vertical"
+          aria-label="Resize details"
+          onPointerDown={divider("x", () => railW, (w0, dx) =>
+            setRailW(nextRailW(w0, dx, panelW)),
+          )}
+        />
+      ) : null}
+
+      <div className="sp-rail" style={{ width: railW, display: railOpen ? undefined : "none" }}>
         <header className="sp-head">
           <span className="sp-head-name" title={path}>
             {name}
@@ -200,12 +307,37 @@ export function InspectorPanel({
           <section className="sp-tab">
             <Layers
               nodes={data?.nodes ?? []}
+              height={layersH}
               sel={sel}
               hov={hov}
               names={assetNameByNode}
               onSelect={setSel}
               onHover={setHov}
             />
+            {/* The list was a fixed 240px, which is why a 24-layer board could not be read. */}
+            <div
+              className="sp-grip sp-grip--y"
+              role="separator"
+              aria-orientation="horizontal"
+              aria-label="Resize layers"
+              onPointerDown={divider("y", () => layersH, (h0, dy) =>
+                setLayersH(nextLayersH(h0, dy, window.innerHeight)),
+              )}
+            />
+            {/* The image the selected layer draws, on its own, pinned under the row that named it. */}
+            {selAsset ? (
+              <figure className="sp-asset-view">
+                <img src={selAsset.uri} alt={selAsset.name} />
+                <figcaption>
+                  <span className="sp-asset-view-n" title={selAsset.name}>
+                    {selAsset.name}
+                  </span>
+                  <span className="sp-asset-view-d">
+                    {selAsset.w} × {selAsset.h} · {formatBytes(selAsset.bytes)}
+                  </span>
+                </figcaption>
+              </figure>
+            ) : null}
             <div className="sp-props">
               {node ? (
                 <Properties
@@ -283,6 +415,7 @@ function LayerIcon({ kind }: { kind: ReturnType<typeof layerKind> }) {
  */
 function Layers({
   nodes,
+  height,
   sel,
   hov,
   names,
@@ -290,6 +423,7 @@ function Layers({
   onHover,
 }: {
   nodes: SpNode[];
+  height: number;
   sel: number | null;
   hov: number | null;
   names: Map<number, string>;
@@ -302,7 +436,7 @@ function Layers({
     list.current?.querySelector(`[data-i="${sel}"]`)?.scrollIntoView({ block: "nearest" });
   }, [sel]);
   return (
-    <div className="sp-layers" ref={list} onMouseLeave={() => onHover(null)}>
+    <div className="sp-layers" style={{ height }} ref={list} onMouseLeave={() => onHover(null)}>
       <div className="sp-sh">
         <span className="sp-sh-t">Layers</span>
         <span className="sp-sh-s">{Math.max(0, nodes.length - 1)}</span>

--- a/canvas/src/canvasLibrary.ts
+++ b/canvas/src/canvasLibrary.ts
@@ -15,7 +15,7 @@ import { WELCOME_PAGE_SLUG } from "./canvasUrl";
 // opening the welcome page pulls a dozen covers rather than every board (the full set is 25 MB of
 // HTML, which a phone should not download to look at one page). Vite still reloads the page when a
 // mockup is saved. `rawLayouts` and `rawIcons` stay eager because they are read during render.
-import { fileLoaders, rawLayouts, rawIcons } from "virtual:canvases";
+import { fileLoaders, rawLayouts, rawIcons, rawAssetNames } from "virtual:canvases";
 
 export interface CanvasLibraryFile {
   path: string;
@@ -176,6 +176,15 @@ export function readCanvasLayout(
     if (LAYOUT_PATTERN.exec(path)?.[1] === pageSlug) return config;
   }
   return undefined;
+}
+
+/**
+ * This folder's inlined images by payload key, if it committed the files they came from: the
+ * inspector's Assets tab joins a board's data: URIs against it to put a file name next to each
+ * one. Undefined for a folder with no `assets/`, `assets-dark/` or `assets.json`.
+ */
+export function readCanvasAssetNames(pageSlug: string) {
+  return rawAssetNames[pageSlug];
 }
 
 const ICON_PATTERN = /canvases\/([^/]+)\/icon\.png$/;

--- a/canvas/src/index.css
+++ b/canvas/src/index.css
@@ -239,6 +239,54 @@ button {
   background: #f5f5f5;
 }
 
+/* The selected layer's own image, between the layers list and the properties under it.
+   Shrinkable, not fixed: a layers list dragged tall would otherwise clip it against the rail. */
+.sp-asset-view {
+  flex: 0 1 168px;
+  min-height: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  /* No top border: `.sp-layers` already draws one above it. */
+  border-bottom: 1px solid var(--sp-line);
+}
+
+.sp-asset-view img {
+  flex: 1;
+  min-height: 0;
+  object-fit: contain;
+  padding: 8px 12px 4px;
+  /* Checkerboard: most of these are cut-outs with alpha, and alpha over a flat ground is a
+     shape you cannot tell from a white one. */
+  background-image:
+    linear-gradient(45deg, #eeeeee 25%, transparent 25%, transparent 75%, #eeeeee 75%),
+    linear-gradient(45deg, #eeeeee 25%, transparent 25%, transparent 75%, #eeeeee 75%);
+  background-size: 12px 12px;
+  background-position: 0 0, 6px 6px;
+  background-origin: content-box;
+  background-clip: content-box;
+}
+
+/* Two lines in the rail: 280px will not hold a path and its dimensions side by side. */
+.sp-asset-view figcaption {
+  flex: none;
+  display: flex;
+  flex-direction: column;
+  padding: 0 12px 8px;
+}
+
+.sp-asset-view-n {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.sp-asset-view-d {
+  color: var(--sp-text-2);
+  font-family: var(--sp-mono);
+}
+
 .sp-board {
   flex: 0 0 auto;
   transform-origin: center;
@@ -250,6 +298,68 @@ button {
   bottom: 10px;
   color: var(--sp-text-2);
   pointer-events: none;
+}
+
+.sp-collapse {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  width: 24px;
+  height: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 4px;
+  color: var(--sp-text-2);
+  background: #ffffff;
+  box-shadow: 0 0 0 1px var(--sp-line);
+}
+
+.sp-collapse:hover {
+  color: var(--sp-text);
+}
+
+/* Dividers. The hit area is wider than the line, which is the whole reason for ::after. */
+.sp-grip {
+  position: relative;
+  flex: none;
+  z-index: 1;
+  background: transparent;
+  touch-action: none;
+}
+
+.sp-grip::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: transparent;
+}
+
+.sp-grip:hover::after,
+.sp-grip:active::after {
+  background: var(--sp-accent);
+}
+
+.sp-grip--x {
+  width: 5px;
+  margin: 0 -2px;
+  cursor: col-resize;
+}
+
+.sp-grip--x::after {
+  left: 2px;
+  right: 2px;
+}
+
+.sp-grip--y {
+  height: 5px;
+  margin: -2px 0;
+  cursor: row-resize;
+}
+
+.sp-grip--y::after {
+  top: 2px;
+  bottom: 2px;
 }
 
 /* Rail */
@@ -391,7 +501,6 @@ button {
 /* Layers */
 .sp-layers {
   flex: none;
-  height: 240px;
   overflow: auto;
   border-bottom: 1px solid var(--sp-line);
 }

--- a/canvas/src/index.css
+++ b/canvas/src/index.css
@@ -247,6 +247,7 @@ button {
   margin: 0;
   display: flex;
   flex-direction: column;
+  overflow: hidden;
   /* No top border: `.sp-layers` already draws one above it. */
   border-bottom: 1px solid var(--sp-line);
 }
@@ -336,8 +337,13 @@ button {
 }
 
 .sp-grip:hover::after,
-.sp-grip:active::after {
+.sp-grip:active::after,
+.sp-grip:focus-visible::after {
   background: var(--sp-accent);
+}
+
+.sp-grip:focus-visible {
+  outline: none;
 }
 
 .sp-grip--x {
@@ -547,7 +553,10 @@ button {
 /* Properties */
 .sp-props {
   flex: 1;
-  min-height: 0;
+  /* Not 0: flex splits a shortfall by basis, and against the asset figure's 168 the properties'
+     own basis of 0 takes none of it — they would be squeezed to nothing before the image gave up
+     a pixel. A floor is what stops that. */
+  min-height: 64px;
   overflow: auto;
 }
 

--- a/canvas/src/index.css
+++ b/canvas/src/index.css
@@ -175,3 +175,567 @@ button {
   overflow-x: auto;
   max-width: 100%;
 }
+
+/* ---- The inspector panel (InspectorPanel.tsx) ------------------------------------------- */
+
+/*
+ * The panel is a flex sibling of the editor rather than an overlay, so tldraw's own viewport
+ * shrinks with it: its ResizeObserver re-measures, and zoom-to-fit, the toolbar and every
+ * screen-space calculation keep working against the space actually left over. Whether it
+ * should float instead is still open; the squeeze is what was measured.
+ */
+.canvas-shell {
+  display: flex;
+  width: 100%;
+  height: 100%;
+}
+
+.canvas-shell > .tldraw__editor {
+  flex: 1 1 auto;
+  width: auto;
+  min-width: 0;
+}
+
+.sp-panel {
+  --sp-line: #e6e6e6;
+  --sp-text: #1e1e1e;
+  --sp-text-2: #7a7a7a;
+  --sp-field: #f5f5f5;
+  --sp-hover: #f5f5f5;
+  --sp-sel: #e5f4ff;
+  --sp-accent: #0d99ff;
+  --sp-mono: ui-monospace, "SF Mono", Menlo, monospace;
+  display: flex;
+  flex: 0 0 auto;
+  height: 100%;
+  border-left: 1px solid var(--sp-line);
+  background: #ffffff;
+  color: var(--sp-text);
+  font: 400 11px/16px Inter, ui-sans-serif, system-ui, -apple-system, sans-serif;
+  font-variant-numeric: tabular-nums;
+  -webkit-font-smoothing: antialiased;
+  user-select: none;
+}
+
+.sp-panel button {
+  font: inherit;
+  color: inherit;
+  background: none;
+  border: 0;
+  padding: 0;
+  cursor: default;
+  text-align: left;
+}
+
+/* Preview */
+.sp-stage {
+  position: relative;
+  flex: 1 1 auto;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  background: #f5f5f5;
+}
+
+.sp-board {
+  flex: 0 0 auto;
+  transform-origin: center;
+}
+
+.sp-zoom {
+  position: absolute;
+  right: 12px;
+  bottom: 10px;
+  color: var(--sp-text-2);
+  pointer-events: none;
+}
+
+/* Rail */
+.sp-rail {
+  flex: 0 0 auto;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  border-left: 1px solid var(--sp-line);
+  overflow: hidden;
+}
+
+.sp-head {
+  flex: none;
+  height: 40px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 0 8px 0 12px;
+  border-bottom: 1px solid var(--sp-line);
+}
+
+.sp-head-name {
+  font-weight: 600;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.sp-head-dim {
+  margin-left: auto;
+  color: var(--sp-text-2);
+  white-space: nowrap;
+}
+
+.sp-head-x {
+  width: 24px;
+  height: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 5px;
+  color: var(--sp-text-2);
+}
+
+.sp-head-x:hover {
+  background: var(--sp-hover);
+  color: var(--sp-text);
+}
+
+.sp-tabs {
+  flex: none;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  padding: 0 4px;
+  border-bottom: 1px solid var(--sp-line);
+}
+
+.sp-tabs button {
+  height: 32px;
+  padding: 0 8px;
+  color: var(--sp-text-2);
+  font-weight: 500;
+}
+
+.sp-tabs button.on {
+  color: var(--sp-text);
+  font-weight: 600;
+}
+
+.sp-tab {
+  display: flex;
+  flex: 1;
+  min-height: 0;
+  flex-direction: column;
+}
+
+/* Section headings, shared by every tab */
+.sp-sh {
+  height: 24px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.sp-sh--pad,
+.sp-sh--group {
+  height: 28px;
+  padding: 4px 12px 0;
+}
+
+.sp-sh--group {
+  color: var(--sp-text-2);
+  font-weight: 500;
+}
+
+.sp-sh-t {
+  font-weight: 600;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.sp-sh-s {
+  margin-left: auto;
+  flex: none;
+  color: var(--sp-text-2);
+  font-family: var(--sp-mono);
+  white-space: nowrap;
+}
+
+.sp-sec {
+  padding: 8px 12px 12px;
+  border-bottom: 1px solid var(--sp-line);
+}
+
+.sp-sec:last-child {
+  border-bottom: 0;
+}
+
+.sp-empty,
+.sp-hint {
+  padding: 12px;
+  color: var(--sp-text-2);
+}
+
+.sp-hint {
+  padding: 8px 0 0;
+}
+
+.sp-scroll {
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+  padding-bottom: 8px;
+}
+
+/* Layers */
+.sp-layers {
+  flex: none;
+  height: 240px;
+  overflow: auto;
+  border-bottom: 1px solid var(--sp-line);
+}
+
+.sp-layers .sp-sh {
+  height: 28px;
+  padding: 4px 12px 0;
+}
+
+.sp-layer {
+  width: 100%;
+  height: 24px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 0 12px;
+  white-space: nowrap;
+}
+
+.sp-layer svg {
+  flex: none;
+  color: var(--sp-text-2);
+}
+
+.sp-layer.hov {
+  background: var(--sp-hover);
+}
+
+.sp-layer.on {
+  background: var(--sp-sel);
+}
+
+.sp-layer-n {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.sp-layer-d {
+  margin-left: auto;
+  flex: none;
+  color: var(--sp-text-2);
+}
+
+/* Properties */
+.sp-props {
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+}
+
+.sp-fields {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+  margin-top: 4px;
+}
+
+.sp-field {
+  height: 24px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 0 8px;
+  border-radius: 5px;
+  background: var(--sp-field);
+}
+
+.sp-field span {
+  flex: none;
+  width: 8px;
+  color: var(--sp-text-2);
+}
+
+.sp-field b {
+  font-weight: 400;
+}
+
+.sp-row {
+  min-height: 24px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.sp-k {
+  flex: none;
+  width: 88px;
+  color: var(--sp-text-2);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.sp-v {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  font-family: var(--sp-mono);
+  color: var(--sp-text-2);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.sp-v.plain {
+  color: var(--sp-text);
+}
+
+.sp-vv {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 4px;
+  min-width: 0;
+}
+
+.sp-src {
+  height: 24px;
+  margin-top: 4px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--sp-text-2);
+  font-family: var(--sp-mono);
+}
+
+.sp-src-l {
+  min-width: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.sp-link {
+  flex: none;
+  color: var(--sp-accent);
+  font-family: Inter, ui-sans-serif, system-ui, sans-serif;
+  cursor: pointer;
+}
+
+.sp-sub {
+  height: 20px;
+  line-height: 20px;
+  margin-top: -4px;
+  padding-left: 96px;
+  font-family: var(--sp-mono);
+  color: var(--sp-text-2);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.sp-longs {
+  height: auto;
+  line-height: 16px;
+  margin-top: 0;
+  white-space: normal;
+}
+
+.sp-state {
+  padding: 0 0 4px 96px;
+  line-height: 16px;
+  color: #b25d00;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.sp-state.overridden {
+  color: #c0392b;
+}
+
+.sp-decl.overridden .sp-k {
+  text-decoration: line-through;
+}
+
+.sp-pill {
+  height: 20px;
+  flex: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 0 6px 0 4px;
+  border-radius: 4px;
+  background: #efefef;
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.sp-pill.plain {
+  padding-left: 6px;
+}
+
+.sp-pill.lost {
+  text-decoration: line-through;
+  color: var(--sp-text-2);
+}
+
+.sp-pill:hover {
+  background: #e4e4e4;
+}
+
+.sp-sw {
+  width: 12px;
+  height: 12px;
+  flex: none;
+  border-radius: 2px;
+  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.12);
+}
+
+.sp-sw--none {
+  box-shadow: none;
+}
+
+/* Assets */
+.sp-asset {
+  width: 100%;
+  height: 40px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 0 12px;
+}
+
+.sp-asset.hov {
+  background: var(--sp-hover);
+}
+
+.sp-asset.on {
+  background: var(--sp-sel);
+}
+
+.sp-th {
+  width: 32px;
+  height: 32px;
+  flex: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 4px;
+  background: #1c1c1e;
+  overflow: hidden;
+}
+
+.sp-th img {
+  max-width: 28px;
+  max-height: 28px;
+  object-fit: contain;
+}
+
+.sp-asset-n {
+  display: flex;
+  align-items: baseline;
+  gap: 5px;
+  min-width: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.sp-asset-n i {
+  font-style: italic;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.sp-asset-n small {
+  flex: none;
+  font-size: 9px;
+  line-height: 12px;
+  padding: 0 3px;
+  border-radius: 3px;
+  background: #efefef;
+  color: var(--sp-text-2);
+}
+
+.sp-asset-d {
+  margin-left: auto;
+  flex: none;
+  color: var(--sp-text-2);
+  white-space: nowrap;
+}
+
+/* Tokens */
+.sp-token {
+  padding: 0 12px;
+}
+
+.sp-token.unused {
+  opacity: 0.45;
+}
+
+.sp-token.on,
+.sp-token.focus {
+  background: var(--sp-sel);
+}
+
+.sp-token-row {
+  height: 24px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.sp-token-n {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.sp-token-v {
+  margin-left: auto;
+  flex: none;
+  max-width: 120px;
+  font-family: var(--sp-mono);
+  color: var(--sp-text-2);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.sp-token-u {
+  flex: none;
+  min-width: 26px;
+  text-align: right;
+  color: var(--sp-text-2);
+  font-family: var(--sp-mono);
+}
+
+.sp-token-u:not(:disabled) {
+  color: var(--sp-accent);
+  cursor: pointer;
+}
+
+.sp-token-note {
+  margin: -4px 0 4px 20px;
+  line-height: 16px;
+  color: var(--sp-text-2);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.sp-token-note code {
+  font-family: var(--sp-mono);
+}

--- a/canvas/src/inspectorAgent.test.ts
+++ b/canvas/src/inspectorAgent.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { AGENT, injectAgent } from "./inspectorAgent";
+
+describe("AGENT", () => {
+  it("is one script tag", () => {
+    expect(AGENT.startsWith("<script>")).toBe(true);
+    expect(AGENT.endsWith("</script>")).toBe(true);
+    expect(AGENT.indexOf("</script>")).toBe(AGENT.length - "</script>".length);
+  });
+
+  it("stays template-literal safe: no backtick, no dollar-brace inside the source", () => {
+    const body = AGENT.slice("<script>".length, -"</script>".length);
+    expect(body).not.toContain("`");
+    expect(body).not.toContain("${");
+  });
+
+  it("carries a regex backslash through untouched", () => {
+    // `String.raw` is what keeps the resolver's regexes readable; a plain template would need
+    // every backslash doubled and would silently turn `\s` into `s`.
+    expect(AGENT).toContain("replace(/^\\s+|\\s+$/g,'')");
+  });
+});
+
+describe("injectAgent", () => {
+  it("splices before </body> when there is one", () => {
+    const out = injectAgent("<html><body><p>x</p></body></html>");
+    expect(out).toBe(`<html><body><p>x</p>${AGENT}</body></html>`);
+  });
+
+  it("appends when there is none — the apple-* generators emit no </body>", () => {
+    const html = "<html><body><p>x</p>";
+    expect(injectAgent(html)).toBe(html + AGENT);
+  });
+
+  it("matches the closing tag case-insensitively and only once", () => {
+    const out = injectAgent("<BODY></BODY>");
+    expect(out).toBe(`<BODY>${AGENT}</BODY>`);
+  });
+});

--- a/canvas/src/inspectorAgent.ts
+++ b/canvas/src/inspectorAgent.ts
@@ -1,0 +1,373 @@
+/**
+ * The script the inspector injects into a board, and the shapes of what it sends back.
+ *
+ * The boards on the canvas are `sandbox=""`: an opaque origin with no scripting, so the canvas
+ * cannot read them. The panel loads the same HTML into a second frame with `allow-scripts` (and
+ * deliberately without `allow-same-origin`, which together would let the frame reach back out)
+ * and splices this script in before `</body>`. Everything it reports is measured in the board's
+ * own layout, and it talks over postMessage.
+ *
+ * The script is ES5 and lives in a `String.raw` literal, so a regex backslash is written once.
+ * Two rules keep it embeddable: no backtick and no `${` anywhere in it (inspectorAgent.test.ts
+ * checks), and the closing `</script>` is assembled in injectAgent so the literal never holds
+ * one.
+ */
+
+export interface SpBox {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+/** One element of the board, in document order; index 0 is the root (`.phone`, else body). */
+export interface SpNode {
+  i: number;
+  tag: string;
+  cls: string;
+  /** Own text, for an element with no element children; up to 60 characters. */
+  text: string;
+  alt: string;
+  depth: number;
+  parent: number;
+  /** Whether an image asset is drawn here, as `<img>` or as a CSS background. */
+  img: boolean;
+  /** Relative to the root, in board px. Null only before layout. */
+  box: SpBox | null;
+}
+
+/** One distinct image on the board, keyed the way the build-time index keys the folder's files. */
+export interface SpAsset {
+  /** `"<payload length>:<fnv1a>"` of the base64 payload; joins against rawAssetNames. */
+  key: string;
+  uri: string;
+  via: "img" | "css";
+  mime: string;
+  /** Payload length in characters. */
+  chars: number;
+  w: number;
+  h: number;
+  alt: string;
+  /** Node indices that draw it. */
+  uses: number[];
+}
+
+export type SpTokenKind =
+  | "color"
+  | "length"
+  | "number"
+  | "font"
+  | "family"
+  | "image"
+  | "filter"
+  | "shadow"
+  | "other"
+  | "unset";
+
+export interface SpToken {
+  name: string;
+  /** As written in `:root`, `600 17px/22px var(--sa-font)`. */
+  decl: string;
+  /** The `/* heading *\/` above it in `:root`, null before the first one. */
+  group: string | null;
+  /** A trailing comment on the same line. */
+  note: string;
+  /** Substituted, as `:root` resolves it. */
+  value: string;
+  kind: SpTokenKind;
+  /** The colour as `rgb()`, for a swatch; empty for other kinds. */
+  canon: string;
+  /** Tokens this one's declaration references. */
+  refs: string[];
+  /** Node indices where a declaration binding it reaches the element and is not overridden. */
+  usedBy: number[];
+  /** Redefinitions outside `:root`, `.dark { --x: … }`. */
+  overrides: { sel: string; decl: string }[];
+  /** Defined only under a scope, never in `:root`. */
+  scoped?: boolean;
+}
+
+export interface SpGroup {
+  name: string;
+  tokens: string[];
+}
+
+export interface SpReady {
+  type: "sp:ready";
+  nodes: SpNode[];
+  size: SpBox;
+  assets: SpAsset[];
+  tokens: SpToken[];
+  groups: SpGroup[];
+  /** Milliseconds the token use pass took. */
+  ms: number;
+}
+
+export type SpBindingState = "applied" | "partial" | "overridden" | "unconfirmed" | "invalid";
+
+export interface SpLonghand {
+  p: string;
+  v: string;
+  ok: boolean;
+}
+
+/** One declaration that reaches the selected element, and whether it won. */
+export interface SpBinding {
+  prop: string;
+  value: string;
+  tokens: string[];
+  /** Token -> its value on this element (not on `:root`, which a `.dark` scope may differ from). */
+  resolved: Record<string, string>;
+  /** Selector it came from; empty for the inline attribute. */
+  src: string;
+  pseudo: string;
+  state: SpBindingState;
+  /** The declaration that took the longhands this one lost, named as written. */
+  by: string | null;
+  longhands: SpLonghand[];
+  elValue: string;
+  inheritedFrom?: { depth: number; tag: string; cls: string; i: string | null };
+}
+
+export interface SpBindings {
+  type: "sp:bindings";
+  i: number;
+  bindings: SpBinding[];
+  computed: Record<string, string>;
+}
+
+export type SpMessage =
+  | SpReady
+  | SpBindings
+  | { type: "sp:pick"; i: number }
+  | { type: "sp:hover"; i: number | null };
+
+const AGENT_BODY = String.raw`(function(){
+var root=document.querySelector('.phone')||document.body;
+
+/* ============ token resolver ============
+   Binds per declaration from the whole cascade, resolves each token on the element (not :root,
+   which a .dark{--x:..} scope makes wrong), and confirms with a hidden probe which longhands the
+   declaration actually produced on screen. See docs/2026-09-07-token-resolution.md. */
+var T=(function(){
+  var wrap=document.createElement('div');
+  wrap.style.cssText='position:absolute;left:0;top:0;width:0;height:0;overflow:hidden;visibility:hidden;pointer-events:none';
+  var probe=document.createElement('div'),zero=document.createElement('div');
+  wrap.appendChild(probe);wrap.appendChild(zero);
+  document.documentElement.appendChild(wrap);
+  var pcs=getComputedStyle(probe),zcs=getComputedStyle(zero);
+
+  /* split "a:b; c:d(e;f)" on top-level semicolons */
+  function splitDecls(text,all){
+    var out=[],depth=0,cur='',q=null,i,ch;
+    for(i=0;i<text.length;i++){ch=text.charAt(i);
+      if(q){cur+=ch;if(ch===q)q=null;continue;}
+      if(ch==='"'||ch==="'")q=ch;else if(ch==='(')depth++;else if(ch===')')depth--;
+      if(ch===';'&&depth===0){out.push(cur);cur='';}else cur+=ch;}
+    if(cur.replace(/\s/g,''))out.push(cur);
+    var decls=[];
+    for(i=0;i<out.length;i++){var d=out[i],c=d.indexOf(':');if(c<0)continue;
+      var prop=d.slice(0,c).replace(/^\s+|\s+$/g,'').toLowerCase(),val=d.slice(c+1).replace(/^\s+|\s+$/g,'');
+      if(val.indexOf('var(')<0&&!all)continue;
+      var toks=[],re=/var\(\s*(--[\w-]+)/g,m;while((m=re.exec(val)))toks.push(m[1]);
+      decls.push({prop:prop,value:val,tokens:toks});}
+    return decls;
+  }
+  function splitSelectors(sel){ /* top-level commas only (":is(a,b)" stays whole) */
+    var out=[],depth=0,cur='',i,ch;
+    for(i=0;i<sel.length;i++){ch=sel.charAt(i);if(ch==='(')depth++;else if(ch===')')depth--;
+      if(ch===','&&depth===0){out.push(cur);cur='';}else cur+=ch;}
+    out.push(cur);return out;
+  }
+  function specificity(sel){ /* ids > classes/attrs/pseudo-classes > types; enough for class-heavy boards */
+    var s=sel.replace(/::?[\w-]+(\([^)]*\))?/g,function(m){return m.indexOf('::')===0||/^:(before|after)/.test(m)?' ':' :x ';});
+    var ids=(s.match(/#[\w-]+/g)||[]).length,cls=(s.match(/\.[\w-]+|\[[^\]]*\]|:x/g)||[]).length;
+    var types=(s.replace(/#[\w-]+|\.[\w-]+|\[[^\]]*\]|:x/g,' ').match(/[a-zA-Z][\w-]*/g)||[]).length;
+    return ids*10000+cls*100+types;
+  }
+  /* every stylesheet rule in cascade order; an inline <style> shares the document's opaque origin, so it is readable */
+  var rules=[];
+  function collect(list){var i,r;for(i=0;i<list.length;i++){r=list[i];
+    if(r.type===1){var d=splitDecls(r.style.cssText,true);
+      if(d.length)rules.push({sel:r.selectorText,parts:splitSelectors(r.selectorText).map(function(p){var m=/::?(before|after|marker|placeholder)\s*$/.exec(p);
+        return m?{sel:p.slice(0,m.index),pseudo:'::'+m[1]}:{sel:p,pseudo:''};}),decls:d,order:rules.length});}
+    else if(r.cssRules)collect(r.cssRules);}}
+  (function(){var i;for(i=0;i<document.styleSheets.length;i++){try{collect(document.styleSheets[i].cssRules);}catch(e){}}})();
+
+  /* :root as written: groups from own-line comments, notes from trailing comments */
+  var css='',i;for(i=0;i<document.styleSheets.length;i++){var o=document.styleSheets[i].ownerNode;if(o&&o.textContent)css+=o.textContent+'\n';}
+  var tokens=[],byName={},groups=[],rootText=(/:root\s*\{([\s\S]*?)\}/.exec(css)||['',''])[1];
+  (function(){var lines=rootText.split('\n'),group=null,gi=-1,li,line,m;
+    for(li=0;li<lines.length;li++){line=lines[li];
+      m=/^\s*\/\*\s*([\s\S]*?)\s*\*\//.exec(line);
+      if(m&&!/--[\w-]+\s*:/.test(line.slice(0,m.index))){group=m[1];gi=groups.length;groups.push({name:group,tokens:[]});line=line.slice(m.index+m[0].length);}
+      var re=/(--[\w-]+)\s*:\s*([^;]*);/g,t,last=null;
+      while((t=re.exec(line))){last={name:t[1],decl:t[2].replace(/^\s+|\s+$/g,''),group:group,note:''};
+        if(!byName[last.name]){tokens.push(last);byName[last.name]=last;if(gi>=0)groups[gi].tokens.push(last.name);}}
+      var tail=/\/\*\s*([\s\S]*?)\s*\*\/\s*$/.exec(line);if(tail&&last)last.note=tail[1];}})();
+  function kind(v){ /* classified on the substituted value: CSS.supports('color', v) is true for any var() string */
+    if(!v)return 'unset';
+    if(/^-?[\d.]+(px|pt|em|rem|%|vw|vh|ch)$/.test(v))return 'length';
+    if(/^-?[\d.]+$/.test(v))return 'number';
+    if(CSS.supports('color',v))return 'color';
+    if(CSS.supports('font',v))return 'font';
+    if(CSS.supports('background-image',v))return 'image';
+    if(CSS.supports('filter',v))return 'filter';
+    if(CSS.supports('box-shadow',v))return 'shadow';
+    if(CSS.supports('font-family',v))return 'family';
+    return 'other';
+  }
+  var rcs=getComputedStyle(document.documentElement);
+  function canon(k,v){if(k!=='color')return '';probe.style.cssText='color:'+v;return pcs.color;}
+  for(i=0;i<tokens.length;i++){var tk=tokens[i];tk.value=rcs.getPropertyValue(tk.name).replace(/^\s+|\s+$/g,'');
+    tk.kind=kind(tk.value);tk.canon=canon(tk.kind,tk.value);tk.refs=(tk.decl.match(/var\(\s*(--[\w-]+)/g)||[]).map(function(s){return s.slice(4).replace(/^\s+/,'');});
+    tk.usedBy=[];tk.overrides=[];}
+  /* tokens redefined outside :root (e.g. .dark{--ac-bg:...}) */
+  (function(){var i,j;for(i=0;i<document.styleSheets.length;i++){var rs;try{rs=document.styleSheets[i].cssRules;}catch(e){continue;}
+    for(j=0;j<rs.length;j++){var r=rs[j];if(r.type!==1||r.selectorText===':root')continue;var k;
+      for(k=0;k<r.style.length;k++){var p=r.style[k];if(p.indexOf('--')===0){var t=byName[p];var ov={sel:r.selectorText,decl:r.style.getPropertyValue(p).replace(/^\s+|\s+$/g,'')};
+        if(t)t.overrides.push(ov);else{t={name:p,decl:'',group:null,note:'',value:'',kind:'unset',canon:'',refs:[],usedBy:[],overrides:[ov],scoped:true};tokens.push(t);byName[p]=t;}}}}}})();
+
+  /* the element's own computed token values, so a .dark{--x:..} redefinition is honoured */
+  function subst(value,cs){
+    return value.replace(/var\(\s*(--[\w-]+)\s*(?:,[^()]*)?\)/g,function(_,n){return cs.getPropertyValue(n).replace(/^\s+|\s+$/g,'');});}
+  /* which declarations reach the element, and whether each one won; the all flag includes the ones without a token */
+  function usesFor(el,all){
+    var cands=[],i,j,k,pseudos={'':getComputedStyle(el)};
+    for(i=0;i<rules.length;i++){var r=rules[i];var best={};
+      for(j=0;j<r.parts.length;j++){var p=r.parts[j];try{if(el.matches(p.sel)){var s=specificity(p.sel);if(!(p.pseudo in best)||s>best[p.pseudo])best[p.pseudo]=s;}}catch(e){}}
+      for(var ps in best){if(!pseudos[ps])pseudos[ps]=getComputedStyle(el,ps);
+        for(j=0;j<r.decls.length;j++)cands.push({prop:r.decls[j].prop,value:r.decls[j].value,tokens:r.decls[j].tokens,src:r.sel,pseudo:ps,spec:best[ps],order:i});}}
+    var inl=splitDecls(el.getAttribute('style')||'',true); /* the raw attribute, so an overrider is named as written */
+    for(j=0;j<inl.length;j++)cands.push({prop:inl[j].prop,value:inl[j].value,tokens:inl[j].tokens,src:'',pseudo:'',spec:1e6,order:rules.length+j});
+    cands.sort(function(a,b){return a.spec-b.spec||a.order-b.order;});
+    /* the longhands each candidate sets, via the probe; the probe copies display so a grid track list resolves */
+    for(i=0;i<cands.length;i++){var c=cands[i],ecs=pseudos[c.pseudo];c.ecs=ecs;
+      probe.style.cssText='display:'+ecs.display;probe.style.setProperty(c.prop,subst(c.value,ecs));
+      c.longs=[];c.all=[];c.invalid=probe.style.length<=1;
+      for(k=0;k<probe.style.length;k++){var L=probe.style[k];if(L==='display')continue;var pv=pcs.getPropertyValue(L),ev=ecs.getPropertyValue(L),same=pv===ev;
+        c.all.push({p:L,v:pv,ok:same});if(pv!==zcs.getPropertyValue(L))c.longs.push({p:L,v:pv,ok:same});}
+      if(!c.longs.length)c.longs=c.all;}
+    var out=[];
+    for(i=cands.length-1;i>=0;i--){var c=cands[i];if(!c.tokens.length&&!all)continue;
+      var bad=[],ok=true;for(k=0;k<c.longs.length;k++)if(!c.longs[k].ok){ok=false;bad.push(c.longs[k].p);}
+      var by=null,byProp=null;
+      if(!ok){ /* name the later declaration that took those longhands, if there is one */
+        for(j=cands.length-1;j>i&&!by;j--){var d=cands[j];if(d.pseudo!==c.pseudo||d.invalid)continue;
+          for(k=0;k<d.all.length;k++)if(bad.indexOf(d.all[k].p)>=0){by=(d.src?d.src+' ':'inline ')+d.prop+': '+d.value;byProp=d.prop;break;}}}
+      var state=c.invalid?'invalid':ok?'applied':!by?'unconfirmed':(byProp===c.prop||bad.length===c.longs.length)?'overridden':'partial';
+      var vals={};for(k=0;k<c.tokens.length;k++)vals[c.tokens[k]]=c.ecs.getPropertyValue(c.tokens[k]).replace(/^\s+|\s+$/g,'');
+      out.push({prop:c.prop,value:c.value,tokens:c.tokens,resolved:vals,src:c.src,pseudo:c.pseudo,state:state,by:by,longhands:c.longs,elValue:c.ecs.getPropertyValue(c.prop)});}
+    out.reverse();return out;
+  }
+  /* inherited properties the element does not bind itself: report the nearest ancestor that does */
+  var INHERITED=/^(color|font|font-[\w-]+|line-height|letter-spacing|text-align|text-transform|word-spacing|visibility|fill|stroke)$/;
+  function bindingsFor(el,all){
+    var own=usesFor(el,all),have={},i,a=el.parentElement,depth=1;
+    for(i=0;i<own.length;i++)if(!own[i].pseudo&&own[i].state!=='overridden')have[own[i].prop.split('-')[0]]=true;
+    while(a&&a.nodeType===1){var up=usesFor(a);
+      for(i=0;i<up.length;i++){var u=up[i];if(u.pseudo||u.state==='overridden'||!INHERITED.test(u.prop)||have[u.prop.split('-')[0]])continue;
+        have[u.prop.split('-')[0]]=true;u.inheritedFrom={depth:depth,tag:a.tagName.toLowerCase(),cls:a.getAttribute('class')||'',i:a.getAttribute('data-sp')};own.push(u);}
+      a=a.parentElement;depth++;}
+    return own;
+  }
+  return {tokens:tokens,groups:groups,rules:rules.length,usesFor:usesFor,bindingsFor:bindingsFor,byName:byName};
+})();
+window.__spTokens=T;
+
+/* ============ element index ============
+   Marked up front: indices are layout-independent, boxes are not, so those wait for measure(). */
+var els=[root],nodes=[],i;
+Array.prototype.forEach.call(root.querySelectorAll('*'),function(el){if(el.tagName==='STYLE'||el.tagName==='SCRIPT')return;els.push(el);});
+for(i=0;i<els.length;i++)els[i].setAttribute('data-sp',i);
+for(i=0;i<els.length;i++){var el=els[i],p=el.parentElement,up=-1;
+  while(i>0&&p){var ps=p.getAttribute('data-sp');if(ps!==null){up=+ps;break;}p=p.parentElement;}
+  nodes.push({i:i,tag:el.tagName.toLowerCase(),cls:el.getAttribute('class')||'',
+    text:el.children.length?'':(el.textContent||'').replace(/\s+/g,' ').replace(/^\s+|\s+$/g,'').slice(0,60),
+    alt:el.getAttribute('alt')||'',depth:up>=0?nodes[up].depth+1:0,parent:up,img:false,box:null});}
+function box(el){var r=el.getBoundingClientRect(),o=root.getBoundingClientRect();
+  return{x:+(r.left-o.left).toFixed(2),y:+(r.top-o.top).toFixed(2),w:+r.width.toFixed(2),h:+r.height.toFixed(2)};}
+
+/* ============ assets ============
+   Keyed by length:fnv1a of the base64 payload, which is how vite.config.ts keys the folder's
+   files, so the parent can join without any attribute in the HTML. FNV-1a rather than SHA
+   because this frame has no crypto.subtle under a non-secure parent (plain http). */
+function fnv(s){var h=0x811c9dc5;for(var i=0;i<s.length;i++){h=Math.imul(h^s.charCodeAt(i),0x01000193)>>>0;}return h.toString(36);}
+var assets=[],byKey={};
+function addAsset(i,uri,via,el){var c=uri.indexOf(','),payload=uri.slice(c+1),k=payload.length+':'+fnv(payload),a=byKey[k];
+  if(!a){a=byKey[k]={key:k,uri:uri,via:via,mime:uri.slice(5,c).split(';')[0],chars:payload.length,w:0,h:0,alt:'',uses:[]};assets.push(a);
+    if(via==='css'){var im=new Image();im.onload=function(){a.w=im.naturalWidth;a.h=im.naturalHeight;schedule();};im.src=uri;}}
+  if(via==='img'){if(el.naturalWidth){a.w=el.naturalWidth;a.h=el.naturalHeight;}if(!a.alt)a.alt=el.getAttribute('alt')||'';}
+  if(a.uses.indexOf(i)<0)a.uses.push(i);nodes[i].img=true;}
+
+/* Every box is read after layout. A script at the end of the body runs at readyState
+   'interactive', before the first layout pass and before the data: URIs have decoded, so
+   measuring here reports 0x0 for every element on every board. */
+function measure(){
+  for(var i=0;i<els.length;i++){var el=els[i];nodes[i].box=box(el);
+    if(el.tagName==='IMG'){var src=el.getAttribute('src')||'';if(src.indexOf('data:')===0)addAsset(i,src,'img',el);}
+    var bg=getComputedStyle(el).backgroundImage;
+    if(bg&&bg.indexOf('data:')>=0){var re=/url\("?(data:image[^")]+)"?\)/g,m;while((m=re.exec(bg)))addAsset(i,m[1],'css',el);}}}
+
+/* One pass over every element, so the Tokens tab can say "used by N" and select them. */
+var tokenMs=-1;
+function countUses(){if(tokenMs>=0)return;var t0=performance.now();
+  for(var i=0;i<els.length;i++){var u=T.usesFor(els[i]);
+    for(var j=0;j<u.length;j++){if(u[j].state==='overridden')continue;
+      for(var k=0;k<u[j].tokens.length;k++){var tk=T.byName[u[j].tokens[k]];if(tk&&tk.usedBy.indexOf(i)<0)tk.usedBy.push(i);}}}
+  tokenMs=Math.round(performance.now()-t0);}
+
+function send(){measure();countUses();
+  parent.postMessage({type:'sp:ready',nodes:nodes,size:box(root),assets:assets,tokens:T.tokens,groups:T.groups,ms:tokenMs},'*');}
+var queued=false;
+function schedule(){if(queued)return;queued=true;requestAnimationFrame(function(){queued=false;send();});}
+/* Three chances, because each one alone has a hole: 'load' waits for the images, the frame after
+   it waits for the layout they cause, and the parent's own hello covers a listener that attached
+   late. The parent keeps whichever arrives last. */
+addEventListener('load',function(){send();schedule();});
+
+/* ============ overlays and selection ============ */
+function overlay(css){var d=document.createElement('div');
+  d.style.cssText='position:fixed;pointer-events:none;z-index:2147483647;display:none;box-sizing:border-box;'+css;
+  document.documentElement.appendChild(d);return d;}
+var hi=overlay('box-shadow:0 0 0 1.5px #0d99ff'),hov=overlay('box-shadow:0 0 0 1px #0d99ff'),
+  badge=overlay('height:16px;padding:0 4px;border-radius:2px;background:#0d99ff;color:#fff;font:10px/16px Inter,system-ui,sans-serif;white-space:nowrap;transform:translateX(-50%)');
+function fmt(n){return String(Math.round(n*100)/100);}
+function place(d,el){if(!el){d.style.display='none';return null;}var r=el.getBoundingClientRect();
+  d.style.display='block';d.style.left=r.left+'px';d.style.top=r.top+'px';d.style.width=r.width+'px';d.style.height=r.height+'px';return r;}
+function at(i){return i===null||i===undefined?null:root.querySelector('[data-sp="'+i+'"]');}
+var selEl=null;
+function select(i){selEl=at(i);var r=place(hi,selEl);
+  if(r){badge.style.display='block';badge.textContent=fmt(r.width)+' × '+fmt(r.height);badge.style.left=(r.left+r.width/2)+'px';badge.style.top=(r.bottom+4)+'px';}
+  else badge.style.display='none';
+  if(!selEl)return;
+  var cs=getComputedStyle(selEl);
+  parent.postMessage({type:'sp:bindings',i:i,bindings:T.bindingsFor(selEl,true),
+    computed:{color:cs.color,'background-color':cs.backgroundColor,
+      font:cs.fontWeight+' '+cs.fontSize+'/'+cs.lineHeight+' '+cs.fontFamily,
+      'border-radius':cs.borderRadius,opacity:cs.opacity,padding:cs.padding}},'*');}
+function hover(i){var el=at(i);place(hov,el&&el!==selEl?el:null);}
+
+addEventListener('message',function(e){var d=e.data;if(!d||typeof d!=='object')return;
+  if(d.type==='sp:hello')send();
+  else if(d.type==='sp:sel')select(d.i);
+  else if(d.type==='sp:hover')hover(d.i);});
+
+function pick(e){var el=e.target&&e.target.closest?e.target.closest('[data-sp]'):null;return el?+el.getAttribute('data-sp'):null;}
+var lastHover=null;
+document.addEventListener('click',function(e){var i=pick(e);if(i===null)return;e.preventDefault();parent.postMessage({type:'sp:pick',i:i},'*');},true);
+document.addEventListener('mousemove',function(e){var i=pick(e);if(i===lastHover)return;lastHover=i;hover(i);parent.postMessage({type:'sp:hover',i:i},'*');},true);
+document.addEventListener('mouseleave',function(){lastHover=null;hover(null);parent.postMessage({type:'sp:hover',i:null},'*');},true);
+})();`;
+
+/** The whole tag, as spliced into a board. Exported for the tests and the Playwright sweeps. */
+export const AGENT = "<script>" + AGENT_BODY + "</" + "script>";
+
+/**
+ * Not every board has a `</body>`: the apple-* generators emit none, so those get the agent
+ * appended. The fallback is load bearing, not defensive — a splice alone reports nothing for
+ * 37 of the repo's 180 boards.
+ */
+export function injectAgent(html: string) {
+  return /<\/body>/i.test(html) ? html.replace(/<\/body>/i, (tag) => AGENT + tag) : html + AGENT;
+}

--- a/canvas/src/inspectorAgent.ts
+++ b/canvas/src/inspectorAgent.ts
@@ -335,7 +335,10 @@ var hi=overlay('box-shadow:0 0 0 1.5px #0d99ff'),hov=overlay('box-shadow:0 0 0 1
 function fmt(n){return String(Math.round(n*100)/100);}
 function place(d,el){if(!el){d.style.display='none';return null;}var r=el.getBoundingClientRect();
   d.style.display='block';d.style.left=r.left+'px';d.style.top=r.top+'px';d.style.width=r.width+'px';d.style.height=r.height+'px';return r;}
-function at(i){return i===null||i===undefined?null:root.querySelector('[data-sp="'+i+'"]');}
+/* els[i], not a querySelector: root is index 0 and carries its own data-sp, but querySelector
+   searches descendants only, so selecting the root row highlighted nothing and never sent
+   bindings — its Styles section sat on "resolving..." for good. */
+function at(i){return i===null||i===undefined?null:(els[i]||null);}
 var selEl=null;
 function select(i){selEl=at(i);var r=place(hi,selEl);
   if(r){badge.style.display='block';badge.textContent=fmt(r.width)+' × '+fmt(r.height);badge.style.left=(r.left+r.width/2)+'px';badge.style.top=(r.bottom+4)+'px';}

--- a/canvas/src/inspectorClicks.ts
+++ b/canvas/src/inspectorClicks.ts
@@ -1,0 +1,53 @@
+import type { Editor, TLEventInfo } from "tldraw";
+import { CANVAS_FILE_SHAPE_TYPE, type CanvasFileShape } from "./CanvasFileShapeUtil";
+
+/**
+ * A locked board cannot be selected, so tldraw reports a click on one as a click on the canvas
+ * and the shape util's own `onClick` never runs — the same problem the welcome page's cards have,
+ * solved the same way (installLockedLinkClicks in CanvasLinkShapeUtil.tsx): watch the editor's
+ * pointer events and call a press and a release over one board, with no drag between them, a
+ * click. Returns the uninstaller.
+ */
+export function installInspectorClicks(
+  editor: Editor,
+  onPick: (shape: CanvasFileShape) => void,
+) {
+  const boardUnderPointer = () =>
+    editor.getShapeAtPoint(editor.inputs.getCurrentPagePoint(), {
+      hitInside: true,
+      hitLocked: true,
+      renderingOnly: true,
+      filter: (shape) => shape.type === CANVAS_FILE_SHAPE_TYPE,
+    }) as CanvasFileShape | undefined;
+
+  let pressed: CanvasFileShape | undefined;
+  const onEvent = (info: TLEventInfo) => {
+    if (info.type !== "pointer") {
+      // Two fingers arriving, or a wheel, in the middle of a press: a zoom, not a click.
+      if (info.type === "pinch" || info.type === "wheel") pressed = undefined;
+      return;
+    }
+    if (info.name === "pointer_down") {
+      // Only the select tool opens the inspector; a click with the pen or the eraser over a
+      // board is a stroke or an erase.
+      pressed =
+        info.button === 0 &&
+        editor.getCurrentToolId() === "select" &&
+        !editor.menus.hasAnyOpenMenus()
+          ? boardUnderPointer()
+          : undefined;
+      return;
+    }
+    if (info.name !== "pointer_up") return;
+    const target = pressed;
+    pressed = undefined;
+    if (!target || editor.inputs.getIsDragging()) return;
+    if (boardUnderPointer()?.id !== target.id) return;
+    onPick(target);
+  };
+
+  editor.on("event", onEvent);
+  return () => {
+    editor.off("event", onEvent);
+  };
+}

--- a/canvas/src/inspectorClicks.ts
+++ b/canvas/src/inspectorClicks.ts
@@ -12,13 +12,19 @@ export function installInspectorClicks(
   editor: Editor,
   onPick: (shape: CanvasFileShape) => void,
 ) {
-  const boardUnderPointer = () =>
-    editor.getShapeAtPoint(editor.inputs.getCurrentPagePoint(), {
+  /**
+   * The topmost shape must *be* a board. A `filter` here instead would search past anything drawn
+   * over one, so every click on an unlocked note or arrow sitting on a board would also open the
+   * inspector and squeeze the canvas out from under the thing being edited.
+   */
+  const boardUnderPointer = () => {
+    const hit = editor.getShapeAtPoint(editor.inputs.getCurrentPagePoint(), {
       hitInside: true,
       hitLocked: true,
       renderingOnly: true,
-      filter: (shape) => shape.type === CANVAS_FILE_SHAPE_TYPE,
-    }) as CanvasFileShape | undefined;
+    });
+    return hit?.type === CANVAS_FILE_SHAPE_TYPE ? (hit as CanvasFileShape) : undefined;
+  };
 
   let pressed: CanvasFileShape | undefined;
   const onEvent = (info: TLEventInfo) => {

--- a/canvas/src/inspectorModel.test.ts
+++ b/canvas/src/inspectorModel.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from "vitest";
+import type { SpAsset, SpNode, SpToken } from "./inspectorAgent";
+import {
+  assetRows,
+  formatBytes,
+  isColorValue,
+  layerKind,
+  layerName,
+  layerSelector,
+  tokenGroups,
+  tokenVia,
+} from "./inspectorModel";
+
+const asset = (over: Partial<SpAsset>): SpAsset => ({
+  key: "100:abc",
+  uri: "data:image/png;base64,AAAA",
+  via: "img",
+  mime: "image/png",
+  chars: 100,
+  w: 160,
+  h: 160,
+  alt: "",
+  uses: [3],
+  ...over,
+});
+
+describe("assetRows", () => {
+  it("names an image from the folder index by content key", () => {
+    const [row] = assetRows([asset({})], { "100:abc": { name: "assets/hero.png", bytes: 75 } });
+    expect(row.name).toBe("assets/hero.png");
+    expect(row.source).toBe("file");
+    expect(row.bytes).toBe(75);
+  });
+
+  it("falls back to alt for a re-encoded image, marked as such", () => {
+    const [row] = assetRows([asset({ alt: "Find My" })], {});
+    expect(row.name).toBe("Find My");
+    expect(row.source).toBe("alt");
+  });
+
+  it("falls back to format and size when there is neither, with decoded bytes", () => {
+    const [row] = assetRows([asset({ chars: 400 })], undefined);
+    expect(row.name).toBe("png 160×160");
+    expect(row.source).toBe("none");
+    expect(row.bytes).toBe(300);
+  });
+});
+
+describe("formatBytes", () => {
+  it("picks the unit", () => {
+    expect(formatBytes(512)).toBe("512 B");
+    expect(formatBytes(2048)).toBe("2.0 KB");
+    expect(formatBytes(204800)).toBe("200 KB");
+    expect(formatBytes(3 * 1024 * 1024)).toBe("3.0 MB");
+  });
+});
+
+const node = (over: Partial<SpNode>): SpNode => ({
+  i: 5,
+  tag: "div",
+  cls: "",
+  text: "",
+  alt: "",
+  depth: 1,
+  parent: 0,
+  img: false,
+  box: null,
+  ...over,
+});
+
+describe("layers", () => {
+  it("names by text, then asset, then class, then tag", () => {
+    expect(layerName(node({ text: "Confirm" }))).toBe("Confirm");
+    expect(layerName(node({ tag: "img", img: true }), "assets/a.png")).toBe("assets/a.png");
+    expect(layerName(node({ cls: "card on" }))).toBe("card");
+    expect(layerName(node({}))).toBe("div");
+    expect(layerName(node({ i: 0, cls: "phone dark" }))).toBe("phone");
+  });
+
+  it("classifies the row's icon", () => {
+    expect(layerKind(node({ i: 0 }))).toBe("frame");
+    expect(layerKind(node({ img: true, text: "x" }))).toBe("image");
+    expect(layerKind(node({ text: "x" }))).toBe("text");
+    expect(layerKind(node({}))).toBe("box");
+  });
+
+  it("spells the selector", () => {
+    expect(layerSelector(node({ tag: "span", cls: "t  big" }))).toBe("span.t.big");
+    expect(layerSelector(node({}))).toBe("div");
+  });
+});
+
+const token = (over: Partial<SpToken>): SpToken => ({
+  name: "--x",
+  decl: "#fff",
+  group: null,
+  note: "",
+  value: "#fff",
+  kind: "color",
+  canon: "rgb(255, 255, 255)",
+  refs: [],
+  usedBy: [],
+  overrides: [],
+  ...over,
+});
+
+describe("tokenGroups", () => {
+  it("keeps the author's headings and order, leading tokens first, scoped last", () => {
+    const tokens = [
+      token({ name: "--font", kind: "family" }),
+      token({ name: "--bg", group: "Surface" }),
+      token({ name: "--ink", group: "Ink" }),
+      token({ name: "--only-dark", scoped: true, kind: "unset" }),
+    ];
+    const groups = [
+      { name: "Surface", tokens: ["--bg"] },
+      { name: "Ink", tokens: ["--ink"] },
+      { name: "Empty", tokens: [] },
+    ];
+    expect(tokenGroups(tokens, groups).map((g) => [g.name, g.tokens.map((t) => t.name)])).toEqual([
+      ["", ["--font"]],
+      ["Surface", ["--bg"]],
+      ["Ink", ["--ink"]],
+      ["Scoped only", ["--only-dark"]],
+    ]);
+  });
+
+  it("groups by kind when the board wrote no headings", () => {
+    const tokens = [
+      token({ name: "--a" }),
+      token({ name: "--w", kind: "length", value: "12px" }),
+      token({ name: "--b" }),
+    ];
+    expect(tokenGroups(tokens, []).map((g) => [g.name, g.tokens.map((t) => t.name)])).toEqual([
+      ["Colours", ["--a", "--b"]],
+      ["Lengths", ["--w"]],
+    ]);
+  });
+});
+
+describe("tokenVia", () => {
+  it("names the used tokens that carry an unused one", () => {
+    const font = token({ name: "--sa-font", kind: "family" });
+    const time = token({ name: "--sa-t-time", kind: "font", refs: ["--sa-font"], usedBy: [1] });
+    const idle = token({ name: "--sa-t-idle", kind: "font", refs: ["--sa-font"] });
+    expect(tokenVia(font, [font, time, idle])).toEqual(["--sa-t-time"]);
+    expect(tokenVia(time, [font, time, idle])).toEqual([]);
+  });
+});
+
+describe("isColorValue", () => {
+  it("trusts a kind when it has one, and the shape of the string otherwise", () => {
+    expect(isColorValue("12px", "color")).toBe(true);
+    expect(isColorValue("#F0A468")).toBe(true);
+    expect(isColorValue("rgba(0,0,0,.5)")).toBe(true);
+    expect(isColorValue("590 18px/18px -apple-system")).toBe(false);
+  });
+});

--- a/canvas/src/inspectorModel.test.ts
+++ b/canvas/src/inspectorModel.test.ts
@@ -1,7 +1,14 @@
 import { describe, expect, it } from "vitest";
 import type { SpAsset, SpNode, SpToken } from "./inspectorAgent";
+import type { AssetRow } from "./inspectorModel";
 import {
+  assetForNode,
   assetRows,
+  fitScale,
+  initialLayersH,
+  nextLayersH,
+  nextPanelW,
+  nextRailW,
   formatBytes,
   isColorValue,
   layerKind,
@@ -154,5 +161,63 @@ describe("isColorValue", () => {
     expect(isColorValue("#F0A468")).toBe(true);
     expect(isColorValue("rgba(0,0,0,.5)")).toBe(true);
     expect(isColorValue("590 18px/18px -apple-system")).toBe(false);
+  });
+});
+
+describe("panel geometry", () => {
+  it("widens the panel when its left edge is dragged left", () => {
+    expect(nextPanelW(736, -100, 1600)).toBe(836);
+    expect(nextPanelW(736, 100, 1600)).toBe(636);
+  });
+
+  it("keeps the canvas and the preview from being dragged away entirely", () => {
+    expect(nextPanelW(736, -9999, 1600)).toBe(1320); // viewport - 280
+    expect(nextPanelW(736, 9999, 1600)).toBe(360);
+    expect(nextRailW(280, -9999, 736)).toBe(496); // panel - 240
+    expect(nextRailW(280, 9999, 736)).toBe(200);
+  });
+
+  it("prefers the minimum when a small viewport crosses the two bounds", () => {
+    // 300 - 280 = 20, below the 360 minimum: a pinned-open panel beats a negative one.
+    expect(nextPanelW(736, 0, 300)).toBe(360);
+  });
+
+  it("opens the layers list on a share of the window, held off both ends", () => {
+    expect(initialLayersH(1127)).toBe(507); // the 24-layer board, ~20 rows visible
+    expect(initialLayersH(700)).toBe(315);
+    expect(initialLayersH(360)).toBe(200); // floor: properties keep their room
+    expect(initialLayersH(2000)).toBe(560); // ceiling: past this you scroll either way
+  });
+
+  it("grows the layers list downward, which is the drag the fixed 240px needed", () => {
+    expect(nextLayersH(240, 160, 1000)).toBe(400);
+    expect(nextLayersH(240, -9999, 1000)).toBe(72);
+    expect(nextLayersH(240, 9999, 1000)).toBe(880); // viewport - 120
+  });
+
+  it("contains the board in the stage and never enlarges past 1:1", () => {
+    // A phone board in a roomy stage: capped, not blown up.
+    expect(fitScale({ w: 900, h: 1200 }, { w: 393, h: 852 })).toBe(1);
+    // Height-bound: (852 - 32) / 852.
+    expect(fitScale({ w: 900, h: 852 }, { w: 393, h: 852 })).toBeCloseTo(820 / 852, 6);
+    // A landscape evidence board fits by width.
+    expect(fitScale({ w: 432, h: 900 }, { w: 1200, h: 400 })).toBeCloseTo(400 / 1200, 6);
+  });
+});
+
+describe("assetForNode", () => {
+  const rows = [
+    { key: "a", uses: [3, 4] },
+    { key: "b", uses: [9] },
+  ] as unknown as AssetRow[];
+
+  it("finds the image a selected layer draws", () => {
+    expect(assetForNode(rows, 4)?.key).toBe("a");
+    expect(assetForNode(rows, 9)?.key).toBe("b");
+  });
+
+  it("is null for no selection and for a layer that draws nothing", () => {
+    expect(assetForNode(rows, null)).toBeNull();
+    expect(assetForNode(rows, 7)).toBeNull();
   });
 });

--- a/canvas/src/inspectorModel.test.ts
+++ b/canvas/src/inspectorModel.test.ts
@@ -6,9 +6,12 @@ import {
   assetRows,
   fitScale,
   initialLayersH,
+  layersBounds,
   nextLayersH,
   nextPanelW,
   nextRailW,
+  panelBounds,
+  railBounds,
   formatBytes,
   isColorValue,
   layerKind,
@@ -192,7 +195,28 @@ describe("panel geometry", () => {
   it("grows the layers list downward, which is the drag the fixed 240px needed", () => {
     expect(nextLayersH(240, 160, 1000)).toBe(400);
     expect(nextLayersH(240, -9999, 1000)).toBe(72);
-    expect(nextLayersH(240, 9999, 1000)).toBe(880); // viewport - 120
+    expect(nextLayersH(240, 9999, 1000)).toBe(800); // viewport - 200
+  });
+
+  it("re-clamps a value whose bound has since moved, which is what render does", () => {
+    // A rail dragged wide, then the panel dragged to its minimum: the stage keeps a strip.
+    const panel = nextPanelW(736, 9999, 1600);
+    expect(nextRailW(496, 0, panel)).toBe(200);
+    expect(panel - nextRailW(496, 0, panel)).toBe(160);
+    // A panel dragged wide, then the window shrunk under it.
+    expect(nextPanelW(1320, 0, 900)).toBe(620);
+    // A layers list dragged tall, then the window shrunk: the grip stays inside the rail.
+    expect(nextLayersH(880, 0, 900)).toBe(700);
+    expect(nextLayersH(880, 0, 900)).toBeLessThan(900);
+  });
+
+  it("reports the same bounds it clamps to, which is what the grips announce", () => {
+    expect(panelBounds(1600)).toEqual([360, 1320]);
+    expect(railBounds(736)).toEqual([200, 496]);
+    expect(layersBounds(1000)).toEqual([72, 800]);
+    // Crossed bounds collapse onto the minimum rather than inverting.
+    expect(panelBounds(300)).toEqual([360, 360]);
+    expect(railBounds(360)).toEqual([200, 200]);
   });
 
   it("contains the board in the stage and never enlarges past 1:1", () => {
@@ -219,5 +243,10 @@ describe("assetForNode", () => {
   it("is null for no selection and for a layer that draws nothing", () => {
     expect(assetForNode(rows, null)).toBeNull();
     expect(assetForNode(rows, 7)).toBeNull();
+  });
+
+  it("takes the first row when one layer draws two images, as the layer name does", () => {
+    const both = [{ key: "bg", uses: [2] }, { key: "fg", uses: [2] }] as unknown as AssetRow[];
+    expect(assetForNode(both, 2)?.key).toBe("bg");
   });
 });

--- a/canvas/src/inspectorModel.ts
+++ b/canvas/src/inspectorModel.ts
@@ -196,28 +196,51 @@ export const initialLayersH = (viewport: number) => clamp(Math.round(viewport * 
 const PANEL_MIN = 360;
 const RAIL_GAP = 280; // canvas left visible beside the panel
 const RAIL_MIN = 200;
-const STAGE_MIN = 240; // preview left visible beside the rail
+const STAGE_MIN = 240; // preview asked for beside the rail; the rail's own minimum wins under it
 const LAYERS_MIN = 72;
-const LAYERS_GAP = 120; // properties left visible under the layers
+const LAYERS_GAP = 200; // room under the layers for the selected asset and the properties
 
 export const clamp = (v: number, lo: number, hi: number) =>
   // lo wins a crossover: on a viewport too small for both bounds, a divider pinned to the
-  // minimum is usable, one pinned to a negative maximum is not.
+  // minimum is usable, one pinned to a negative maximum is not. That crossover is reachable at
+  // the panel minimum, where 360 cannot hold RAIL_MIN + STAGE_MIN and the rail keeps its 200.
   Math.max(lo, Math.min(v, hi));
+
+/**
+ * What each divider may range over. Exported because the bounds are also what the grips report
+ * to a screen reader and what an arrow key steps within, not only what a drag is clamped to.
+ */
+export const panelBounds = (viewport: number): [number, number] => [
+  PANEL_MIN,
+  Math.max(PANEL_MIN, viewport - RAIL_GAP),
+];
+export const railBounds = (panelW: number): [number, number] => [
+  RAIL_MIN,
+  Math.max(RAIL_MIN, panelW - STAGE_MIN),
+];
+export const layersBounds = (viewport: number): [number, number] => [
+  LAYERS_MIN,
+  Math.max(LAYERS_MIN, viewport - LAYERS_GAP),
+];
 
 /**
  * Where a divider lands. The panel and the rail are both docked right, so their left edges
  * resize them and a leftward drag — a negative dx — makes them wider. The layers list is above
  * its divider, so it follows dy directly.
+ *
+ * Every one of these is applied at render as well as at drag time, with a zero delta. A bound
+ * moves when the window resizes or when the divider on the other side of it is dragged, and a
+ * value only clamped where it was set outlives its own bound: a layers list dragged tall in a
+ * tall window put its grip below the rail's bottom edge, where nothing could reach it again.
  */
 export const nextPanelW = (start: number, dx: number, viewport: number) =>
-  clamp(start - dx, PANEL_MIN, viewport - RAIL_GAP);
+  clamp(start - dx, ...panelBounds(viewport));
 
 export const nextRailW = (start: number, dx: number, panelW: number) =>
-  clamp(start - dx, RAIL_MIN, panelW - STAGE_MIN);
+  clamp(start - dx, ...railBounds(panelW));
 
 export const nextLayersH = (start: number, dy: number, viewport: number) =>
-  clamp(start + dy, LAYERS_MIN, viewport - LAYERS_GAP);
+  clamp(start + dy, ...layersBounds(viewport));
 
 /** Contain, never past 1:1 — a board blown up past its own pixels is blurrier, not bigger. */
 export const fitScale = (stage: { w: number; h: number }, board: { w: number; h: number }) => {

--- a/canvas/src/inspectorModel.ts
+++ b/canvas/src/inspectorModel.ts
@@ -1,0 +1,171 @@
+/**
+ * What the inspector panel derives from an agent report before drawing it. Pure functions, so
+ * the joins and fallbacks are testable without a frame.
+ */
+import type { SpAsset, SpGroup, SpNode, SpToken, SpTokenKind } from "./inspectorAgent";
+
+/** Where an asset's name came from, so a fallback is never passed off as a file name. */
+export type AssetNameSource = "file" | "alt" | "none";
+
+export interface AssetRow {
+  key: string;
+  name: string;
+  source: AssetNameSource;
+  bytes: number;
+  w: number;
+  h: number;
+  mime: string;
+  via: "img" | "css";
+  uri: string;
+  uses: number[];
+}
+
+/**
+ * Joins the board's images against the folder's committed files by content. A generator that
+ * re-encodes (a PIL resize) produces bytes that match nothing, so the image's alt text is the
+ * fallback, and after that its format and size.
+ */
+export function assetRows(
+  assets: SpAsset[],
+  names: Record<string, { name: string; bytes: number }> | undefined,
+): AssetRow[] {
+  return assets.map((a) => {
+    const hit = names?.[a.key];
+    const format = a.mime.replace(/^image\//, "") || "image";
+    const name = hit ? hit.name : a.alt || `${format} ${a.w}×${a.h}`;
+    return {
+      key: a.key,
+      name,
+      source: hit ? "file" : a.alt ? "alt" : "none",
+      // A base64 payload decodes to three bytes per four characters, less any padding.
+      bytes: hit ? hit.bytes : Math.floor((a.chars * 3) / 4),
+      w: a.w,
+      h: a.h,
+      mime: a.mime,
+      via: a.via,
+      uri: a.uri,
+      uses: a.uses,
+    };
+  });
+}
+
+export function formatBytes(n: number) {
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(n < 10240 ? 1 : 0)} KB`;
+  return `${(n / 1024 / 1024).toFixed(1)} MB`;
+}
+
+export type LayerKind = "frame" | "image" | "text" | "box";
+
+export function layerKind(node: SpNode): LayerKind {
+  if (node.i === 0) return "frame";
+  if (node.img) return "image";
+  if (node.text) return "text";
+  return "box";
+}
+
+/** The label a layer row shows: its text, else the image's name, else its first class, else its tag. */
+export function layerName(node: SpNode, assetName?: string) {
+  if (node.i === 0) return node.cls.split(/\s+/)[0] || node.tag;
+  if (node.text) return node.text;
+  if (node.img && assetName) return assetName;
+  return node.cls.split(/\s+/)[0] || node.tag;
+}
+
+/** `div.card` for the muted suffix beside a layer's name. */
+export function layerSelector(node: SpNode) {
+  const cls = node.cls.split(/\s+/).filter(Boolean);
+  return node.tag + (cls.length ? `.${cls.join(".")}` : "");
+}
+
+export interface TokenGroupView {
+  /** The author's heading, or a kind label when the board wrote none. */
+  name: string;
+  tokens: SpToken[];
+}
+
+export const KIND_LABEL: Record<SpTokenKind, string> = {
+  color: "Colours",
+  length: "Lengths",
+  number: "Numbers",
+  font: "Type",
+  family: "Families",
+  image: "Images",
+  filter: "Filters",
+  shadow: "Shadows",
+  other: "Other",
+  unset: "Unset",
+};
+
+/**
+ * The Tokens tab's groups: the `/* heading *\/` comments in `:root`, in the author's order, with
+ * the tokens before the first heading in an unnamed group ahead of them and the ones defined only
+ * under a scope (`.dark { --x }`) after. A board with no headings at all is grouped by kind.
+ */
+export function tokenGroups(tokens: SpToken[], groups: SpGroup[]): TokenGroupView[] {
+  const byName = new Map(tokens.map((t) => [t.name, t]));
+  const out: TokenGroupView[] = [];
+  if (groups.length) {
+    const leading = tokens.filter((t) => t.group === null && !t.scoped);
+    if (leading.length) out.push({ name: "", tokens: leading });
+    for (const g of groups) {
+      const list = g.tokens.map((n) => byName.get(n)).filter((t): t is SpToken => !!t);
+      if (list.length) out.push({ name: g.name, tokens: list });
+    }
+  } else {
+    const byKind = new Map<SpTokenKind, SpToken[]>();
+    for (const t of tokens) {
+      if (t.scoped) continue;
+      const list = byKind.get(t.kind) ?? [];
+      list.push(t);
+      byKind.set(t.kind, list);
+    }
+    for (const [kind, list] of byKind) out.push({ name: KIND_LABEL[kind], tokens: list });
+  }
+  const scoped = tokens.filter((t) => t.scoped);
+  if (scoped.length) out.push({ name: "Scoped only", tokens: scoped });
+  return out;
+}
+
+/**
+ * Tokens that reach the screen only through another token's declaration (`--sa-font` inside
+ * every `--sa-t-*`): the names of the used tokens that reference this one.
+ */
+export function tokenVia(token: SpToken, tokens: SpToken[]) {
+  if (token.usedBy.length) return [];
+  return tokens.filter((t) => t.usedBy.length && t.refs.includes(token.name)).map((t) => t.name);
+}
+
+/** Whether a value can be drawn as a swatch: a token of colour kind, or a colour-shaped string. */
+export function isColorValue(value: string, kind?: SpTokenKind) {
+  if (kind) return kind === "color";
+  return /^(#[0-9a-f]{3,8}|rgba?\(|hsla?\(|color\()/i.test(value.trim());
+}
+
+/**
+ * Properties worth listing even when nothing binds a token to them: the visible ones. Layout
+ * properties (position, width, flex, …) are in the boxes already and would drown the list.
+ */
+export const VISIBLE_PROPS = new Set([
+  "color",
+  "background",
+  "background-color",
+  "background-image",
+  "font",
+  "font-size",
+  "font-weight",
+  "font-family",
+  "line-height",
+  "letter-spacing",
+  "border",
+  "border-color",
+  "border-bottom",
+  "border-top",
+  "border-radius",
+  "box-shadow",
+  "opacity",
+  "padding",
+  "gap",
+  "fill",
+  "stroke",
+]);

--- a/canvas/src/inspectorModel.ts
+++ b/canvas/src/inspectorModel.ts
@@ -169,3 +169,58 @@ export const VISIBLE_PROPS = new Set([
   "fill",
   "stroke",
 ]);
+
+/**
+ * The image a selected layer draws, if it draws one. `uses` already carries the node indices
+ * behind every row — it is what the Assets tab highlights with — so the selection needs no
+ * second index of its own.
+ */
+export const assetForNode = (rows: AssetRow[], node: number | null): AssetRow | null =>
+  node === null ? null : (rows.find((a) => a.uses.includes(node)) ?? null);
+
+/* --- Panel geometry ---------------------------------------------------------------------- */
+
+/** Starting sizes. Every one of them is a drag away from something else. */
+export const PANEL_W = 736;
+export const RAIL_W = 280;
+
+/**
+ * How tall the layers list opens: a share of the window rather than a constant, because the
+ * boards here run to 24 layers and a fixed 240px showed nine of them on every screen size. Held
+ * off both ends — a short window still owes the properties below it room, and on a tall one a
+ * list past ~34 rows is scrolled, not read.
+ */
+export const initialLayersH = (viewport: number) => clamp(Math.round(viewport * 0.45), 200, 560);
+
+/** Drag limits, so a divider cannot swallow the thing on the other side of it. */
+const PANEL_MIN = 360;
+const RAIL_GAP = 280; // canvas left visible beside the panel
+const RAIL_MIN = 200;
+const STAGE_MIN = 240; // preview left visible beside the rail
+const LAYERS_MIN = 72;
+const LAYERS_GAP = 120; // properties left visible under the layers
+
+export const clamp = (v: number, lo: number, hi: number) =>
+  // lo wins a crossover: on a viewport too small for both bounds, a divider pinned to the
+  // minimum is usable, one pinned to a negative maximum is not.
+  Math.max(lo, Math.min(v, hi));
+
+/**
+ * Where a divider lands. The panel and the rail are both docked right, so their left edges
+ * resize them and a leftward drag — a negative dx — makes them wider. The layers list is above
+ * its divider, so it follows dy directly.
+ */
+export const nextPanelW = (start: number, dx: number, viewport: number) =>
+  clamp(start - dx, PANEL_MIN, viewport - RAIL_GAP);
+
+export const nextRailW = (start: number, dx: number, panelW: number) =>
+  clamp(start - dx, RAIL_MIN, panelW - STAGE_MIN);
+
+export const nextLayersH = (start: number, dy: number, viewport: number) =>
+  clamp(start + dy, LAYERS_MIN, viewport - LAYERS_GAP);
+
+/** Contain, never past 1:1 — a board blown up past its own pixels is blurrier, not bigger. */
+export const fitScale = (stage: { w: number; h: number }, board: { w: number; h: number }) => {
+  const pad = 32;
+  return Math.max(0.05, Math.min(1, (stage.w - pad) / board.w, (stage.h - pad) / board.h));
+};

--- a/canvas/src/virtual-canvases.d.ts
+++ b/canvas/src/virtual-canvases.d.ts
@@ -24,6 +24,13 @@ declare module "virtual:canvases" {
   /** Each folder's icon.png as an emitted asset URL, eager: read during render. */
   export const rawIcons: Record<string, string>;
   /**
+   * Per folder slug, `"<payload length>:<fnv1a>"` of a data: URI's base64 payload -> the file
+   * in that folder it was inlined from. Built from `assets/**`, `assets-dark/**` and
+   * `assets.json`, so it needs no attribute in the HTML and no regeneration; eager because it
+   * is small (about 60 bytes per asset) and read while a panel renders.
+   */
+  export const rawAssetNames: Record<string, Record<string, { name: string; bytes: number }>>;
+  /**
    * Absolute path the boards were actually read from, and `""` in a production build — the
    * bundle is public and this is the build machine's filesystem. EmptyLibraryNotice in App.tsx
    * shows it to a project that has no boards yet, because "which directory is this canvas

--- a/canvas/vite.config.ts
+++ b/canvas/vite.config.ts
@@ -81,14 +81,95 @@ const jsString = (value: string) =>
     .replace(/\u2029/g, "\\u2029")
     .replace(/</g, "\\u003c");
 
+/** Any JSON-serialisable value as a JavaScript literal, escaped the same way. */
+const jsLiteral = (value: unknown) =>
+  JSON.stringify(value)
+    .replace(/\u2028/g, "\\u2028")
+    .replace(/\u2029/g, "\\u2029")
+    .replace(/</g, "\\u003c");
+
 /** The historical key for a board, kept whatever directory it was actually read from. */
 const keyFor = (slug: string, file: string) => `../../mockups/canvases/${slug}/${file}`;
+
+const ASSET_MIME = new Set([".png", ".jpg", ".jpeg", ".webp", ".gif", ".svg"]);
+
+/**
+ * FNV-1a 32 over a string's code units, base 36. The inspector's agent runs the same function
+ * over the base64 payload of each data: URI inside the board, and joins on `length:hash`. A
+ * plain hash rather than SHA because the agent runs in a sandboxed frame with no `crypto.subtle`
+ * in every deployment, and this does 3 MB in about 12 ms.
+ */
+function fnv1a(s: string) {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < s.length; i++) h = Math.imul(h ^ s.charCodeAt(i), 0x01000193) >>> 0;
+  return h.toString(36);
+}
+
+interface AssetName {
+  /** Path inside the board folder, `assets/art/hero.png`, or `assets.json#key`. */
+  name: string;
+  /** Decoded size, i.e. the file's own byte count. */
+  bytes: number;
+}
+
+/**
+ * `length:hash` of the base64 payload -> the source file, for every image a folder's generator
+ * could have inlined: `assets/**`, `assets-dark/**` and the values of `assets.json`. `refs/` is
+ * skipped because it holds third-party captures that are never committed. A generator that
+ * re-encodes on the way (a PIL resize) produces bytes that match nothing here, and the
+ * inspector then falls back to the image's alt text.
+ */
+function assetIndex(folder: string): Record<string, AssetName> {
+  const out: Record<string, AssetName> = {};
+  const add = (payload: string, name: string, bytes: number) => {
+    const key = `${payload.length}:${fnv1a(payload)}`;
+    if (!(key in out)) out[key] = { name, bytes };
+  };
+  const walk = (dir: string, rel: string) => {
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const e of entries) {
+      if (e.name.startsWith(".")) continue;
+      const p = path.join(dir, e.name);
+      if (e.isDirectory()) {
+        if (e.name !== "refs") walk(p, `${rel}${e.name}/`);
+        continue;
+      }
+      if (!ASSET_MIME.has(path.extname(e.name).toLowerCase())) continue;
+      const buf = fs.readFileSync(p);
+      add(buf.toString("base64"), rel + e.name, buf.length);
+    }
+  };
+  for (const sub of ["assets", "assets-dark"]) walk(path.join(folder, sub), `${sub}/`);
+  const json = path.join(folder, "assets.json");
+  if (fs.existsSync(json)) {
+    try {
+      const map: unknown = JSON.parse(fs.readFileSync(json, "utf8"));
+      if (map && typeof map === "object") {
+        for (const [key, v] of Object.entries(map)) {
+          if (typeof v !== "string" || !v.startsWith("data:")) continue;
+          const payload = v.slice(v.indexOf(",") + 1);
+          const pad = payload.endsWith("==") ? 2 : payload.endsWith("=") ? 1 : 0;
+          add(payload, `assets.json#${key}`, Math.floor((payload.length * 3) / 4) - pad);
+        }
+      }
+    } catch {
+      // a malformed assets.json names nothing; the boards still render
+    }
+  }
+  return out;
+}
 
 interface Board {
   slug: string;
   html: string[];
   layout: boolean;
   icon: boolean;
+  assets: Record<string, AssetName>;
 }
 
 /**
@@ -140,6 +221,7 @@ function scan(dir: string): Board[] {
           .sort(),
         layout: fs.existsSync(path.join(folder, "layout.json")),
         icon: fs.existsSync(path.join(folder, "icon.png")),
+        assets: assetIndex(folder),
       };
     })
     .filter((b): b is Board => b !== null && b.html.length > 0);
@@ -182,6 +264,7 @@ function canvasesSource(): Plugin {
       const loaders: string[] = [];
       const layouts: string[] = [];
       const icons: string[] = [];
+      const assets: string[] = [];
 
       boards.forEach((board, i) => {
         const folder = path.join(canvasesDir, board.slug);
@@ -200,6 +283,9 @@ function canvasesSource(): Plugin {
           imports.push(`import __icon${i} from ${spec(path.join(folder, "icon.png"), "?url")};`);
           icons.push(`  ${jsString(keyFor(board.slug, "icon.png"))}: __icon${i},`);
         }
+        if (Object.keys(board.assets).length) {
+          assets.push(`  ${jsString(board.slug)}: ${jsLiteral(board.assets)},`);
+        }
       });
 
       return [
@@ -213,6 +299,7 @@ function canvasesSource(): Plugin {
         `export const fileLoaders = {\n${loaders.join("\n")}\n};`,
         `export const rawLayouts = {\n${layouts.join("\n")}\n};`,
         `export const rawIcons = {\n${icons.join("\n")}\n};`,
+        `export const rawAssetNames = {\n${assets.join("\n")}\n};`,
       ].join("\n");
     },
 
@@ -229,7 +316,9 @@ function canvasesSource(): Plugin {
 
       const inside = (p: string) => p.startsWith(canvasesDir + path.sep);
       const structural = (file: string) =>
-        inside(file) && /(\.html|layout\.json|icon\.png)$/.test(file);
+        inside(file) &&
+        (/(\.html|layout\.json|icon\.png|assets\.json)$/.test(file) ||
+          /\/assets(-dark)?\//.test(file));
 
       const rebuild = () => {
         const mod = server.moduleGraph.getModuleById(RESOLVED_ID);
@@ -249,6 +338,11 @@ function canvasesSource(): Plugin {
 
       server.watcher.on("add", onFile);
       server.watcher.on("unlink", onFile);
+      // An asset edited in place keeps its name and changes its hash, so the index is stale
+      // until the module is rebuilt. Board HTML edits already reload through the module graph.
+      server.watcher.on("change", (file) => {
+        if (inside(file) && /\/assets(-dark)?\/|assets\.json$/.test(file)) rebuild();
+      });
       server.watcher.on("addDir", onDir);
       server.watcher.on("unlinkDir", onDir);
     },

--- a/docs/2026-09-07-asset-naming.md
+++ b/docs/2026-09-07-asset-naming.md
@@ -1,0 +1,435 @@
+<!-- Written 2026-09-07 while the inspector panel was still a spike (see
+2026-09-07-inspector-panel-feasibility.md, section 5, item 2). Kept because the measurements
+in section 3 settle a question that would otherwise be re-argued from first principles. -->
+
+# Naming the images in the inspector's Assets tab
+
+**Date:** 2026-09-07
+**Question:** a board's images reach the canvas as anonymous `data:` URIs. How does the
+Assets tab put a filename next to each one, for all 180 boards, without asking authors to
+remember anything?
+
+## 1. Recommendation
+
+**Match by content, at build time, against the files the folder already commits.** The
+`prototyping-canvases` plugin hashes every image under `<slug>/assets/**`, `assets-dark/**`
+and every `data:` value in `assets.json`, and exports `rawAssetNames` — per folder, a map
+from `"<payload length>:<fnv1a>"` of the base64 payload to `{ name, bytes }`. The inspector's
+agent hashes each image it finds the same way and the parent joins the two. Nothing in the
+HTML changes, no generator is re-run, and there is nothing new for an author to do: the file
+they inlined is the name.
+
+Measured on the repo as committed:
+
+| | named | of | |
+|---|---|---|---|
+| `<img>` elements | **518** | 606 | 85.5 % |
+| CSS `url(data:)` backgrounds | **214** | 214 | 100 %, and the spike never counted these |
+| boards with images | 80 | 82 | every image named |
+| folders | 11 | 13 | |
+
+The 88 unnamed images are all in two folders whose generators re-encode through PIL on the
+way in (`apple-icons`, 86; `00-welcome`, 2), so the bytes on the board match no file. 87 of
+those 88 carry `alt` text that *is* the name (`alt="Find My"` for `assets/FindMy.png`), which
+is the fallback. Zero hash collisions across the 441 distinct URIs in the corpus. Cost: 127 ms
+once at dev-server start, 31 KB in the eager bundle for this repo's 494 assets, no change to
+install size.
+
+It beats the alternatives because it is the only one that is right for boards nobody re-runs.
+Option (a), an attribute emitted by `gen.py`, names nothing on any of the 82 image-bearing
+boards until its folder is regenerated, and one folder (`luma-ios`, 12 of those boards)
+cannot be regenerated from a checkout at all. It also cannot name the 214 CSS backgrounds,
+which have no element to carry an attribute. Option (b) as literally posed — expose the
+committed `assets.json` — covers 3 of 13 folders. Details in section 4.
+
+## 2. What is actually there
+
+Facts that changed the shape of the answer, all re-verified:
+
+- **`assets.json` is not measurement evidence.** The README and `layout.md` say it is, but
+  the three that exist (`claude-ios`, `luma-ios`, `templates`) are `{ "<key>": "data:…" }`
+  maps: pre-encoded bitmaps a generator reads and drops into `src` unchanged. The other ten
+  image folders have an `assets/` directory instead, and their generator base64-encodes the
+  file at build time. Both are joinable by content; neither is joinable by anything else.
+- **Every generator funnels images through one helper** (`img(name)`, `uri(path)`,
+  `art(id)`) that takes a filename and returns a data URI. The name is known at generation
+  time; it is simply not written out. 11 of 13 helpers pass the bytes through verbatim.
+- **Two helpers transform.** `apple-icons/gen.py` `icon_uri` resizes to `ICON_PX` with
+  LANCZOS and re-saves; `00-welcome/gen.py` crops, resizes and re-encodes the banner as JPEG.
+- **Images are not only `<img>`.** 214 `background: url(data:…)` declarations on 19 boards
+  (`duolingo-ios/00d-art` alone has 128; the three `luma-ios` home boards have 17 each).
+- **`notion-ios` and `raycast-ios` have no `gen.py`** and no images. Nothing to name.
+- **`assets/refs/` is gitignored** and holds third-party captures. The index skips it, and
+  the 3 evidence boards that embed images (56 of them) all matched committed files anyway.
+- **The spike already posts every `<img>`'s full `src`** to the parent (`nodes[i].src`), so
+  the byte volume of the join was already being paid.
+
+## 3. Measurements
+
+Scripts under `scratch/asset-naming/` (gitignored). Boards are `mockups/canvases/*/[0-9]*.html`.
+
+**Join rate, by content** (`match.py`, `css.py`):
+
+```
+folder            imgs  named  alt         folder            imgs  named  alt
+00-welcome           2      0    1         claude-ios           3      3    3
+apple-calendar       2      2    0         duolingo-ios       147    147    3
+apple-home-lock    106    106    0         luma-ios            20     20    0
+apple-icons         86      0   86         snapaction-ios     100    100    3
+apple-photos        11     11    0         spotify-ios         65     65    0
+apple-settings      14     14    0         templates            7      7    7
+apple-wallet        17     17    0
+```
+
+415 distinct `<img>` URIs, 67 reused on more than one board, 0 matched across folders.
+
+**Join key** — collisions among the 441 distinct payloads (img and CSS):
+
+| key | collisions |
+|---|---|
+| payload length | 24 |
+| length + first 80 chars (what the spike sends as `key`) | 1 |
+| FNV-1a 32 | 0 |
+| length + FNV-1a 32 (recommended) | 0 |
+| SHA-256 | 0 |
+
+FNV-1a rather than SHA because the sandboxed frame does not always have `crypto.subtle`:
+it does under a `127.0.0.1` parent (`isSecureContext` true, measured), it does not under an
+`about:blank` or plain-http parent. FNV-1a in the frame costs 12 ms per 3 MB payload and
+7–28 ms for a whole board, and produces the same value as Python and Node bit for bit
+(checked on the same payload from three runtimes).
+
+**Build cost** (`timing.mjs`, `loadvirtual.mjs`): 455 files, 13.2 MB of assets. base64 5 ms,
+FNV over the base64 26 ms (Bun), 22 ms (Node 26). The full virtual module, loaded through
+Vite's own `createServer` with the patched config: **127 ms**, `rawAssetNames` 31,608 bytes
+for 494 entries in 13 folders. The module is loaded once and again on structural change.
+`bunx tsc -b --noEmit` and `bunx vite build` both pass with the patch applied.
+
+**End to end** (`agent_e2e.py`): the agent snippet in section 5 injected into real boards in
+a `sandbox="allow-scripts"` frame under real Chrome, joined against the same index:
+
+| board | assets | named | hashing |
+|---|---|---|---|
+| `snapaction-ios/01-timeline` | 25 | 25 (`assets/art/sb-a.png`, `01-hbl.png`, …) | 7 ms |
+| `luma-ios/11-home-nearby` | 18 | 18 (1 img, 17 CSS, all `assets.json#home_*`) | 20 ms |
+| `claude-ios/13-photo-attached` | 1 | 1 (`assets.json#photo`) | 11 ms |
+| `apple-icons/00-icon-set` | 43 | 0, all 43 have `alt` | 28 ms |
+
+**What option (a) would cost** (`rerun.sh`): each folder copied to `scratch/`, its `gen.py`
+run there with the `tools/.venv` Python, output compared to the committed boards.
+
+- 12 of 14 generators run and reproduce every board **byte for byte** — so regeneration is
+  safe and deterministic where it is possible.
+- `luma-ios` fails: it needs `refassets.json`, which is gitignored. Its 12 image-bearing
+  boards cannot be regenerated from a checkout.
+- `00-welcome` failed only because the copy broke its `../../../assets/banner.webp` path;
+  in place it runs.
+- 82 boards carry images and would need regenerating; a board not re-run names nothing.
+- Byte cost is not the problem: `data-asset="…"` on every `<img>` adds about 20 KB to
+  29.3 MB of committed HTML.
+- A `;name=` parameter in the data URI (`data:image/png;name=hero.png;base64,…`) renders
+  fine in Chrome, in `<img>` and in CSS `url()` (measured, `nameparam.py`), and could be
+  added inside each generator's helper with no call-site changes. But it is still a
+  regeneration, and it is a convention every future `gen.py` has to know.
+
+## 4. Alternatives, and why not
+
+**(a) `gen.py` emits a name.** Correct only after regeneration; 82 boards affected, 12 of
+them impossible to regenerate; cannot name CSS backgrounds; a convention for authors to
+carry. Its one advantage, that it works for a transformed image, covers 88 of 606 images and
+87 of those already have `alt`. Not worth it as the primary path. It remains a fine
+*addition* for a generator that transforms: any `<img alt>` is the fallback, and that is
+what those two generators already emit.
+
+**(b) expose `assets.json` alone.** 3 of 13 folders have one. Correct for them, silent for
+the rest. The recommendation is (b) generalised to what folders actually contain.
+
+**(c) parse in the parent with `DOMParser` instead of the agent.** The parent holds the HTML
+string, so it could extract URIs without the frame at all. Rejected as the *primary* path
+because it cannot give `naturalWidth`/`naturalHeight` without decoding each image a second
+time, and cannot see CSS backgrounds without computing styles. It is a good fallback for
+the reuse count across boards: the plugin could scan all HTML at load (85 ms for 29.3 MB,
+measured) and export per-asset board counts, if that column earns its place.
+
+**(d) a Vite middleware serving the index on request.** Works in dev, does nothing on the
+hosted static build. The virtual module works in both.
+
+## 5. Change list
+
+Nothing below is applied. The plugin diff was applied, checked, and reverted; it is in full
+in the appendix and in `scratch/asset-naming/plugin.diff`.
+
+**`canvas/vite.config.ts`** — appendix. In short:
+- `jsLiteral(value)`: `jsString` generalised to any JSON value, same U+2028/U+2029/`<`
+  escaping, because file names come off the filesystem.
+- `fnv1a`, `AssetName`, `assetIndex(folder)`: walks `assets/` and `assets-dark/` (skipping
+  `refs/` and dot-files), reads `assets.json`, keys by `"<length>:<fnv1a>"`, first name wins.
+- `Board.assets`, filled by `scan()`; `load()` emits
+  `export const rawAssetNames = { "<slug>": {…}, … }`, keyed by slug, folders with no assets
+  omitted.
+- Watcher: `structural()` also matches `assets.json` and anything under `assets/`; a new
+  `change` listener rebuilds the module when an asset is edited in place, since a renamed
+  file keeps its name and changes its hash.
+
+**`canvas/src/virtual-canvases.d.ts`** — appendix. One export:
+`rawAssetNames: Record<string, Record<string, { name: string; bytes: number }>>`.
+
+**`canvas/src/canvasLibrary.ts`** — an accessor beside `readCanvasLayout`:
+
+```ts
+import { fileLoaders, rawLayouts, rawIcons, rawAssetNames } from "virtual:canvases";
+
+/** This folder's inlined images by payload key, if it committed the files they came from. */
+export function readCanvasAssetNames(pageSlug: string) {
+  return rawAssetNames[pageSlug];
+}
+```
+
+**`canvas/src/InspectorPanel.tsx`** (not touched here; owned by the panel work). The agent's
+`measure()` computes the key the index uses and also reports CSS backgrounds:
+
+```js
+function fnv(s){var h=0x811c9dc5;for(var i=0;i<s.length;i++){h=Math.imul(h^s.charCodeAt(i),0x01000193)>>>0;}return h.toString(36);}
+function key(uri){var p=uri.slice(uri.indexOf(',')+1);return p.length+':'+fnv(p);}
+/* in measure(): */
+var assets=[];
+for(var i=0;i<els.length;i++){var el=els[i];
+  if(el.tagName==='IMG'){var src=el.getAttribute('src')||'';
+    if(src.indexOf('data:')===0)assets.push({i:i,key:key(src),via:'img',mime:src.slice(5,src.indexOf(';')),
+      chars:src.length,w:el.naturalWidth,h:el.naturalHeight,alt:el.getAttribute('alt')||''});}
+  var bg=getComputedStyle(el).backgroundImage,m=/url\("?(data:image[^")]+)"?\)/.exec(bg);
+  if(m)assets.push({i:i,key:key(m[1]),via:'css',mime:m[1].slice(5,m[1].indexOf(';')),chars:m[1].length,w:0,h:0,alt:''});}
+```
+
+`nodes[i].src` then no longer needs to carry the full URI; `key` is 15 characters. The parent
+groups by `key` and resolves:
+
+```ts
+const names = readCanvasAssetNames(pageSlug);
+const groups = new Map<string, { name: string; bytes: number; w: number; h: number; mime: string; uses: number[] }>();
+for (const a of data.assets) {
+  const hit = names?.[a.key];
+  const g = groups.get(a.key) ?? {
+    name: hit?.name ?? (a.alt || `${a.mime.replace("image/", "")} ${a.w}×${a.h}`),
+    bytes: hit?.bytes ?? Math.floor((a.chars * 3) / 4),
+    w: a.w, h: a.h, mime: a.mime, uses: [],
+  };
+  g.uses.push(a.i);
+  groups.set(a.key, g);
+}
+```
+
+That gives each row: name (file, else alt, else `png 160×160`), byte size (the file's, else
+decoded length), dimensions, format, on-board reuse count, and the layers that use it (the
+`uses` indices select in the layer list). The name is italicised or otherwise marked when it
+came from the fallback, so an unnamed image is not passed off as a named one.
+
+**Docs.** `mockups/canvases/README.md` and `skills/prototype-canvas/references/layout.md`
+both call `assets.json` "measurement evidence". It is an inlined-asset map; say so, and say
+that the inspector names images from `assets/` and `assets.json`, so a generator that wants
+its images named inlines the file as it is. Keep the two in step.
+
+**Regeneration:** none.
+
+## 6. What it still cannot do
+
+- **Name a transformed image.** 88 of 606 today, in `apple-icons` (resized) and
+  `00-welcome` (cropped and re-encoded). 87 have `alt`; the one that does not is the
+  welcome mark. A generator that transforms can add `alt`, or an author can commit the
+  post-transform bytes; the plugin will not guess.
+- **Name an image whose source is not committed.** By design: `assets/refs/` is skipped
+  because those files are not in the repo, so a board built from them shows the fallback
+  even on the machine that has them. Today that is zero images.
+- **Tell two identical files apart.** First name wins. `duolingo-ios` commits `assets/art`
+  and `assets/art-gen`; where a file is byte-identical in both the tab shows the first.
+  Zero cases today across folders, not measured within one.
+- **Count reuse across boards.** The agent sees one board. 67 of 415 URIs recur on other
+  boards; the plugin could scan all HTML at load for 85 ms to say so, if the column matters.
+- **Help the 98 image-free boards.** Empty tab, as before. That is the boards, not the tab.
+- **Survive plain-http hosting for `crypto.subtle`** — irrelevant to this design, which is
+  why FNV-1a was chosen, but worth restating: nothing here needs a secure context.
+- **Show anything for a board that is not on disk as files.** `notion-ios` and `raycast-ios`
+  have hand-written HTML and no assets folder; they also have no images.
+
+## 7. Appendix: the checked plugin diff
+
+Applied to `canvas/vite.config.ts` and `canvas/src/virtual-canvases.d.ts`, passed `tsc -b`,
+`vite build`, and a `createServer` load of the generated module, then reverted.
+
+```diff
+diff --git a/canvas/src/virtual-canvases.d.ts b/canvas/src/virtual-canvases.d.ts
+index b2a5dad..6af6119 100644
+--- a/canvas/src/virtual-canvases.d.ts
++++ b/canvas/src/virtual-canvases.d.ts
+@@ -23,6 +23,13 @@ declare module "virtual:canvases" {
+   export const rawLayouts: Record<string, CanvasLayoutConfig>;
+   /** Each folder's icon.png as an emitted asset URL, eager: read during render. */
+   export const rawIcons: Record<string, string>;
++  /**
++   * Per folder slug, `"<payload length>:<fnv1a>"` of a data: URI's base64 payload -> the file
++   * in that folder it was inlined from. Built from `assets/**`, `assets-dark/**` and
++   * `assets.json`, so it needs no attribute in the HTML and no regeneration; eager because it
++   * is small (about 60 bytes per asset) and read while a panel renders.
++   */
++  export const rawAssetNames: Record<string, Record<string, { name: string; bytes: number }>>;
+   /**
+    * Absolute path the boards were actually read from, and `""` in a production build — the
+    * bundle is public and this is the build machine's filesystem. EmptyLibraryNotice in App.tsx
+diff --git a/canvas/vite.config.ts b/canvas/vite.config.ts
+index 8da59d7..84c4083 100644
+--- a/canvas/vite.config.ts
++++ b/canvas/vite.config.ts
+@@ -81,14 +81,95 @@ const jsString = (value: string) =>
+     .replace(/\u2029/g, "\\u2029")
+     .replace(/</g, "\\u003c");
+ 
++/** Any JSON-serialisable value as a JavaScript literal, escaped the same way. */
++const jsLiteral = (value: unknown) =>
++  JSON.stringify(value)
++    .replace(/\u2028/g, "\\u2028")
++    .replace(/\u2029/g, "\\u2029")
++    .replace(/</g, "\\u003c");
++
+ /** The historical key for a board, kept whatever directory it was actually read from. */
+ const keyFor = (slug: string, file: string) => `../../mockups/canvases/${slug}/${file}`;
+ 
++const ASSET_MIME = new Set([".png", ".jpg", ".jpeg", ".webp", ".gif", ".svg"]);
++
++/**
++ * FNV-1a 32 over a string's code units, base 36. The inspector's agent runs the same function
++ * over the base64 payload of each data: URI inside the board, and joins on `length:hash`. A
++ * plain hash rather than SHA because the agent runs in a sandboxed frame with no `crypto.subtle`
++ * in every deployment, and this does 3 MB in about 12 ms.
++ */
++function fnv1a(s: string) {
++  let h = 0x811c9dc5;
++  for (let i = 0; i < s.length; i++) h = Math.imul(h ^ s.charCodeAt(i), 0x01000193) >>> 0;
++  return h.toString(36);
++}
++
++interface AssetName {
++  /** Path inside the board folder, `assets/art/hero.png`, or `assets.json#key`. */
++  name: string;
++  /** Decoded size, i.e. the file's own byte count. */
++  bytes: number;
++}
++
++/**
++ * `length:hash` of the base64 payload -> the source file, for every image a folder's generator
++ * could have inlined: `assets/**`, `assets-dark/**` and the values of `assets.json`. `refs/` is
++ * skipped because it holds third-party captures that are never committed. A generator that
++ * re-encodes on the way (a PIL resize) produces bytes that match nothing here, and the
++ * inspector then falls back to the image's alt text.
++ */
++function assetIndex(folder: string): Record<string, AssetName> {
++  const out: Record<string, AssetName> = {};
++  const add = (payload: string, name: string, bytes: number) => {
++    const key = `${payload.length}:${fnv1a(payload)}`;
++    if (!(key in out)) out[key] = { name, bytes };
++  };
++  const walk = (dir: string, rel: string) => {
++    let entries: fs.Dirent[];
++    try {
++      entries = fs.readdirSync(dir, { withFileTypes: true });
++    } catch {
++      return;
++    }
++    for (const e of entries) {
++      if (e.name.startsWith(".")) continue;
++      const p = path.join(dir, e.name);
++      if (e.isDirectory()) {
++        if (e.name !== "refs") walk(p, `${rel}${e.name}/`);
++        continue;
++      }
++      if (!ASSET_MIME.has(path.extname(e.name).toLowerCase())) continue;
++      const buf = fs.readFileSync(p);
++      add(buf.toString("base64"), rel + e.name, buf.length);
++    }
++  };
++  for (const sub of ["assets", "assets-dark"]) walk(path.join(folder, sub), `${sub}/`);
++  const json = path.join(folder, "assets.json");
++  if (fs.existsSync(json)) {
++    try {
++      const map: unknown = JSON.parse(fs.readFileSync(json, "utf8"));
++      if (map && typeof map === "object") {
++        for (const [key, v] of Object.entries(map)) {
++          if (typeof v !== "string" || !v.startsWith("data:")) continue;
++          const payload = v.slice(v.indexOf(",") + 1);
++          const pad = payload.endsWith("==") ? 2 : payload.endsWith("=") ? 1 : 0;
++          add(payload, `assets.json#${key}`, Math.floor((payload.length * 3) / 4) - pad);
++        }
++      }
++    } catch {
++      // a malformed assets.json names nothing; the boards still render
++    }
++  }
++  return out;
++}
++
+ interface Board {
+   slug: string;
+   html: string[];
+   layout: boolean;
+   icon: boolean;
++  assets: Record<string, AssetName>;
+ }
+ 
+ /**
+@@ -140,6 +221,7 @@ function scan(dir: string): Board[] {
+           .sort(),
+         layout: fs.existsSync(path.join(folder, "layout.json")),
+         icon: fs.existsSync(path.join(folder, "icon.png")),
++        assets: assetIndex(folder),
+       };
+     })
+     .filter((b): b is Board => b !== null && b.html.length > 0);
+@@ -182,6 +264,7 @@ function canvasesSource(): Plugin {
+       const loaders: string[] = [];
+       const layouts: string[] = [];
+       const icons: string[] = [];
++      const assets: string[] = [];
+ 
+       boards.forEach((board, i) => {
+         const folder = path.join(canvasesDir, board.slug);
+@@ -200,6 +283,9 @@ function canvasesSource(): Plugin {
+           imports.push(`import __icon${i} from ${spec(path.join(folder, "icon.png"), "?url")};`);
+           icons.push(`  ${jsString(keyFor(board.slug, "icon.png"))}: __icon${i},`);
+         }
++        if (Object.keys(board.assets).length) {
++          assets.push(`  ${jsString(board.slug)}: ${jsLiteral(board.assets)},`);
++        }
+       });
+ 
+       return [
+@@ -213,6 +299,7 @@ function canvasesSource(): Plugin {
+         `export const fileLoaders = {\n${loaders.join("\n")}\n};`,
+         `export const rawLayouts = {\n${layouts.join("\n")}\n};`,
+         `export const rawIcons = {\n${icons.join("\n")}\n};`,
++        `export const rawAssetNames = {\n${assets.join("\n")}\n};`,
+       ].join("\n");
+     },
+ 
+@@ -229,7 +316,9 @@ function canvasesSource(): Plugin {
+ 
+       const inside = (p: string) => p.startsWith(canvasesDir + path.sep);
+       const structural = (file: string) =>
+-        inside(file) && /(\.html|layout\.json|icon\.png)$/.test(file);
++        inside(file) &&
++        (/(\.html|layout\.json|icon\.png|assets\.json)$/.test(file) ||
++          /\/assets(-dark)?\//.test(file));
+ 
+       const rebuild = () => {
+         const mod = server.moduleGraph.getModuleById(RESOLVED_ID);
+@@ -249,6 +338,11 @@ function canvasesSource(): Plugin {
+ 
+       server.watcher.on("add", onFile);
+       server.watcher.on("unlink", onFile);
++      // An asset edited in place keeps its name and changes its hash, so the index is stale
++      // until the module is rebuilt. Board HTML edits already reload through the module graph.
++      server.watcher.on("change", (file) => {
++        if (inside(file) && /\/assets(-dark)?\/|assets\.json$/.test(file)) rebuild();
++      });
+       server.watcher.on("addDir", onDir);
+       server.watcher.on("unlinkDir", onDir);
+     },
+```

--- a/docs/2026-09-07-inspector-panel-feasibility.md
+++ b/docs/2026-09-07-inspector-panel-feasibility.md
@@ -1,0 +1,111 @@
+<!-- Written 2026-09-07 after building the inspector panel design as a throwaway spike on
+canvas/ and driving it in a real browser. Kept because sections 3 and 5 are the parts a
+future implementation will otherwise rediscover the hard way. Nothing here shipped yet. -->
+
+# Inspecting a board from the canvas: what a spike found
+
+**Date:** 2026-09-07
+**Context:** the accepted design is a docked right-hand panel — a large preview of the clicked
+board on the left, a fixed rail on the right with layers, properties, assets and tokens.
+**Question asked:** does it work against the canvas as `main` has it today?
+
+---
+
+## 1. Executive summary
+
+It works. A click on a locked board opens the panel, the panel squeezes the canvas without
+breaking tldraw, and a second iframe reads a board the canvas itself deliberately cannot —
+72 layers, 25 assets, 89 tokens and a measured `440 × 956` off `snapaction-ios/01-timeline`.
+Swept across all 180 boards in the repo, every one reports.
+
+Three bugs turned up on the way, all now fixed in the spike, all of which any implementation
+would have hit. The remaining work is design, not feasibility: the layer list does not scale
+to the biggest boards, half the boards have no assets to show, image assets cannot be named,
+and the preview stage assumes every board is phone-shaped.
+
+## 2. What was built
+
+`canvas/src/InspectorPanel.tsx` (new, uncommitted), plus edits to `App.tsx` and `index.css`.
+It is a spike: it exists to answer questions, not to ship. It still carries an `?inspect=<board>`
+deep link added for the probes, and it draws only the Inspect tab of the design.
+
+The probes are `scratch/spike/*.py`, driving real Chrome through Playwright.
+
+## 3. The three bugs
+
+**A frame that stays blank forever.** The panel was intermittently stuck on "reading board…"
+with a frame whose document was literally `<html><head></head><body></body></html>`, even
+though its `srcdoc` attribute held all 73 KB. Reassigning the *same* srcdoc from the console
+brought it instantly to life.
+
+`useCanvasFileHtml` resolves asynchronously whenever the board's chunk is not cached, so React
+mounts the iframe with `srcdoc=""` and mutates the attribute a tick later — and Chrome drops
+that second navigation while the first is still pending. It only looked intermittent because a
+warm cache hides it: click a board the canvas has already drawn and it works, deep-link
+straight into one and it never loads. The fix is to not render the frame until the HTML is
+there, keyed by path, so the element is *created* with its final srcdoc.
+
+**Every measurement was zero.** A script at the end of the body runs at `readyState:
+'interactive'` — before the first layout pass, and before the data: URIs have decoded. Boxes
+read there are `0×0` for every element on every board, which is what the properties panel was
+faithfully displaying. Measured across the repo, 113 of 180 boards reported a `0×0` artboard.
+Boxes have to be read on `load` and again on the frame after it; the agent now marks elements
+up front (indices are layout-independent) and measures at send time.
+
+**Not every board has a `</body>`.** The `apple-*` generators emit none. An injector that
+splices on `</body>` silently does nothing for them, so the fallback that appends is load
+bearing, not defensive.
+
+Two smaller ones, worth knowing:
+
+- `sp:ready` is fire-and-forget, so it is lost for good if it arrives before the parent's
+  listener attaches. The frame's `onLoad` asking again covers it.
+- Reading `event.source.name` on the frame throws — an opaque-origin window exposes almost
+  nothing. Identity has to be `event.source === frame.contentWindow`, which does work.
+
+## 4. What the sweep says about the boards
+
+The shipped agent run against every board (`scratch/spike/sweep.py`):
+
+| | min | median | max |
+|---|---|---|---|
+| elements per board | 7 | 76 | 352 |
+| `:root` tokens per board | 7 | 67 | 89 |
+
+- 180 of 180 boards report. 0 measure `0×0` after the fix.
+- 98 of 180 boards contain no images at all.
+- 606 images across the repo, 103 of them with alt text. The rest are anonymous data URIs.
+- 10 distinct artboard sizes, and not all of them are phones: the evidence boards measure
+  around `2152 × 460`.
+
+## 5. What the design still has to answer
+
+1. **The layer list does not scale.** The median board is 76 elements, but
+   `luma-ios/11-home-nearby` is 352 and the design-token boards are around 290. A flat
+   scrolling list of 294 rows labelled `card`, `a`, `pill` is not navigable. It needs the tree
+   with collapsing, or a filter down to text and image nodes.
+2. **Assets cannot be named, and half the boards have none.** The panel can honestly show
+   dimensions, bytes and reuse count, but not filenames, unless `gen.py` emits names or the
+   Vite plugin exposes `assets.json` — `virtual:canvases` currently gives only `fileLoaders`,
+   `rawLayouts`, `rawIcons`. For 98 boards the tab is empty either way.
+3. **A token resolves to the wrong value.** The spike prints the element's computed `color`
+   next to whichever `var()` it finds, so `background:var(--sa-amber)` shows
+   `rgb(247,246,242)` — the text colour — instead of `rgb(240,164,104)`. Resolution has to be
+   per declaration, not per element.
+4. **The preview scale is a constant.** At 85% the board overflows the stage by 33px at
+   1024×768 and wastes 142px at 1728×1117. "As large as possible" means fit-to-height computed
+   from the stage — and the stage has to cope with a `2152 × 460` board, not just phones.
+5. **The camera does not move.** Opening the panel leaves the clicked board wherever it was at
+   19% zoom, often behind the panel.
+6. **Narrow viewports are undefined.** At 390px the 736px panel is wider than the window and
+   the canvas collapses to 0px.
+
+Still open from the design review: whether the panel squeezes the canvas or floats over it.
+The squeeze is what was measured here, and it costs a lot — the canvas drops to 703px at a
+1440px viewport and to 287px at 1024px.
+
+## 6. Checks
+
+`tsc -b` clean. `bun run build` succeeds. `oxlint` reports three warnings, all spike-level:
+`only-export-components`, one useless escape, and a `set-state-in-effect` that a `key={path}`
+on the panel would remove.

--- a/docs/2026-09-07-token-resolution.md
+++ b/docs/2026-09-07-token-resolution.md
@@ -1,0 +1,388 @@
+<!-- Written 2026-09-07 after the inspector-panel spike showed `--sa-amber -> rgb(247,246,242)`
+for an element whose amber is its background. Kept because the numbers in section 3 decide the
+design, and because section 5 is the code that has to live inside the injected agent. -->
+
+# Resolving a board's tokens from inside the inspector frame
+
+**Date:** 2026-09-07
+**Context:** the inspector panel (`docs/2026-09-07-inspector-panel-feasibility.md`) promises
+"token name above its resolved value" for a selected element. The spike regexes `var(--x)` out
+of the inline `style` attribute and prints the element's computed `color` next to whatever it
+finds, so `background:var(--sa-amber)` shows the text colour.
+**Question asked:** what should the agent compute, so that a person reading the panel can tell
+which token drives which visible property, and where must it admit it cannot know?
+
+Everything below was measured against all 180 boards in `mockups/canvases/*/[0-9]*.html`,
+in real Chrome, inside a `sandbox="allow-scripts"` frame exactly as the panel loads them.
+The scripts are in `scratch/token-resolution/` (gitignored): `census.py` and `census2.py` are
+the static counts, `cssom.py` is the CSSOM experiment, `resolver.js` is the agent code,
+`sweep.py` runs it on every element of every board, `cases.py`, `inh_case.py` and `inherit.py`
+are the targeted checks.
+
+---
+
+## 1. Recommendation
+
+**Bind per declaration from the cascade, resolve each token on the element, and confirm the
+binding with a probe element.** Concretely, for a selected element the agent:
+
+1. Collects every declaration that mentions `var()` and reaches the element: from the inline
+   `style` attribute *and* from every `<style>` rule whose selector the element `matches()`.
+   Each declaration is split property by property, so a `var()` is bound to its own property.
+2. Resolves each token with `getComputedStyle(el).getPropertyValue('--x')` — on the element,
+   not on `:root`. That returns the token's fully substituted value (`#F0A468`, or
+   `590 18px/18px -apple-system,…` for a type token defined through `--sa-font`), and it is the
+   only call that honours a scoped redefinition like `.dark{--hs-grey3:#464649}`.
+3. Sets the same declaration, with the tokens substituted, on a hidden zero-sized probe, and
+   reads which longhands that produced (`background` → `background-color`; `font` → weight,
+   size, line-height, family; `border` → twelve sides) and their values. Comparing those to the
+   element's own computed longhands proves whether the token actually reached the screen.
+4. Reports one of three states per binding. **applied** — every longhand the declaration sets
+   matches the element. **partial** — some do, and the declaration that took the rest is named
+   (`table.ev td.n font-family: ui-monospace, Menlo, monospace`). **overridden** — none do, and
+   the winner is named (`inline border-bottom: none`).
+5. For inherited properties the element does not bind itself (`color`, `font-*`,
+   `letter-spacing`, …) walks up and reports the nearest ancestor's binding, tagged with where
+   it came from (`color ← --l-ink, inherited from div.phone`).
+
+Why this and not the alternatives the brief listed:
+
+- **(a) Parse the inline style per declaration, then read `getComputedStyle(el)[prop]`.**
+  Necessary but not sufficient. Only 12% of bindings on these boards come from the inline
+  attribute; 88% reach the element through a `<style>` rule (`.card{background:var(--sa-card)}`,
+  `.phone{width:var(--sa-w)}`). Reading the computed property back is also the wrong
+  confirmation: `getComputedStyle(el).background` is a 60-character shorthand serialisation, and
+  for `font` it is empty whenever the element has any non-default font longhand. The probe gives
+  the longhand list for free and makes the comparison exact.
+- **(b) Resolve the token on `:root` and show its declared value.** Always cheap and never
+  wrong about the token, but it does not answer the question. It cannot say which property the
+  token feeds, it cannot see that the binding lost the cascade (448 bindings do, on 180 boards),
+  and it is wrong on the one board that actually applies `.dark` (19 bindings resolve to a
+  different value on the element than on `:root`). It is, however, exactly what the Tokens tab
+  needs, so the same resolver computes it once per board.
+- **A hybrid** is what the recommendation is: (a) widened to the stylesheet and inheritance,
+  (b) done on the element, and a probe joining the two.
+
+The resolver runs in under 10 ms for a median board when asked for every element, 229 ms on
+the worst (294 elements), and about 1–8 ms for a single element with its ancestors. Compute a
+single element's bindings on `sp:sel`, not up front: the full per-element payload for
+`luma-ios/12-home-later` is 107 KB of JSON, while the token list is 11–19 KB.
+
+## 2. What the panel should show
+
+Per selected element, one row per binding, in the order the properties are declared:
+
+```
+background   ← --sa-amber          #F0A468   ■        applied
+font         ← --sa-t-time         590 18px/18px SF Pro …        applied
+             weight 590 · size 18px · line 18px · family -apple-system, "system-ui", …
+border       ← --sa-line           #2A2A2A   ■        partial — border-bottom from inline border-bottom: none
+color        ← --l-ink             #FFFFFF   ■        applied · inherited from div.phone
+```
+
+Three columns carry the three different facts, and the panel should keep them apart:
+
+- **`property ← token`** is the binding: which declaration, from which source (inline, a
+  selector, or an ancestor). Show the selector on hover or in a muted suffix.
+- **The token's value** is the substituted custom-property value (`#F0A468`), not the
+  element's computed `rgb(240, 164, 104)`. The author wrote the hex, the swatch is drawn from
+  the canonical `rgb()` the resolver also returns, and the two never disagree for colours.
+- **The state** is the honest part. `applied` is proven by the probe. `partial` and
+  `overridden` name what won; the design should render the losing token struck through or
+  dimmed with the winner's text beside it, because a designer reading "this card's border is
+  `--sa-line`" would otherwise be misled on the 1% of elements where an inline
+  `border-bottom:none` cut it.
+
+For a `font` binding show the longhands the probe returned (weight, size, line-height, family)
+under the row; that is the "type token" reading a designer wants and it is what `partial` will
+usually be about (170 of 172 partials are `font` with `font-family` or `font-size` replaced by
+a later rule).
+
+For a declaration with more than one token (30 bindings, all `linear-gradient(… var(--g-fade)
+72%, var(--g-fade) 100%)` and `repeat(var(--a-cols), var(--a-icon))`) show the declaration
+text with each token's value, and the single confirmed longhand. Which token contributed which
+stop is not knowable from computed style and should not be pretended.
+
+### The Tokens tab
+
+Group by the author's own `/* headings */` in `:root`. Every one of the 180 boards has them
+(1,305 headings, about 7 per board: Surface, Line, Ink, Accent, Radius, Type, Metrics), and
+they carry meaning the value cannot (luma's "Fills (white over the backdrop)"). Rules:
+
+- A comment on its own line starts a group; a comment trailing a token on the same line is that
+  token's note (2,398 of them across the repo, all luma-style annotations such as
+  "host-only section headers"). Show notes as a muted second line.
+- Tokens before the first heading (79 boards, 102 tokens, almost always the family
+  `--x-font`) go in an unnamed first group. Three boards have no headings at all
+  (`00-welcome`, the two `apple-icons` boards): fall back to grouping by kind.
+- Each row: swatch for colours (39% of tokens), a small specimen for fonts (27%), the bare
+  value for lengths (31%), the value for families and filters. `CSS.supports()` classifies
+  every one of the 11,109 tokens into colour / length / font / family / filter / number; none
+  land in "other".
+- Show `used by N elements` and let a click select or highlight them; 71% of a board's tokens
+  are unused on that board (the sheet is shared across the canvas), so sort or dim by use. A
+  further 1% are used only through another token (`--sa-font` inside every `--sa-t-*`); show
+  those as "via --sa-t-time, …".
+- Where a token is redefined under a scope (`.dark{--ac-bg:#000000}`, 469 redefinitions on 35
+  boards), show both values on the row with the selector.
+
+The per-element view and the Tokens tab meet at the token name: clicking `--sa-amber` in an
+element row jumps to its Tokens row, and the Tokens row lists the elements.
+
+## 3. Measured failure-mode frequencies
+
+180 boards, 11,109 `:root` tokens (min 7, median 67, max 89), 37 boards without `</body>`.
+
+| Claim in the brief | Measured |
+|---|---|
+| Tokens used inline | 1,339 elements, 1,845 declarations |
+| Tokens used in `<style>` rules | 6,584 `var()` in rules, 546 distinct selectors; **88% of element bindings** (12,673 of 14,423) arrive through a rule, 12% inline |
+| Shorthand with a `var()` inline | **1,154 of 1,845 (63%)**: `font` 647, `background` 356, `border-radius` 115, `border` 27, `border-bottom` 9 |
+| `var()` that is not the whole value | 55 inline (`border:1px solid var(--x)`, one gradient, three `calc(-1 * var(--x))`) |
+| More than one `var()` in a declaration | 8 inline declarations, 30 bindings in total — one chatgpt gradient repeated across 6 boards, and `repeat(var(--a-cols), var(--a-icon))` |
+| `var(--a, fallback)` | 0 |
+| `var()` naming an undefined token | 0 |
+| Tokens defined through other tokens | **2,954 of 11,109 (27%)**, on 177 boards; all composites (`600 17px/22px var(--sa-font)`), 0 pure aliases |
+| Tokens redefined outside `:root` | 469 on 35 boards, every one inside `.dark{}`; the class is applied on 1 board (`apple-home-lock/02-home-dark`), where 19 bindings resolve differently on the element than on `:root` |
+| Tokens with relative units, `%`, `currentColor` | 0, 0, 0 — the boards are px-only, so the probe's context does not matter today |
+| Descendant / list / pseudo selectors using `var()` | 1,420 rules; 6 pseudo-class rules, 31 pseudo-element rules (15 use `var()`), 0 `@media`, 0 ids |
+| Duplicate token names in one `:root` | 0 |
+
+Resolver sweep, every element of every board (14,423 bindings on 7,618 elements):
+
+| State | Count | Share |
+|---|---|---|
+| applied — probe longhands all match | 13,975 | 96.9% |
+| overridden — a later declaration took the property; winner named | 276 | 1.9% |
+| partial — some longhands taken; winner named | 172 | 1.2% |
+| unconfirmed — mismatch with no winner found | **0** | |
+| invalid — declaration the browser rejected | 0 | |
+
+By property: `color` 4,032 applied / 49 overridden; `font` 3,844 / 57 / 170 partial;
+`background` 1,282 / 39; `border-bottom` 1,253 / 0; `height` 961 / 32; `border-radius` 947 /
+22 / 1; `width` 785 / 30; `border` 464 / 21 / 1; `left` 158 / 26; everything else all applied.
+
+Two round-trip failures showed up and were fixed by the probe design rather than by special
+cases: `grid-template-columns` resolves to a track list only on a grid container, so the probe
+copies the element's `display`; and a probe under `<html>` resolves `--hs-grey3` to the light
+value inside a `.dark` subtree, so tokens are substituted from the element's computed style
+before the declaration is set on the probe.
+
+Inheritance, over the 5,993 elements that carry text directly:
+
+| | bound on itself | bound on an ancestor | bound nowhere |
+|---|---|---|---|
+| `color` | 3,528 (59%) | **1,789 (30%)** | 676 (11%, on 9 evidence/token boards that use literal colours) |
+| `font` | 3,907 (65%) | **2,086 (35%)** | 0 |
+
+The ancestor is usually `.phone` or a card: depth 1: 764, 2: 468, 3: 497, 4: 1,779, 5: 329,
+6: 36, 7: 2.
+
+Timing: `usesFor` on every element of a board, median 8.7 ms, max 229 ms
+(`duolingo-ios/00d-art`, 294 elements). `bindingsFor` on one element with its ancestor walk,
+0.9–7.6 ms.
+
+## 4. What it still cannot resolve, and what to show
+
+- **Which token contributed what inside one value.** A gradient with two tokens, a `calc()`,
+  or `repeat(var(--cols), var(--w))` confirms as one longhand. Show the declaration with each
+  token's value and do not split the credit.
+- **Colour that is bound to nothing.** 11% of text elements sit on boards whose colours are
+  literals. The row should say "no token — `color: #111` from `.k`", which the same candidate
+  list provides if the panel asks for declarations without `var()` too (the resolver already
+  collects them to name overriders).
+- **Pseudo-elements.** 15 rules bind tokens on `::before`/`::after`. The resolver handles them
+  through `getComputedStyle(el, '::before')` and tags the binding with the pseudo, but the
+  layers list has no node for them; render them under the owning element as `::before`.
+- **Specificity is approximated.** Ids, classes, attributes, pseudo-classes and types are
+  counted; `:is()`/`:where()`/`:not()` internals are not weighed. On these boards it never
+  mattered (0 unconfirmed), and a wrong order still surfaces as `overridden` with the true
+  winner named, because the probe judges by value, not by ordering.
+- **`!important` and `@layer`** are not modelled; neither appears on any board. A wrong guess
+  again degrades to a named override, not to a wrong value.
+- **Values the probe cannot reproduce.** Percentages against a parent (`height:50%`), `em`,
+  `currentColor`, inherited `font-size` in the token itself. None occur today. If one did, the
+  state would come out `unconfirmed`; render that as the token and value with a question mark,
+  never as `applied`.
+- **Tokens applied through JavaScript or SVG attributes.** The boards have no scripts and the
+  `fill:var()` uses are in rules, so this is theoretical.
+
+## 5. The agent-side resolver
+
+This is the exact text validated by the sweep, minus the wrapper. It is ES5, contains no
+backtick and no `${`, and is meant to be pasted into the `AGENT` template literal in
+`canvas/src/InspectorPanel.tsx`. When it goes into the literal, every `\` in a regex must be
+doubled and any `</script>` written as `<\/script>` — the same rules the current agent already
+follows. Call `__spTokens.bindingsFor(el)` on `sp:sel` and post the result; post
+`__spTokens.tokens` and `__spTokens.groups` once in `sp:ready`, with `uses` filled in by one
+pass over the marked elements.
+
+```js
+/* Token resolver — runs inside the board's document (opaque origin, sandbox=allow-scripts).
+   ES5 only, no backticks or dollar-brace, since this gets embedded in a TS template literal.
+   Exposes window.__spTokens = { tokens, groups, usesFor(el), bindingsFor(el), byName } */
+(function(){
+  /* ---- probe: a hidden, zero-sized, out-of-flow box the resolver can style freely ---- */
+  var wrap=document.createElement('div');
+  wrap.style.cssText='position:absolute;left:0;top:0;width:0;height:0;overflow:hidden;visibility:hidden;pointer-events:none';
+  var probe=document.createElement('div'),zero=document.createElement('div');
+  wrap.appendChild(probe);wrap.appendChild(zero);
+  document.documentElement.appendChild(wrap);
+  var pcs=getComputedStyle(probe),zcs=getComputedStyle(zero);
+
+  /* ---- split "a:b; c:d(e;f)" on top-level semicolons ---- */
+  function splitDecls(text,all){
+    var out=[],depth=0,cur='',q=null,i,ch;
+    for(i=0;i<text.length;i++){ch=text.charAt(i);
+      if(q){cur+=ch;if(ch===q)q=null;continue;}
+      if(ch==='"'||ch==="'")q=ch;else if(ch==='(')depth++;else if(ch===')')depth--;
+      if(ch===';'&&depth===0){out.push(cur);cur='';}else cur+=ch;}
+    if(cur.replace(/\s/g,''))out.push(cur);
+    var decls=[];
+    for(i=0;i<out.length;i++){var d=out[i],c=d.indexOf(':');if(c<0)continue;
+      var prop=d.slice(0,c).replace(/^\s+|\s+$/g,'').toLowerCase(),val=d.slice(c+1).replace(/^\s+|\s+$/g,'');
+      if(val.indexOf('var(')<0&&!all)continue;
+      var toks=[],re=/var\(\s*(--[\w-]+)/g,m;while((m=re.exec(val)))toks.push(m[1]);
+      decls.push({prop:prop,value:val,tokens:toks});}
+    return decls;
+  }
+  function splitSelectors(sel){ /* top-level commas only (":is(a,b)" stays whole) */
+    var out=[],depth=0,cur='',i,ch;
+    for(i=0;i<sel.length;i++){ch=sel.charAt(i);if(ch==='(')depth++;else if(ch===')')depth--;
+      if(ch===','&&depth===0){out.push(cur);cur='';}else cur+=ch;}
+    out.push(cur);return out;
+  }
+  function specificity(sel){ /* good enough for class-heavy boards; ids > classes/attrs/pseudo-classes > types */
+    var s=sel.replace(/::?[\w-]+(\([^)]*\))?/g,function(m){return m.indexOf('::')===0||/^:(before|after)/.test(m)?' ':' :x ';});
+    var ids=(s.match(/#[\w-]+/g)||[]).length,cls=(s.match(/\.[\w-]+|\[[^\]]*\]|:x/g)||[]).length;
+    var types=(s.replace(/#[\w-]+|\.[\w-]+|\[[^\]]*\]|:x/g,' ').match(/[a-zA-Z][\w-]*/g)||[]).length;
+    return ids*10000+cls*100+types;
+  }
+  /* ---- every stylesheet rule, in cascade order; the inline <style> sheet is readable from the opaque origin ---- */
+  var rules=[];
+  function collect(list){var i,r;for(i=0;i<list.length;i++){r=list[i];
+    if(r.type===1){var d=splitDecls(r.style.cssText,true);
+      if(d.length)rules.push({sel:r.selectorText,parts:splitSelectors(r.selectorText).map(function(p){var m=/::?(before|after|marker|placeholder)\s*$/.exec(p);
+        return m?{sel:p.slice(0,m.index),pseudo:'::'+m[1]}:{sel:p,pseudo:''};}),decls:d,order:rules.length});}
+    else if(r.cssRules)collect(r.cssRules);}}
+  (function(){var i;for(i=0;i<document.styleSheets.length;i++){try{collect(document.styleSheets[i].cssRules);}catch(e){}}})();
+
+  /* ---- :root as written: groups from own-line comments, notes from trailing comments ---- */
+  var css='',i;for(i=0;i<document.styleSheets.length;i++){var o=document.styleSheets[i].ownerNode;if(o&&o.textContent)css+=o.textContent+'\n';}
+  var tokens=[],byName={},groups=[],rootText=(/:root\s*\{([\s\S]*?)\}/.exec(css)||['',''])[1];
+  (function(){var lines=rootText.split('\n'),group=null,gi=-1,li,line,m;
+    for(li=0;li<lines.length;li++){line=lines[li];
+      m=/^\s*\/\*\s*([\s\S]*?)\s*\*\//.exec(line);
+      if(m&&!/--[\w-]+\s*:/.test(line.slice(0,m.index))){group=m[1];gi=groups.length;groups.push({name:group,tokens:[]});line=line.slice(m.index+m[0].length);}
+      var re=/(--[\w-]+)\s*:\s*([^;]*);/g,t,last=null;
+      while((t=re.exec(line))){last={name:t[1],decl:t[2].replace(/^\s+|\s+$/g,''),group:group,note:''};
+        if(!byName[last.name]){tokens.push(last);byName[last.name]=last;if(gi>=0)groups[gi].tokens.push(last.name);}}
+      var tail=/\/\*\s*([\s\S]*?)\s*\*\/\s*$/.exec(line);if(tail&&last)last.note=tail[1];}})();
+  function kind(v){
+    if(!v)return 'unset';
+    if(/^-?[\d.]+(px|pt|em|rem|%|vw|vh|ch)$/.test(v))return 'length';
+    if(/^-?[\d.]+$/.test(v))return 'number';
+    if(CSS.supports('color',v))return 'color';
+    if(CSS.supports('font',v))return 'font';
+    if(CSS.supports('background-image',v))return 'image';
+    if(CSS.supports('filter',v))return 'filter';
+    if(CSS.supports('box-shadow',v))return 'shadow';
+    if(CSS.supports('font-family',v))return 'family';
+    return 'other';
+  }
+  var rcs=getComputedStyle(document.documentElement);
+  function canon(k,v){ /* what the panel draws a swatch from */
+    if(k!=='color')return '';probe.style.cssText='color:'+v;return pcs.color;}
+  for(i=0;i<tokens.length;i++){var tk=tokens[i];tk.value=rcs.getPropertyValue(tk.name).replace(/^\s+|\s+$/g,'');
+    tk.kind=kind(tk.value);tk.canon=canon(tk.kind,tk.value);tk.refs=(tk.decl.match(/var\(\s*(--[\w-]+)/g)||[]).map(function(s){return s.slice(4).replace(/^\s+/,'');});
+    tk.uses=0;tk.overrides=[];}
+  /* tokens redefined outside :root (e.g. .dark{--ac-bg:...}) */
+  (function(){var i,j;for(i=0;i<document.styleSheets.length;i++){var rs;try{rs=document.styleSheets[i].cssRules;}catch(e){continue;}
+    for(j=0;j<rs.length;j++){var r=rs[j];if(r.type!==1||r.selectorText===':root')continue;var k;
+      for(k=0;k<r.style.length;k++){var p=r.style[k];if(p.indexOf('--')===0){var t=byName[p];var ov={sel:r.selectorText,decl:r.style.getPropertyValue(p).replace(/^\s+|\s+$/g,'')};
+        if(t)t.overrides.push(ov);else{t={name:p,decl:'',group:null,note:'',value:'',kind:'unset',canon:'',refs:[],uses:0,overrides:[ov],scoped:true};tokens.push(t);byName[p]=t;}}}}}})();
+
+  /* ---- per element: which declarations with var() reach it, and whether they won ---- */
+  function subst(value,cs){ /* the element's own computed token values, so a .dark{--x:..} redefinition is honoured */
+    return value.replace(/var\(\s*(--[\w-]+)\s*(?:,[^()]*)?\)/g,function(_,n){return cs.getPropertyValue(n).replace(/^\s+|\s+$/g,'');});}
+  function usesFor(el){
+    var cands=[],i,j,k,pseudos={'':getComputedStyle(el)};
+    for(i=0;i<rules.length;i++){var r=rules[i];var best={};
+      for(j=0;j<r.parts.length;j++){var p=r.parts[j];try{if(el.matches(p.sel)){var s=specificity(p.sel);if(!(p.pseudo in best)||s>best[p.pseudo])best[p.pseudo]=s;}}catch(e){}}
+      for(var ps in best){if(!pseudos[ps])pseudos[ps]=getComputedStyle(el,ps);
+        for(j=0;j<r.decls.length;j++)cands.push({prop:r.decls[j].prop,value:r.decls[j].value,tokens:r.decls[j].tokens,src:r.sel,pseudo:ps,spec:best[ps],order:i});}}
+    var inl=splitDecls(el.getAttribute('style')||'',true); /* the raw attribute, so an overrider is named as written */
+    for(j=0;j<inl.length;j++)cands.push({prop:inl[j].prop,value:inl[j].value,tokens:inl[j].tokens,src:'',pseudo:'',spec:1e6,order:rules.length+j});
+    cands.sort(function(a,b){return a.spec-b.spec||a.order-b.order;});
+    /* which longhands each candidate sets, via the probe; tokens substituted in the element's context */
+    for(i=0;i<cands.length;i++){var c=cands[i],ecs=pseudos[c.pseudo];c.ecs=ecs;
+      probe.style.cssText='display:'+ecs.display;probe.style.setProperty(c.prop,subst(c.value,ecs));
+      c.longs=[];c.all=[];c.invalid=probe.style.length<=1;
+      for(k=0;k<probe.style.length;k++){var L=probe.style[k];if(L==='display')continue;var pv=pcs.getPropertyValue(L),ev=ecs.getPropertyValue(L),same=pv===ev;
+        c.all.push({p:L,v:pv,ok:same});if(pv!==zcs.getPropertyValue(L))c.longs.push({p:L,v:pv,ok:same});}
+      if(!c.longs.length)c.longs=c.all;}
+    var out=[];
+    for(i=cands.length-1;i>=0;i--){var c=cands[i];if(!c.tokens.length)continue;
+      var bad=[],ok=true;for(k=0;k<c.longs.length;k++)if(!c.longs[k].ok){ok=false;bad.push(c.longs[k].p);}
+      var by=null,byProp=null;
+      if(!ok){ /* name the later declaration that took those longhands, if there is one */
+        for(j=cands.length-1;j>i&&!by;j--){var d=cands[j];if(d.pseudo!==c.pseudo||d.invalid)continue;
+          for(k=0;k<d.all.length;k++)if(bad.indexOf(d.all[k].p)>=0){by=(d.src?d.src+' ':'inline ')+d.prop+': '+d.value;byProp=d.prop;break;}}}
+      var state=c.invalid?'invalid':ok?'applied':!by?'unconfirmed':(byProp===c.prop||bad.length===c.longs.length)?'overridden':'partial';
+      var vals={};for(k=0;k<c.tokens.length;k++)vals[c.tokens[k]]=c.ecs.getPropertyValue(c.tokens[k]).replace(/^\s+|\s+$/g,'');
+      out.push({prop:c.prop,value:c.value,tokens:c.tokens,resolved:vals,src:c.src,pseudo:c.pseudo,state:state,by:by,longhands:c.longs,elValue:c.ecs.getPropertyValue(c.prop)});}
+    out.reverse();return out;
+  }
+  /* inherited properties the element does not bind itself: report the nearest ancestor that does */
+  var INHERITED=/^(color|font|font-[\w-]+|line-height|letter-spacing|text-align|text-transform|word-spacing|visibility|fill|stroke)$/;
+  function bindingsFor(el){
+    var own=usesFor(el),have={},i,a=el.parentElement,depth=1;
+    for(i=0;i<own.length;i++)if(!own[i].pseudo&&own[i].state!=='overridden')have[own[i].prop.split('-')[0]]=true;
+    while(a&&a.nodeType===1){var up=usesFor(a);
+      for(i=0;i<up.length;i++){var u=up[i];if(u.pseudo||u.state==='overridden'||!INHERITED.test(u.prop)||have[u.prop.split('-')[0]])continue;
+        have[u.prop.split('-')[0]]=true;u.inheritedFrom={depth:depth,tag:a.tagName.toLowerCase(),cls:a.getAttribute('class')||'',i:a.getAttribute('data-sp')};own.push(u);}
+      a=a.parentElement;depth++;}
+    return own;
+  }
+  window.__spTokens={tokens:tokens,groups:groups,rules:rules.length,usesFor:usesFor,bindingsFor:bindingsFor,byName:byName};
+})();
+```
+
+What one binding looks like on the wire, for the element from the bug report
+(`snapaction-ios/01-timeline`, `div.sh`):
+
+```json
+{"prop":"background","value":"var(--sa-amber)","tokens":["--sa-amber"],
+ "resolved":{"--sa-amber":"#F0A468"},"src":"","pseudo":"","state":"applied","by":null,
+ "longhands":[{"p":"background-color","v":"rgb(240, 164, 104)","ok":true}],
+ "elValue":"rgb(240, 164, 104) none repeat scroll 0% 0% / auto padding-box border-box"}
+```
+
+And a token row, as the Tokens tab receives it:
+
+```json
+{"name":"--l-amber","decl":"#F1CD8A","group":"Ink","note":"host-only section headers",
+ "value":"#F1CD8A","kind":"color","canon":"rgb(241, 205, 138)","refs":[],"uses":3,"overrides":[]}
+```
+
+## 6. Things the CSSOM experiment settled
+
+Recorded because each one was a guess before `cssom.py` ran, and each shapes the code above.
+
+- `document.styleSheets[0].cssRules` is readable inside the `allow-scripts` frame. The sheet
+  is an inline `<style>`, so it shares the document's (opaque) origin; only fetched sheets
+  would throw.
+- A shorthand with `var()` in `el.style` expands to its longhands (`background` → 9 entries),
+  and `getPropertyValue` on every longhand returns `''` — the browser stores them as pending
+  substitution. `getPropertyValue('background')` and `cssText` still return `var(--sa-amber)`,
+  which is why the resolver parses `cssText`/the attribute rather than iterating properties.
+- `getComputedStyle(el).getPropertyValue('--sa-t-time')` returns the substituted stream,
+  `590 18px/18px -apple-system,BlinkMacSystemFont,…`; the browser does the token-in-token
+  resolution for free. The declared hex is preserved exactly (`#F0A468`), which is what the
+  panel should print.
+- `getComputedStyle(el).font` does serialise on these boards, but it is empty as soon as any
+  font longhand is non-default (`td.n` above), so it is not a safe confirmation source.
+- `CSS.supports('color', v)` is true for any `var()` string, so kinds must be classified on
+  the substituted value, never on the declaration.
+- Chrome computes a `1.5px` border width as `1px` on both the probe and the element; the probe
+  comparison is immune to that kind of snapping because both sides go through the same engine.

--- a/mockups/canvases/README.md
+++ b/mockups/canvases/README.md
@@ -22,9 +22,13 @@ server is otherwise confined to, so only link at something you trust.
 
 A folder is an unzipped Sketch file: `layout.json` plays `document.json` and
 `meta.json`, `icon.png` plays `previews/preview.png`, `assets/` plays
-`images/`, and the numbered boards are the pages. `probes.json`,
-`crops.json` and `assets.json` are the measurement evidence. Commit them
-with the boards. Everything a run makes on the way, grids, shots, montages,
+`images/`, and the numbered boards are the pages. `probes.json` and
+`crops.json` are the measurement evidence. Commit them with the boards.
+`assets.json`, where a folder has one, is a `name → data URI` map of
+pre-encoded images the generator inlines; commit it too, it is the only
+copy of those images. The canvas's inspector names a board's images by
+content, from `assets/` first and `assets.json` second, and falls back to
+the image's `alt` when a generator re-encoded it. Everything a run makes on the way, grids, shots, montages,
 candidate boards, goes in `<slug>/scratch/`. The root `.gitignore` ignores
 `scratch/` at any depth, and `assets/refs/` too, which is where third-party
 captures go. No folder needs a `.gitignore` of its own.

--- a/skills/prototype-canvas/references/layout.md
+++ b/skills/prototype-canvas/references/layout.md
@@ -22,8 +22,13 @@ the dev server is otherwise confined to, so only link at something you trust.
 
 A folder is an unzipped Sketch file: `layout.json` plays `document.json` and
 `meta.json`, `icon.png` plays `previews/preview.png`, `assets/` plays
-`images/`, and the numbered boards are the pages. `probes.json`, `crops.json`
-and `assets.json` are the measurement evidence — commit them with the boards.
+`images/`, and the numbered boards are the pages. `probes.json` and `crops.json`
+are the measurement evidence — commit them with the boards. `assets.json`,
+where a folder has one, is a `name → data URI` map of pre-encoded images the
+generator inlines; commit it too, it is the only copy of those images. The
+canvas's inspector names a board's images by content, from `assets/` first
+and `assets.json` second, and falls back to the image's `alt` when a
+generator re-encoded it.
 Everything a run makes on the way (grids, shots, montages, candidate boards)
 goes in `<slug>/scratch/`, which should be gitignored at any depth, along with
 `assets/refs/` where third-party captures go.


### PR DESCRIPTION
Click a board on the canvas and a panel docks on the right: the board rendered large, and a rail that names every layer, resolves every design token, and lists every image by its source filename.

The canvas renders boards as `<iframe srcdoc sandbox="">`, so the app deliberately cannot read them. The panel loads the same HTML into a second frame with `allow-scripts` and *without* `allow-same-origin`, injects an agent, and talks to it over `postMessage`. Everything the panel shows is measured in the board's own layout.

## What it looks like

The panel docks as a flex sibling rather than an overlay, so tldraw's own resize observer keeps the viewport correct — the toolbar, page menu and zoom readout all stay live while it is open.

![The inspector panel open beside the canvas](https://raw.githubusercontent.com/ReScienceLab/super-prototyping/media/inspector-panel/inspector-panel/a-panel-in-context.png)

Selecting the `div.sh` divider on `snapaction-ios/01-timeline` — the element whose token used to resolve wrongly. `background` binds `--sa-amber` to `#F0A468`, the computed `background-color` confirms `rgb(240, 164, 104)`, and the two inherited bindings name the ancestor they come from.

![Inspect tab with a selected layer](https://raw.githubusercontent.com/ReScienceLab/super-prototyping/media/inspector-panel/inspector-panel/b-inspect.png)

The Tokens tab, grouped by the board's own `/* heading */` comments, with a use count per token and the unused ones dimmed — 28 used of 89 on this board.

![Tokens tab](https://raw.githubusercontent.com/ReScienceLab/super-prototyping/media/inspector-panel/inspector-panel/c-tokens.png)

`luma-ios/11-home-nearby`, where 17 of the 18 assets are CSS `url(data:)` backgrounds that nothing could see before. All 18 are named from the folder's `assets.json`.

![Assets tab](https://raw.githubusercontent.com/ReScienceLab/super-prototyping/media/inspector-panel/inspector-panel/d-assets.png)

## Three bugs that a naive implementation hits

Each of these was found by driving the real app, and each is fixed here with the reasoning kept in a comment:

- **A frame that stays blank forever.** A board's HTML arrives asynchronously, so React mounts the iframe with `srcdoc=""` and mutates the attribute a tick later — and Chrome drops that second navigation while the first is still pending. The frame is now *created* with its final `srcdoc`, keyed by path. It looked intermittent only because a warm cache hides it.
- **Every measurement was zero.** A script at the end of the body runs at `readyState: 'interactive'`, before the first layout pass and before the data URIs decode. Measured across the repo, 113 of 180 boards reported a `0×0` artboard. Boxes are now read on `load` and again on the following frame.
- **Not every board has a `</body>`.** The `apple-*` generators emit none, so the append fallback is load-bearing, not defensive.

## Naming assets

Images are inlined as anonymous `data:` URIs — no filename, no path, and only 103 of 606 carry alt text. The Vite plugin now hashes every image under a folder's `assets/`, `assets-dark/` and `assets.json` and exports `rawAssetNames`; the agent hashes each image the same way and the parent joins. The file an author inlined *is* the name — nothing to remember, no generator to re-run, no HTML change.

- 518/606 `<img>` named (85.5%), plus all 214 CSS `url(data:)` backgrounds, which nothing counted before.
- 0 collisions across 441 distinct payloads for `length + FNV-1a 32`.
- The 88 misses are `apple-icons` and `00-welcome`, whose generators re-encode through PIL; 87 of them carry alt text, which is the fallback.
- FNV rather than SHA because a sandboxed frame under a non-secure parent has no `crypto.subtle`.

## Resolving tokens

The panel used to print an element's computed `color` next to whichever `var()` it found, so `background:var(--sa-amber)` displayed the *text* colour. Resolution is now per declaration, across the full cascade — the inline attribute and every `<style>` rule the element matches — resolved with `getComputedStyle(el)` rather than `:root`, then confirmed against a hidden probe so each binding is labelled **applied**, **partial** or **overridden** with the winning declaration named.

Measured over 180 boards: 63% of inline declarations with a `var()` are shorthands; inline-only parsing would miss 88% of bindings; 30% of text elements inherit their token-bound `color` from an ancestor; and one board applies `.dark{}`, which is what makes `:root` resolution wrong rather than merely imprecise.

## Verified

`tsc -b`, `oxlint`, 36 tests, and `vite build` all pass. Driven in real Chrome through the click path: the original `--sa-amber` case now reports `#F0A468` / `rgb(240,164,104)`; `.card` reports `partial` naming `inline border-bottom: none`; inherited colour reports `inherited from div.phone`; the `.dark` board resolves against the element; `luma-ios/11-home-nearby` names all 18 CSS backgrounds from `assets.json`; `apple-icons` falls back to alt for all 43. A 180-board sweep: every board reports, none measures `0×0`.

## Also

`assets.json` was documented as "measurement evidence behind the tokens". It is a `name → data URI` map, and only 3 of 13 folders have one. Corrected in `AGENTS.md`, `CONTRIBUTING.md`, `mockups/canvases/README.md` and the skill reference.

## Resizing, and the selected layer's image

Three dividers — panel/canvas, stage/rail, layers/properties — plus a collapse that folds the rail away for a full-width preview. Each takes a pointer capture, without which a drag dies the moment the cursor crosses the board's iframe, and each takes Tab and arrow keys. The bounds live in `inspectorModel.ts` and are applied at render as well as at the drag, because a bound moves when the window resizes or the divider on the other side of it is dragged.

The preview was a constant 0.85, so resizing only ever bought grey; it contains-to-fit now, capped at 1:1. The layers list opens at 45% of the window rather than 240px. Selecting a layer that draws an image shows that image on its own between the list and the properties.

## Review fixes

Escape had been bound since the first commit and a second listener broke it, so deselecting closed the panel; the root layer could not be selected, because `querySelector` does not match the root it is called on; and a click on an annotation drawn over a board opened the inspector as well, because the hit test filtered past whatever was on top.

## Deliberately not in this PR

Open design questions, unchanged: the flat layer list on 350-element boards, the camera not re-fitting when the panel opens, narrow viewports, and whether the panel squeezes the canvas or floats over it. Rationale for the whole feature is in the three `docs/2026-09-07-*.md` notes.

Screenshots are hosted on the `media/inspector-panel` branch rather than committed here, so they add nothing to the plugin install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

