### PR TITLE
canvas: every board has an address, ?canvas=<slug>#<file>

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,9 @@ registry, no build step and no design tool.
 Five of the fourteen app folders in `mockups/canvases/`. That folder's own
 `README.md` lists them all. Each is a real `clone-prototype` run, rebuilt
 from measured samples with the evidence recorded for every token. Open any
-of them with `?canvas=<slug>`; the address follows whichever page is open, so
-the URL in the bar is always the link to share.
+of them with `?canvas=<slug>`, and one board of it with
+`?canvas=<slug>#<file>`. The address follows whatever is open, the page and
+the board in the inspector, so the URL in the bar is always the link to share.
 
 ### `duolingo-ios`, eight screens that are mostly picture
 
@@ -154,7 +155,9 @@ it on 127.0.0.1:5173 against `./mockups/canvases`, and prints the address.
 `--canvases DIR` points it somewhere else, `--port N` moves it, `sp-canvas
 status` and `sp-canvas stop` do what they say.
 
-Deep-link a board with `?canvas=<slug>`. The bottom toolbar carries a
+Deep-link a page with `?canvas=<slug>`, and one board of it with
+`?canvas=<slug>#<file>`: it opens in the inspector with the camera on it, and
+clicking any board writes that link into the address bar. The bottom toolbar carries a
 styles-panel toggle alongside tldraw's own tools; the top bar carries a
 force-relayout button. Press it after editing a `layout.json`. A board folder
 added after boot appears on its own.

--- a/canvas/public/404.html
+++ b/canvas/public/404.html
@@ -31,7 +31,7 @@
     <main>
       <p class="code">404</p>
       <h1>Page not found</h1>
-      <p>There is nothing at this address. The canvas lives at the root; open a board with <code>?canvas=&lt;slug&gt;</code>.</p>
+      <p>There is nothing at this address. The canvas lives at the root; open a page with <code>?canvas=&lt;slug&gt;</code>, one board of it with <code>#&lt;file&gt;</code> after that.</p>
       <nav>
         <a class="primary" href="/">Open the canvas</a>
         <a href="https://github.com/ReScienceLab/super-prototyping">View on GitHub</a>

--- a/canvas/src/App.tsx
+++ b/canvas/src/App.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import {
   Tldraw,
   createShapeId,
@@ -15,7 +15,7 @@ import {
 } from "tldraw";
 import "tldraw/tldraw.css";
 import { installAgentBridge } from "./agentBridge";
-import { WELCOME_PAGE_SLUG, slugFromUrl, urlForSlug } from "./canvasUrl";
+import { WELCOME_PAGE_SLUG, boardFromUrl, slugFromUrl, urlForSlug } from "./canvasUrl";
 import {
   CANVAS_FILE_DEFAULT_SIZE,
   CANVAS_FILE_SHAPE_TYPE,
@@ -691,43 +691,92 @@ function relayoutCanvasLibrary(editor: Editor) {
 }
 
 /**
- * Opens the page the address names (canvasUrl.ts): `?canvas=<slug>` for a board, the bare URL
- * for the welcome page. So a specific round can be linked to or scripted against instead of
+ * Opens what the address names (canvasUrl.ts): the page, `?canvas=<slug>` or the bare URL for
+ * the welcome page, and after the hash a board of it, `#<file>`, which opens in the inspector.
+ * So a specific round, or one board in it, can be linked to or scripted against instead of
  * relying on whichever page tldraw last persisted, and the bare URL is always the way in: keep
- * a board open across reloads by deep-linking it, not by leaving it on screen.
+ * a board open across reloads by deep-linking it, not by leaving it on screen. A board the
+ * address names that is not on that page closes the inspector, so what is on screen never
+ * contradicts the address. Returns the board opened, if any.
  */
-function applyCanvasFromUrl(editor: Editor) {
+function applyCanvasFromUrl(
+  editor: Editor,
+  show: (file: CanvasLibraryFile | null) => void,
+) {
   const slug = slugFromUrl(window.location.href);
   const page = editor.getPages().find((c) => c.meta.canvasSlug === slug);
   if (page) editor.setCurrentPage(page.id);
+  const board = boardFromUrl(window.location.href);
+  const file =
+    readCanvasLibrary()
+      .flat()
+      .find((c) => c.pageSlug === slug && c.fileName === board) ?? null;
+  show(file);
+  return file;
 }
 
 /**
- * Keeps the address on the page being looked at, so whatever is on screen can be shared by
- * copying the URL. Each page change (a welcome card, tldraw's page menu) pushes a history
- * entry, so Back returns to the previous board and, from a board, to the welcome page; a
- * popstate opens the page that entry names. Installed after applyCanvasFromUrl so the first
- * run finds the address already applied and only corrects it, without a new entry, when it
- * named no folder. Pages tldraw persisted but no folder claims have no slug and leave the
- * address as it is.
+ * Keeps the address on what is being looked at, so whatever is on screen can be shared by
+ * copying the URL: the page, and the board open in the inspector when it is one of that page's
+ * (an inspector left open across a page change names a board of the other page, which the
+ * address then leaves out). The address is derived from those two whenever either changes,
+ * never edited in place, so the two writers cannot disagree: the page is watched here, and
+ * App calls `write` when the inspector opens or closes.
+ *
+ * Each change pushes a history entry, so Back returns to the previous board and, from a board,
+ * to its page and the welcome page; a popstate applies the entry it lands on. Applying an
+ * address is the one time the page changes without the address needing to follow, so the
+ * watcher stands down for it and `apply` corrects the address once, without an entry, for a
+ * page or board it named that does not exist. Pages tldraw persisted but no folder claims have
+ * no slug and leave the address as it is.
  */
-function installCanvasUrlSync(editor: Editor) {
-  let first = true;
-  const stopSync = react("canvas page in the address", () => {
+function installCanvasUrlSync(
+  editor: Editor,
+  inspected: () => CanvasLibraryFile | null,
+  show: (file: CanvasLibraryFile | null) => void,
+) {
+  const write = (push: boolean) => {
     const slug = editor.getCurrentPage().meta.canvasSlug;
-    const push = !first;
-    first = false;
     if (typeof slug !== "string") return;
-    const href = urlForSlug(window.location.href, slug);
+    const file = inspected();
+    const board = file?.pageSlug === slug ? file.fileName : undefined;
+    const href = urlForSlug(window.location.href, slug, board);
     if (href === window.location.href) return;
     if (push) window.history.pushState(null, "", href);
     else window.history.replaceState(null, "", href);
+  };
+
+  let applying = false;
+  const apply = () => {
+    applying = true;
+    let file: CanvasLibraryFile | null;
+    try {
+      file = applyCanvasFromUrl(editor, show);
+    } finally {
+      applying = false;
+    }
+    write(false);
+    return file;
+  };
+
+  // The first run is the subscription; `apply` writes the address right after it.
+  let first = true;
+  const stopSync = react("canvas page in the address", () => {
+    editor.getCurrentPageId();
+    if (first || applying) {
+      first = false;
+      return;
+    }
+    write(true);
   });
-  const onPopState = () => applyCanvasFromUrl(editor);
-  window.addEventListener("popstate", onPopState);
-  return () => {
-    stopSync();
-    window.removeEventListener("popstate", onPopState);
+  window.addEventListener("popstate", apply);
+  return {
+    apply,
+    write,
+    uninstall: () => {
+      stopSync();
+      window.removeEventListener("popstate", apply);
+    },
   };
 }
 
@@ -750,32 +799,74 @@ function initializeCanvas(editor: Editor) {
   applySnapDefault(editor);
   initializeCanvasLibrary(editor);
   editor.selectNone();
-  requestAnimationFrame(() => editor.zoomToFit());
 }
+
+/** Distance from the viewport's edge to the board the address named, in screen px. */
+const BOARD_ZOOM_INSET = 80;
 
 export default function App() {
   const [stylesVisible, setStylesVisible] = useState(false);
   /** The board open in the inspector: click any board on the canvas to open it, Escape or × to close. */
-  const [inspecting, setInspecting] = useState<{
-    path: string;
-    name: string;
-    w: number;
-    h: number;
-  } | null>(null);
+  const [inspecting, setInspecting] = useState<CanvasLibraryFile | null>(null);
   const editorRef = useRef<Editor | null>(null);
+  /** The same board, for the address writer, which runs outside React. */
+  const inspected = useRef<CanvasLibraryFile | null>(null);
+  /** Writes the address from the page and the inspector; installed with the editor. */
+  const writeUrl = useRef<(push: boolean) => void>(() => {});
+  /** A board the address named, for the camera to go to once the inspector is beside it. */
+  const zoomTo = useRef<CanvasLibraryFile | null>(null);
 
-  // Stable, so the panel's Escape listener is not torn down and rebound on every App render.
-  const onCloseInspector = useCallback(() => setInspecting(null), []);
-  const onPick = useCallback((shape: CanvasFileShape) => {
-    const { path, name, w, h } = shape.props;
-    setInspecting({ path, name, w, h });
+  /**
+   * Opens a board in the inspector, or closes it. A pick or a close is a new address; applying
+   * an address is not, and passes `push: false`.
+   */
+  const show = useCallback((file: CanvasLibraryFile | null, push: boolean) => {
+    inspected.current = file;
+    setInspecting(file);
+    if (push) writeUrl.current(true);
   }, []);
+  const onCloseInspector = useCallback(() => show(null, true), [show]);
+  const onPick = useCallback(
+    (shape: CanvasFileShape) => {
+      const file = readCanvasLibrary()
+        .flat()
+        .find((c) => c.path === shape.props.path);
+      if (file) show(file, true);
+    },
+    [show],
+  );
+
+  // The camera goes to a board the address named, after the inspector has taken its share of
+  // the window: a layout effect, so the panel is in the DOM, and the viewport measured here
+  // because tldraw measures it on a throttled resize observer, up to 200ms behind, which would
+  // fit the board to the canvas width the panel just took. Every `show` from an address is a
+  // fresh library object, so the effect runs even for the board already open.
+  useLayoutEffect(() => {
+    const editor = editorRef.current;
+    const file = zoomTo.current;
+    zoomTo.current = null;
+    if (!editor || !file) return;
+    const bounds = editor.getShapePageBounds(fileShapeId(file));
+    if (!bounds) return;
+    editor.updateViewportScreenBounds(editor.getContainer());
+    editor.zoomToBounds(bounds, { inset: BOARD_ZOOM_INSET });
+  }, [inspecting]);
 
   function handleMount(editor: Editor) {
     editorRef.current = editor;
     initializeCanvas(editor);
-    applyCanvasFromUrl(editor);
-    return installCanvasUrlSync(editor);
+    const sync = installCanvasUrlSync(
+      editor,
+      () => inspected.current,
+      (file) => {
+        zoomTo.current = file;
+        show(file, false);
+      },
+    );
+    writeUrl.current = sync.write;
+    // The address names a board, or the whole page is the view.
+    if (!sync.apply()) requestAnimationFrame(() => editor.zoomToFit());
+    return sync.uninstall;
   }
 
   return (
@@ -810,8 +901,8 @@ export default function App() {
           <InspectorPanel
             key={inspecting.path}
             path={inspecting.path}
-            name={inspecting.name}
-            size={{ w: inspecting.w, h: inspecting.h }}
+            name={inspecting.title}
+            size={boardSize(inspecting)}
             onClose={onCloseInspector}
           />
         ) : null}

--- a/canvas/src/App.tsx
+++ b/canvas/src/App.tsx
@@ -823,7 +823,10 @@ export default function App() {
   const show = useCallback((file: CanvasLibraryFile | null, push: boolean) => {
     inspected.current = file;
     setInspecting(file);
-    if (push) writeUrl.current(true);
+    if (push) {
+      zoomTo.current = null; // the reader's own pick or close, so no address is left to zoom to
+      writeUrl.current(true);
+    }
   }, []);
   const onCloseInspector = useCallback(() => show(null, true), [show]);
   const onPick = useCallback(

--- a/canvas/src/canvasUrl.test.ts
+++ b/canvas/src/canvasUrl.test.ts
@@ -1,26 +1,42 @@
 import { describe, expect, it } from 'vitest'
-import { WELCOME_PAGE_SLUG, slugFromUrl, urlForSlug } from './canvasUrl'
+import { WELCOME_PAGE_SLUG, boardFromUrl, slugFromUrl, urlForSlug } from './canvasUrl'
 
 // The address is what people paste to each other, so both directions have to agree: the URL a
-// page writes must open that page, and the welcome page must write the bare URL back.
+// page writes must open that page, the URL a board writes must open that board, and the welcome
+// page must write the bare URL back.
 describe('canvas URLs', () => {
   const root = 'https://prototyping.rescience.com/'
 
-  it('reads a board slug and falls back to the welcome page', () => {
+  it('reads a page slug and falls back to the welcome page', () => {
     expect(slugFromUrl(root + '?canvas=luma-ios')).toBe('luma-ios')
     expect(slugFromUrl(root)).toBe(WELCOME_PAGE_SLUG)
     expect(slugFromUrl(root + '?other=1')).toBe(WELCOME_PAGE_SLUG)
   })
 
-  it('writes a board as ?canvas= and the welcome page as the bare URL', () => {
+  it('reads a board from the hash, and none from an address without one', () => {
+    expect(boardFromUrl(root + '?canvas=luma-ios#03-event')).toBe('03-event')
+    expect(boardFromUrl(root + '#00-welcome')).toBe('00-welcome')
+    expect(boardFromUrl(root + '?canvas=luma-ios')).toBeUndefined()
+    expect(boardFromUrl(root + '?canvas=luma-ios#')).toBeUndefined()
+  })
+
+  it('writes a page as ?canvas= and the welcome page as the bare URL', () => {
     expect(urlForSlug(root, 'luma-ios')).toBe(root + '?canvas=luma-ios')
     expect(urlForSlug(root + '?canvas=luma-ios', 'notion-ios')).toBe(root + '?canvas=notion-ios')
     expect(urlForSlug(root + '?canvas=luma-ios', WELCOME_PAGE_SLUG)).toBe(root)
   })
 
+  it('writes a board as the hash, and drops it when none is open', () => {
+    expect(urlForSlug(root, 'luma-ios', '03-event')).toBe(root + '?canvas=luma-ios#03-event')
+    expect(urlForSlug(root + '?canvas=luma-ios#03-event', 'luma-ios')).toBe(root + '?canvas=luma-ios')
+    expect(urlForSlug(root + '?canvas=luma-ios#03-event', 'notion-ios')).toBe(root + '?canvas=notion-ios')
+    expect(urlForSlug(root, WELCOME_PAGE_SLUG, '00-welcome')).toBe(root + '#00-welcome')
+  })
+
   it('round-trips and keeps unrelated parameters', () => {
-    const href = urlForSlug(root + '?other=1', 'raycast-ios')
+    const href = urlForSlug(root + '?other=1', 'raycast-ios', '02-home')
     expect(slugFromUrl(href)).toBe('raycast-ios')
+    expect(boardFromUrl(href)).toBe('02-home')
     expect(new URL(href).searchParams.get('other')).toBe('1')
     expect(new URL(urlForSlug(href, WELCOME_PAGE_SLUG)).search).toBe('?other=1')
   })

--- a/canvas/src/canvasUrl.test.ts
+++ b/canvas/src/canvasUrl.test.ts
@@ -18,6 +18,14 @@ describe('canvas URLs', () => {
     expect(boardFromUrl(root + '#00-welcome')).toBe('00-welcome')
     expect(boardFromUrl(root + '?canvas=luma-ios')).toBeUndefined()
     expect(boardFromUrl(root + '?canvas=luma-ios#')).toBeUndefined()
+    expect(boardFromUrl(root + '?canvas=luma-ios#%')).toBeUndefined()
+    expect(boardFromUrl(root + '?canvas=luma-ios#%E0%A4%A')).toBeUndefined()
+  })
+
+  it('round-trips a file name the hash would otherwise mangle', () => {
+    for (const name of ['03 event', '100%-width', 'a#b?c']) {
+      expect(boardFromUrl(urlForSlug(root, 'luma-ios', name))).toBe(name)
+    }
   })
 
   it('writes a page as ?canvas= and the welcome page as the bare URL', () => {

--- a/canvas/src/canvasUrl.ts
+++ b/canvas/src/canvasUrl.ts
@@ -13,10 +13,18 @@ export function slugFromUrl(href: string) {
   return new URL(href).searchParams.get(CANVAS_PARAM) ?? WELCOME_PAGE_SLUG;
 }
 
-/** The board an address opens, by file name: its hash, else nothing. */
+/**
+ * The board an address opens, by file name: its hash, else nothing. The hash is typed by hand,
+ * so a broken escape in it is a board that does not exist, not an error.
+ */
 export function boardFromUrl(href: string) {
   const { hash } = new URL(href);
-  return hash ? decodeURIComponent(hash.slice(1)) : undefined;
+  if (!hash) return undefined;
+  try {
+    return decodeURIComponent(hash.slice(1));
+  } catch {
+    return undefined;
+  }
 }
 
 /**
@@ -27,6 +35,6 @@ export function urlForSlug(href: string, slug: string, board?: string) {
   const url = new URL(href);
   if (slug === WELCOME_PAGE_SLUG) url.searchParams.delete(CANVAS_PARAM);
   else url.searchParams.set(CANVAS_PARAM, slug);
-  url.hash = board ?? "";
+  url.hash = board ? encodeURIComponent(board) : "";
   return url.href;
 }

--- a/canvas/src/canvasUrl.ts
+++ b/canvas/src/canvasUrl.ts
@@ -1,6 +1,8 @@
-// The address of a page. A board is `?canvas=<slug>`, the canvases/<slug> folder name; the
-// welcome page is the bare URL, so the way in stays the shortest link there is. Anything else
-// in the query string is left alone.
+// The address of what is on screen. A page is `?canvas=<slug>`, the canvases/<slug> folder
+// name; the welcome page is the bare URL, so the way in stays the shortest link there is. A
+// board of that page is the hash, `?canvas=<slug>#<file>` for canvases/<slug>/<file>.html: the
+// board open in the inspector, and what a link to one board points at. Anything else in the
+// query string is left alone.
 
 export const WELCOME_PAGE_SLUG = "00-welcome";
 
@@ -11,10 +13,20 @@ export function slugFromUrl(href: string) {
   return new URL(href).searchParams.get(CANVAS_PARAM) ?? WELCOME_PAGE_SLUG;
 }
 
-/** The address for a page slug, built on `href` so the origin, path and other parameters stay. */
-export function urlForSlug(href: string, slug: string) {
+/** The board an address opens, by file name: its hash, else nothing. */
+export function boardFromUrl(href: string) {
+  const { hash } = new URL(href);
+  return hash ? decodeURIComponent(hash.slice(1)) : undefined;
+}
+
+/**
+ * The address for a page slug and, if one is open, a board of it, built on `href` so the
+ * origin, path and other parameters stay.
+ */
+export function urlForSlug(href: string, slug: string, board?: string) {
   const url = new URL(href);
   if (slug === WELCOME_PAGE_SLUG) url.searchParams.delete(CANVAS_PARAM);
   else url.searchParams.set(CANVAS_PARAM, slug);
+  url.hash = board ?? "";
   return url.href;
 }

--- a/docs/2026-09-08-board-links.md
+++ b/docs/2026-09-08-board-links.md
@@ -1,0 +1,43 @@
+# Every board has an address
+
+2026-09-08. A page had a link, `?canvas=<slug>`, and a board did not, so pointing at one screen
+meant "the third one in the second row of luma-ios". Now `?canvas=<slug>#<file>` is that board,
+`canvases/<slug>/<file>.html`: open the link and it is in the inspector, with the camera on it.
+
+## What changed
+
+- The board goes in the hash, not a second query parameter. It is a location within the page,
+  which is what a fragment is, and it is what the address bar already shows when a board is
+  clicked: the inspector opening or closing writes the address, the way a page change always
+  has. `canvasUrl.ts` reads and writes both halves.
+- The address is derived, never edited in place. `installCanvasUrlSync` in `App.tsx` computes it
+  from two things, the current page and the board in the inspector, and the board only counts
+  when it is one of that page's. Two writers (the page reaction, the inspector's open and close)
+  call one `write`, so they cannot disagree, and an inspector left open across a page change
+  simply drops out of the address.
+- Applying an address is the one time the page changes without the address needing to follow.
+  The reaction stands down while `apply` runs, and `apply` corrects the address once, without a
+  history entry, when it named a page or board that does not exist.
+- The hash edited by hand in the address bar is a same-document navigation, so it arrives as a
+  `popstate` and goes through the same `apply` as Back and Forward.
+- The camera goes to the board after the inspector has taken its share of the window, in a
+  layout effect. tldraw measures its viewport on a throttled resize observer, up to 200ms
+  behind, so the effect measures it itself (`updateViewportScreenBounds`) before `zoomToBounds`;
+  without that the board is fitted to the width the panel just took. When the address names a
+  board the page is not zoomed to fit first, or the fit would land after and undo it.
+
+## Not changed
+
+- `?canvas=<slug>` alone does what it did: the page, zoomed to fit, no inspector.
+- Clicking a board does not move the camera. The reader just clicked it.
+- The inspector still stays open across a page change; only the address stops naming it.
+
+## Checked
+
+Headless Chrome (Playwright) against the dev server: a board link opens the inspector on that
+board with the board fully in view and centred in the canvas beside the panel, and pushes
+nothing; closing drops the hash and pushes one entry; Back reopens the board; clicking another
+board writes its hash; a page-menu change writes `?canvas=` without a hash and Back restores
+page and board; an unknown hash, edited in place or on a fresh load, leaves the inspector closed
+and is replaced, not pushed; `#00-welcome` works on the bare URL; a page link alone writes
+nothing and shows the whole row.

--- a/mockups/canvases/README.md
+++ b/mockups/canvases/README.md
@@ -33,8 +33,10 @@ candidate boards, goes in `<slug>/scratch/`. The root `.gitignore` ignores
 `scratch/` at any depth, and `assets/refs/` too, which is where third-party
 captures go. No folder needs a `.gitignore` of its own.
 
-Switch boards with the page menu at the top-left of the canvas. Deep-link a
-board with `?canvas=<slug>`, e.g. `http://127.0.0.1:5173/?canvas=notion-ios`.
+Switch pages with the page menu at the top-left of the canvas. Deep-link a
+page with `?canvas=<slug>`, e.g. `http://127.0.0.1:5173/?canvas=notion-ios`,
+and one board of it with `#<file>` after that, e.g.
+`?canvas=notion-ios#02-search-ask-ai`.
 
 ## 00-welcome
 

--- a/skills/clone-prototype/SKILL.md
+++ b/skills/clone-prototype/SKILL.md
@@ -469,6 +469,9 @@ empty folder is not a board.
 open "http://127.0.0.1:<port>/?canvas=<slug>"
 ```
 
+`#<file>` after that opens one board in the inspector, with the camera on
+it: `?canvas=<slug>#03-home` is the link to give for one screen.
+
 ---
 
 ## Phase 6: the folder documents itself

--- a/skills/clone-prototype/SKILL.md
+++ b/skills/clone-prototype/SKILL.md
@@ -461,7 +461,7 @@ the capture itself.
 
 **Open the board as soon as its first HTML file lands.** The dev server
 watches the boards directory and picks up a folder created after it booted,
-so there is nothing to restart. If `?canvas=<slug>` opens the wrong board
+so there is nothing to restart. If `?canvas=<slug>` opens the wrong page
 anyway — right URL, no error — the folder holds no `.html` file yet, and an
 empty folder is not a board.
 

--- a/skills/prototype-canvas/SKILL.md
+++ b/skills/prototype-canvas/SKILL.md
@@ -41,8 +41,11 @@ actually bind, and prints the address.
 - `sp-canvas root` prints which copy of the app it found — and with `-v`,
   everywhere it looked. The first thing to run when the canvas is not what
   you expected.
-- Deep-link a board with `?canvas=<slug>`, e.g.
-  `http://127.0.0.1:5173/?canvas=notion-ios`.
+- Deep-link a page with `?canvas=<slug>`, e.g.
+  `http://127.0.0.1:5173/?canvas=notion-ios`, and one board of it with
+  `#<file>` after that, e.g. `?canvas=notion-ios#02-search-ask-ai`: it opens
+  in the inspector with the camera on it. Give the board link when pointing
+  at one screen.
 
 Keep it on loopback. This is a local design tool, not a service to expose.
 

--- a/tools/sp_canvas.py
+++ b/tools/sp_canvas.py
@@ -244,8 +244,8 @@ def cmd_start(a):
     print(f"boards   {boards}")
     print(f"app      {app}")
     print(f"running  {how}")
-    print(f"\nDeep-link one board with ?canvas=<slug>, "
-          f"e.g. http://127.0.0.1:{a.port}/?canvas=notion-ios")
+    print(f"\nDeep-link a page with ?canvas=<slug>, one board of it with #<file>, "
+          f"e.g. http://127.0.0.1:{a.port}/?canvas=notion-ios#01-splash")
 
 
 def _is_our_server(pid, port):


### PR DESCRIPTION
## What

A page had a link (`?canvas=<slug>`) and a board did not, so pointing at one screen meant "the third one in the second row of luma-ios". Now `?canvas=<slug>#<file>` is that board: open the link and it is in the inspector, with the camera on it. Click any board and its link is in the address bar; close the inspector and the hash goes.

## How

- `canvasUrl.ts` reads and writes both halves of the address; the board is the hash, a location within the page.
- `installCanvasUrlSync` derives the address from two things, the current page and the board in the inspector (only when it belongs to that page), through one `write`. Page changes and inspector open/close push; applying an address (load, Back, Forward, an edited hash) never pushes, and corrects a bad address once by replace.
- The camera goes to the board in a layout effect after the panel has taken its width, measuring the viewport itself (`updateViewportScreenBounds`) since tldraw's resize observer is throttled. When the address names a board, the page is not zoomed to fit first.
- Docs updated (README, both skills, canvases README) and a decision note in `docs/2026-09-08-board-links.md`.

## Checked

- `tsc -b`, `oxlint`, `vitest` (38 passed, 5 new for `canvasUrl`).
- Headless Chrome against the dev server, 27 checks: board link opens the inspector with the board fully in view beside the panel and pushes nothing; close drops the hash with one push; Back reopens it; clicking a board writes its hash; page-menu change writes `?canvas=` without hash and Back restores page and board; unknown hash (edited or on load) leaves the inspector closed and is replaced, not pushed; `#00-welcome` works on the bare URL; a page link alone writes nothing and shows the whole row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
