### PR TITLE
canvas: an inline svg is a vector asset in the inspector

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,9 @@ Rules inside a canvas folder:
   `name → data URI` map of pre-encoded images the generator inlines, not
   evidence. The canvas's inspector names a board's images by content, from
   `assets/` first and `assets.json` second, so a re-encoded image that
-  matches neither falls back to its `alt`.
+  matches neither falls back to its `alt`. An inline `<svg>` is named the
+  same way from `assets/icons/`, by its geometry rather than its bytes, and
+  handed back as a vector asset.
 - Never commit `ref-*.html` or `assets/refs/`. They hold third-party
   captures, the root `.gitignore` already excludes them, and the
   clone-prototype skill rebuilds them. `spotify-ios` is the one exception:

--- a/canvas/src/InspectorPanel.tsx
+++ b/canvas/src/InspectorPanel.tsx
@@ -382,7 +382,10 @@ export function InspectorPanel({
                     {selAsset.name}
                   </span>
                   <span className="sp-asset-view-d">
-                    {selAsset.w} × {selAsset.h} · {formatBytes(selAsset.bytes)}
+                    {selAsset.via === "svg"
+                      ? `${fmt(selAsset.w)} × ${fmt(selAsset.h)} · svg`
+                      : `${selAsset.w} × ${selAsset.h} · ${formatBytes(selAsset.bytes)}`}
+                    {selAsset.svg ? <CopySvg key={selAsset.key} svg={selAsset.svg} /> : null}
                   </span>
                 </figcaption>
               </figure>
@@ -401,7 +404,7 @@ export function InspectorPanel({
                   name={name}
                   path={path}
                   data={data}
-                  assets={assets.length}
+                  assets={assets}
                   usedTokens={usedTokens}
                 />
               ) : (
@@ -430,7 +433,34 @@ export function InspectorPanel({
   );
 }
 
+/** The vector asset, to the clipboard: the markup as it stands alone, for Figma or another gen.py. */
+function CopySvg({ svg }: { svg: string }) {
+  const [copied, setCopied] = useState(false);
+  useEffect(() => {
+    if (!copied) return;
+    const t = setTimeout(() => setCopied(false), 1500);
+    return () => clearTimeout(t);
+  }, [copied]);
+  return (
+    <button
+      type="button"
+      className="sp-copy"
+      onClick={() => void navigator.clipboard.writeText(svg).then(() => setCopied(true))}
+    >
+      {copied ? "Copied" : "Copy SVG"}
+    </button>
+  );
+}
+
 function LayerIcon({ kind }: { kind: ReturnType<typeof layerKind> }) {
+  if (kind === "vector")
+    return (
+      <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor">
+        <path d="M2.5 9.5C2.5 4.5 7.5 7.5 9.5 2.5" />
+        <circle cx="2.5" cy="9.5" r="1.2" fill="currentColor" stroke="none" />
+        <circle cx="9.5" cy="2.5" r="1.2" fill="currentColor" stroke="none" />
+      </svg>
+    );
   if (kind === "text")
     return (
       <svg width="12" height="12" viewBox="0 0 12 12" fill="currentColor">
@@ -484,13 +514,16 @@ function Layers({
     if (sel === null) return;
     list.current?.querySelector(`[data-i="${sel}"]`)?.scrollIntoView({ block: "nearest" });
   }, [sel]);
+  // An icon is one layer: the paths inside an svg stay indexed (the Tokens tab counts uses on
+  // them) but are not listed.
+  const rows = nodes.filter((n) => !n.inSvg);
   return (
     <div className="sp-layers" style={{ height }} ref={list} onMouseLeave={() => onHover(null)}>
       <div className="sp-sh">
         <span className="sp-sh-t">Layers</span>
-        <span className="sp-sh-s">{Math.max(0, nodes.length - 1)}</span>
+        <span className="sp-sh-s">{Math.max(0, rows.length - 1)}</span>
       </div>
-      {nodes.map((n) => (
+      {rows.map((n) => (
         <button
           key={n.i}
           type="button"
@@ -524,11 +557,12 @@ function Summary({
   name: string;
   path: string;
   data: SpReady;
-  assets: number;
+  assets: AssetRow[];
   usedTokens: number;
 }) {
   const file = path.slice(path.lastIndexOf("/") + 1);
   const root = data.nodes[0];
+  const vectors = assets.filter((a) => a.via === "svg").length;
   return (
     <div className="sp-sec">
       <div className="sp-sh">
@@ -537,7 +571,8 @@ function Summary({
       </div>
       <Row k="Frame" v={root?.box ? `${fmt(root.box.w)} × ${fmt(root.box.h)}` : "–"} />
       <Row k="Layers" v={String(Math.max(0, data.nodes.length - 1))} />
-      <Row k="Images" v={String(assets)} />
+      <Row k="Images" v={String(assets.length - vectors)} />
+      <Row k="Vectors" v={String(vectors)} />
       <Row k="Tokens" v={`${usedTokens} used of ${data.tokens.length}`} />
       <div className="sp-hint">Click a layer, or an element in the preview.</div>
     </div>
@@ -770,7 +805,7 @@ function Assets({
   onSelect: (i: number) => void;
   onHover: (i: number | null) => void;
 }) {
-  if (!rows.length) return <div className="sp-empty">No images on this board.</div>;
+  if (!rows.length) return <div className="sp-empty">No images or vectors on this board.</div>;
   return (
     <div className="sp-scroll" onMouseLeave={() => onHover(null)}>
       <div className="sp-sh sp-sh--pad">
@@ -785,19 +820,19 @@ function Assets({
             key={a.key}
             type="button"
             className={cx("sp-asset", on && "on", hovered && "hov")}
-            title={`${a.name}\n${a.mime} · ${formatBytes(a.bytes)} · ${a.via === "css" ? "background" : "img"}`}
+            title={`${a.name}\n${a.mime} · ${formatBytes(a.bytes)} · ${a.via === "css" ? "background" : a.via}`}
             onClick={() => onSelect(a.uses[0])}
             onMouseEnter={() => onHover(a.uses[0])}
           >
-            <span className="sp-th">
+            <span className={cx("sp-th", a.via === "svg" && "svg")}>
               <img src={a.uri} alt="" />
             </span>
             <span className="sp-asset-n">
               {a.source === "file" ? a.name : <i>{a.name}</i>}
-              {a.source === "alt" ? <small>alt</small> : null}
+              {a.source === "alt" || a.source === "label" ? <small>{a.source}</small> : null}
             </span>
             <span className="sp-asset-d">
-              {a.w && a.h ? `${a.w} × ${a.h}` : formatBytes(a.bytes)}
+              {a.w && a.h ? `${fmt(a.w)} × ${fmt(a.h)}` : formatBytes(a.bytes)}
               {a.uses.length > 1 ? ` · ×${a.uses.length}` : ""}
             </span>
           </button>

--- a/canvas/src/InspectorPanel.tsx
+++ b/canvas/src/InspectorPanel.tsx
@@ -570,7 +570,7 @@ function Summary({
         <span className="sp-sh-s">{file}</span>
       </div>
       <Row k="Frame" v={root?.box ? `${fmt(root.box.w)} × ${fmt(root.box.h)}` : "–"} />
-      <Row k="Layers" v={String(Math.max(0, data.nodes.length - 1))} />
+      <Row k="Layers" v={String(Math.max(0, data.nodes.filter((n) => !n.inSvg).length - 1))} />
       <Row k="Images" v={String(assets.length - vectors)} />
       <Row k="Vectors" v={String(vectors)} />
       <Row k="Tokens" v={`${usedTokens} used of ${data.tokens.length}`} />

--- a/canvas/src/index.css
+++ b/canvas/src/index.css
@@ -284,8 +284,22 @@ button {
 }
 
 .sp-asset-view-d {
+  display: flex;
+  align-items: baseline;
   color: var(--sp-text-2);
   font-family: var(--sp-mono);
+}
+
+.sp-copy {
+  margin-left: auto;
+  padding: 0 6px;
+  border-radius: 4px;
+  font-family: inherit;
+  color: var(--sp-accent);
+}
+
+.sp-copy:hover {
+  background: var(--sp-hover);
 }
 
 .sp-board {
@@ -759,6 +773,17 @@ button {
   max-width: 28px;
   max-height: 28px;
   object-fit: contain;
+}
+
+/* A vector is drawn in whatever colour the board gave it, black included, so its thumb takes
+   the checkerboard the selected view uses rather than the dark ground the photos sit on. */
+.sp-th.svg {
+  background-color: #fff;
+  background-image:
+    linear-gradient(45deg, #eeeeee 25%, transparent 25%, transparent 75%, #eeeeee 75%),
+    linear-gradient(45deg, #eeeeee 25%, transparent 25%, transparent 75%, #eeeeee 75%);
+  background-size: 8px 8px;
+  background-position: 0 0, 4px 4px;
 }
 
 .sp-asset-n {

--- a/canvas/src/inspectorAgent.ts
+++ b/canvas/src/inspectorAgent.ts
@@ -318,6 +318,7 @@ function addAsset(i,uri,via,el){var c=uri.indexOf(','),payload=uri.slice(c+1),k=
    supplied (currentColor, var(), a fill from a stylesheet) are written in, and xmlns is added
    where a literal icon had none — so an <img> in the parent draws it and Figma accepts it. */
 function addSvg(i,el){
+  if(!el.querySelector('path,rect,circle,ellipse,line,polygon,polyline,text,image,use'))return;
   var c=el.cloneNode(true),cs=getComputedStyle(el),inner=c.querySelectorAll('[data-sp]'),n;
   for(n=0;n<inner.length;n++)inner[n].removeAttribute('data-sp');
   c.removeAttribute('data-sp');c.removeAttribute('style');c.removeAttribute('class');c.removeAttribute('preserveAspectRatio');
@@ -326,7 +327,10 @@ function addSvg(i,el){
   if(!c.hasAttribute('stroke'))c.setAttribute('stroke',cs.stroke);
   var svg=c.outerHTML.replace(/currentColor/gi,cs.color)
     .replace(/var\(\s*(--[\w-]+)[^)]*\)/g,function(m,p){return cs.getPropertyValue(p).replace(/^\s+|\s+$/g,'')||m;});
-  var k='svg:'+fnv(svgSignature(svg)),a=byKey[k];
+  /* One row per glyph and colour: the geometry key joins the file, and the colours after it keep
+     a red and a black instance of the same glyph apart, so what a row shows is what it copies.
+     ponytail: the root's computed colours; a colour that differs only in a child's var() collapses. */
+  var k='svg:'+fnv(svgSignature(svg))+':'+fnv(cs.fill+'|'+cs.stroke+'|'+cs.color),a=byKey[k];
   if(!a){var vb=(el.getAttribute('viewBox')||'').split(/[\s,]+/);
     a=byKey[k]={key:k,uri:'data:image/svg+xml;charset=utf-8,'+encodeURIComponent(svg),via:'svg',mime:'image/svg+xml',
       chars:svg.length,w:+vb[2]||0,h:+vb[3]||0,alt:svgLabel(el),svg:svg,uses:[]};assets.push(a);}

--- a/canvas/src/inspectorAgent.ts
+++ b/canvas/src/inspectorAgent.ts
@@ -325,6 +325,13 @@ function addSvg(i,el){
   if(!c.hasAttribute('xmlns'))c.setAttribute('xmlns','http://www.w3.org/2000/svg');
   if(!c.hasAttribute('fill'))c.setAttribute('fill',cs.fill);
   if(!c.hasAttribute('stroke'))c.setAttribute('stroke',cs.stroke);
+  /* A stylesheet rule on a child (apple-wallet's .ds path{fill:…}) leaves the copy: write a child's
+     computed fill/stroke in where it differs from its parent's and no attribute carries it.
+     ponytail: fill and stroke only; opacity or a dasharray from a stylesheet is lost. */
+  var src=el.querySelectorAll('*'),dst=c.querySelectorAll('*'),j,s,ps;
+  for(j=0;j<src.length;j++){s=getComputedStyle(src[j]);ps=getComputedStyle(src[j].parentNode);
+    if(!dst[j].hasAttribute('fill')&&s.fill!==ps.fill)dst[j].setAttribute('fill',s.fill);
+    if(!dst[j].hasAttribute('stroke')&&s.stroke!==ps.stroke)dst[j].setAttribute('stroke',s.stroke);}
   var svg=c.outerHTML.replace(/currentColor/gi,cs.color)
     .replace(/var\(\s*(--[\w-]+)[^)]*\)/g,function(m,p){return cs.getPropertyValue(p).replace(/^\s+|\s+$/g,'')||m;});
   /* One row per glyph and colour: the geometry key joins the file, and the colours after it keep

--- a/canvas/src/inspectorAgent.ts
+++ b/canvas/src/inspectorAgent.ts
@@ -10,8 +10,10 @@
  * The script is ES5 and lives in a `String.raw` literal, so a regex backslash is written once.
  * Two rules keep it embeddable: no backtick and no `${` anywhere in it (inspectorAgent.test.ts
  * checks), and the closing `</script>` is assembled in injectAgent so the literal never holds
- * one.
+ * one. `svgSignature.ts` is the one piece of it written elsewhere: its source is spliced in ahead
+ * of the body, so the frame signs a vector exactly as the build-time index does.
  */
+import { svgSignature } from "./svgSignature";
 
 export interface SpBox {
   x: number;
@@ -30,24 +32,33 @@ export interface SpNode {
   alt: string;
   depth: number;
   parent: number;
-  /** Whether an image asset is drawn here, as `<img>` or as a CSS background. */
+  /** Whether an asset is drawn here: an `<img>`, a CSS background or an inline `<svg>`. */
   img: boolean;
+  /** Inside an `<svg>`: a path, a group, a gradient stop. The layers list hides these. */
+  inSvg?: boolean;
   /** Relative to the root, in board px. Null only before layout. */
   box: SpBox | null;
 }
 
 /** One distinct image on the board, keyed the way the build-time index keys the folder's files. */
 export interface SpAsset {
-  /** `"<payload length>:<fnv1a>"` of the base64 payload; joins against rawAssetNames. */
+  /**
+   * `"<payload length>:<fnv1a>"` of the base64 payload, or `"svg:<fnv1a>"` of an inline vector's
+   * geometry signature; joins against rawAssetNames.
+   */
   key: string;
   uri: string;
-  via: "img" | "css";
+  via: "img" | "css" | "svg";
   mime: string;
-  /** Payload length in characters. */
+  /** Payload length in characters; for a vector, the standalone markup's. */
   chars: number;
+  /** For a vector, the viewBox size in board units. */
   w: number;
   h: number;
+  /** The `alt`; for a vector, its accessible name, class or the caption beside it. */
   alt: string;
+  /** A vector on its own: cascade colours written in, xmlns added. What Copy SVG hands out. */
+  svg?: string;
   /** Node indices that draw it. */
   uses: number[];
 }
@@ -280,11 +291,12 @@ window.__spTokens=T;
 var els=[root],nodes=[],i;
 Array.prototype.forEach.call(root.querySelectorAll('*'),function(el){if(el.tagName==='STYLE'||el.tagName==='SCRIPT')return;els.push(el);});
 for(i=0;i<els.length;i++)els[i].setAttribute('data-sp',i);
+function inSvg(el){var p=el.parentElement;return !!(p&&p.closest('svg'));}
 for(i=0;i<els.length;i++){var el=els[i],p=el.parentElement,up=-1;
   while(i>0&&p){var ps=p.getAttribute('data-sp');if(ps!==null){up=+ps;break;}p=p.parentElement;}
   nodes.push({i:i,tag:el.tagName.toLowerCase(),cls:el.getAttribute('class')||'',
     text:el.children.length?'':(el.textContent||'').replace(/\s+/g,' ').replace(/^\s+|\s+$/g,'').slice(0,60),
-    alt:el.getAttribute('alt')||'',depth:up>=0?nodes[up].depth+1:0,parent:up,img:false,box:null});}
+    alt:el.getAttribute('alt')||'',depth:up>=0?nodes[up].depth+1:0,parent:up,img:false,inSvg:inSvg(el),box:null});}
 function box(el){var r=el.getBoundingClientRect(),o=root.getBoundingClientRect();
   return{x:+(r.left-o.left).toFixed(2),y:+(r.top-o.top).toFixed(2),w:+r.width.toFixed(2),h:+r.height.toFixed(2)};}
 
@@ -300,12 +312,49 @@ function addAsset(i,uri,via,el){var c=uri.indexOf(','),payload=uri.slice(c+1),k=
   if(via==='img'){if(el.naturalWidth){a.w=el.naturalWidth;a.h=el.naturalHeight;}if(!a.alt)a.alt=el.getAttribute('alt')||'';}
   if(a.uses.indexOf(i)<0)a.uses.push(i);nodes[i].img=true;}
 
+/* An inline <svg> is an asset too, keyed by its geometry rather than its bytes: the generators'
+   icon() writes class, style and preserveAspectRatio into the root tag on the way in, so the
+   board's markup is never the file's. The copy handed out stands alone — the colours the cascade
+   supplied (currentColor, var(), a fill from a stylesheet) are written in, and xmlns is added
+   where a literal icon had none — so an <img> in the parent draws it and Figma accepts it. */
+function addSvg(i,el){
+  var c=el.cloneNode(true),cs=getComputedStyle(el),inner=c.querySelectorAll('[data-sp]'),n;
+  for(n=0;n<inner.length;n++)inner[n].removeAttribute('data-sp');
+  c.removeAttribute('data-sp');c.removeAttribute('style');c.removeAttribute('class');c.removeAttribute('preserveAspectRatio');
+  if(!c.hasAttribute('xmlns'))c.setAttribute('xmlns','http://www.w3.org/2000/svg');
+  if(!c.hasAttribute('fill'))c.setAttribute('fill',cs.fill);
+  if(!c.hasAttribute('stroke'))c.setAttribute('stroke',cs.stroke);
+  var svg=c.outerHTML.replace(/currentColor/gi,cs.color)
+    .replace(/var\(\s*(--[\w-]+)[^)]*\)/g,function(m,p){return cs.getPropertyValue(p).replace(/^\s+|\s+$/g,'')||m;});
+  var k='svg:'+fnv(svgSignature(svg)),a=byKey[k];
+  if(!a){var vb=(el.getAttribute('viewBox')||'').split(/[\s,]+/);
+    a=byKey[k]={key:k,uri:'data:image/svg+xml;charset=utf-8,'+encodeURIComponent(svg),via:'svg',mime:'image/svg+xml',
+      chars:svg.length,w:+vb[2]||0,h:+vb[3]||0,alt:svgLabel(el),svg:svg,uses:[]};assets.push(a);}
+  if(a.uses.indexOf(i)<0)a.uses.push(i);nodes[i].img=true;}
+/* No board writes a title on its icons, so with no file to name one the name is a guess from
+   context: the accessible name if there is one; else a class, when it is a word (logo, aiface)
+   and not a generator's abbreviation (i, mk); else a caption, which is the one short leaf of text
+   beside the icon within two ancestors — the span under a tab icon, the label in a chip. A clock,
+   a keyboard row, a whole composer or a screen of text is not a caption: the icon stays nameless.
+   ponytail: two ancestors and one leaf sibling is the ceiling; a <title> in the svg beats it. */
+function svgLabel(el){var t=el.querySelector('title'),c=(el.getAttribute('class')||'').split(/\s+/)[0],p=el.parentElement,d,k,n,s,one;
+  if(el.getAttribute('aria-label'))return el.getAttribute('aria-label');
+  if(t&&t.textContent)return t.textContent.replace(/^\s+|\s+$/g,'');
+  if(c.length>=3)return c;
+  for(d=0;p&&d<2;d++,p=p.parentElement){one=null;
+    for(k=0;k<p.childNodes.length;k++){n=p.childNodes[k];if(n.nodeType===1?(n.contains(el)||n.children.length):n.nodeType!==3)continue;
+      s=(n.textContent||'').replace(/\s+/g,' ').replace(/^\s+|\s+$/g,'');if(!s)continue;
+      if(one!==null||s.length>40||!/[a-z]/i.test(s)){one=false;break;}one=s;}
+    if(one)return one;}
+  return '';}
+
 /* Every box is read after layout. A script at the end of the body runs at readyState
    'interactive', before the first layout pass and before the data: URIs have decoded, so
    measuring here reports 0x0 for every element on every board. */
 function measure(){
   for(var i=0;i<els.length;i++){var el=els[i];nodes[i].box=box(el);
     if(el.tagName==='IMG'){var src=el.getAttribute('src')||'';if(src.indexOf('data:')===0)addAsset(i,src,'img',el);}
+    else if(el.tagName==='svg'&&!nodes[i].inSvg)addSvg(i,el);
     var bg=getComputedStyle(el).backgroundImage;
     if(bg&&bg.indexOf('data:')>=0){var re=/url\("?(data:image[^")]+)"?\)/g,m;while((m=re.exec(bg)))addAsset(i,m[1],'css',el);}}}
 
@@ -356,15 +405,21 @@ addEventListener('message',function(e){var d=e.data;if(!d||typeof d!=='object')r
   else if(d.type==='sp:sel')select(d.i);
   else if(d.type==='sp:hover')hover(d.i);});
 
-function pick(e){var el=e.target&&e.target.closest?e.target.closest('[data-sp]'):null;return el?+el.getAttribute('data-sp'):null;}
+/* A click on a path is a click on its icon: the layers list shows the svg as one layer. */
+function pick(e){var el=e.target&&e.target.closest?e.target.closest('[data-sp]'):null;if(el&&el.closest('svg'))el=el.closest('svg');return el?+el.getAttribute('data-sp'):null;}
 var lastHover=null;
 document.addEventListener('click',function(e){var i=pick(e);if(i===null)return;e.preventDefault();parent.postMessage({type:'sp:pick',i:i},'*');},true);
 document.addEventListener('mousemove',function(e){var i=pick(e);if(i===lastHover)return;lastHover=i;hover(i);parent.postMessage({type:'sp:hover',i:i},'*');},true);
 document.addEventListener('mouseleave',function(){lastHover=null;hover(null);parent.postMessage({type:'sp:hover',i:null},'*');},true);
 })();`;
 
-/** The whole tag, as spliced into a board. Exported for the tests and the Playwright sweeps. */
-export const AGENT = "<script>" + AGENT_BODY + "</" + "script>";
+/**
+ * The whole tag, as spliced into a board. Exported for the tests and the Playwright sweeps. The
+ * signature function rides along as its own source: it has no outer references, so the text is
+ * the same function whether the bundle was minified or not.
+ */
+export const AGENT =
+  "<script>var svgSignature=" + svgSignature.toString() + ";" + AGENT_BODY + "</" + "script>";
 
 /**
  * Not every board has a `</body>`: the apple-* generators emit none, so those get the agent

--- a/canvas/src/inspectorModel.test.ts
+++ b/canvas/src/inspectorModel.test.ts
@@ -57,7 +57,7 @@ describe("assetRows", () => {
 
   const vector = (over: Partial<SpAsset>) =>
     asset({
-      key: "svg:k1",
+      key: "svg:k1:c1",
       via: "svg",
       mime: "image/svg+xml",
       uri: "data:image/svg+xml;charset=utf-8,%3Csvg%2F%3E",
@@ -69,7 +69,10 @@ describe("assetRows", () => {
     });
 
   it("names a vector from the folder's icon by geometry key, and carries its markup", () => {
-    const [row] = assetRows([vector({})], { "svg:k1": { name: "assets/icons/tab-photos.svg", bytes: 2100 } });
+    const names = { "svg:k1": { name: "assets/icons/tab-photos.svg", bytes: 2100 } };
+    const [row, other] = assetRows([vector({}), vector({ key: "svg:k1:c2", svg: "<svg fill='red'/>" })], names);
+    expect(other.name).toBe("assets/icons/tab-photos.svg");
+    expect(other.svg).toBe("<svg fill='red'/>");
     expect(row.name).toBe("assets/icons/tab-photos.svg");
     expect(row.source).toBe("file");
     expect(row.svg).toBe("<svg/>");

--- a/canvas/src/inspectorModel.test.ts
+++ b/canvas/src/inspectorModel.test.ts
@@ -54,6 +54,39 @@ describe("assetRows", () => {
     expect(row.source).toBe("none");
     expect(row.bytes).toBe(300);
   });
+
+  const vector = (over: Partial<SpAsset>) =>
+    asset({
+      key: "svg:k1",
+      via: "svg",
+      mime: "image/svg+xml",
+      uri: "data:image/svg+xml;charset=utf-8,%3Csvg%2F%3E",
+      svg: "<svg/>",
+      chars: 6,
+      w: 28.705,
+      h: 23.719,
+      ...over,
+    });
+
+  it("names a vector from the folder's icon by geometry key, and carries its markup", () => {
+    const [row] = assetRows([vector({})], { "svg:k1": { name: "assets/icons/tab-photos.svg", bytes: 2100 } });
+    expect(row.name).toBe("assets/icons/tab-photos.svg");
+    expect(row.source).toBe("file");
+    expect(row.svg).toBe("<svg/>");
+  });
+
+  it("names a fileless vector from the label the agent guessed, marked as a guess", () => {
+    const [row] = assetRows([vector({ alt: "All Photos" })], {});
+    expect(row.name).toBe("All Photos");
+    expect(row.source).toBe("label");
+    expect(row.bytes).toBe(6);
+  });
+
+  it("falls back to svg and its viewBox size", () => {
+    const [row] = assetRows([vector({})], undefined);
+    expect(row.name).toBe("svg 28.705×23.719");
+    expect(row.source).toBe("none");
+  });
 });
 
 describe("formatBytes", () => {
@@ -90,6 +123,7 @@ describe("layers", () => {
   it("classifies the row's icon", () => {
     expect(layerKind(node({ i: 0 }))).toBe("frame");
     expect(layerKind(node({ img: true, text: "x" }))).toBe("image");
+    expect(layerKind(node({ tag: "svg", img: true }))).toBe("vector");
     expect(layerKind(node({ text: "x" }))).toBe("text");
     expect(layerKind(node({}))).toBe("box");
   });

--- a/canvas/src/inspectorModel.ts
+++ b/canvas/src/inspectorModel.ts
@@ -4,8 +4,11 @@
  */
 import type { SpAsset, SpGroup, SpNode, SpToken, SpTokenKind } from "./inspectorAgent";
 
-/** Where an asset's name came from, so a fallback is never passed off as a file name. */
-export type AssetNameSource = "file" | "alt" | "none";
+/**
+ * Where an asset's name came from, so a fallback is never passed off as a file name: `alt` is an
+ * image's own, `label` is a vector's guess from the class or the caption beside it.
+ */
+export type AssetNameSource = "file" | "alt" | "label" | "none";
 
 export interface AssetRow {
   key: string;
@@ -15,15 +18,18 @@ export interface AssetRow {
   w: number;
   h: number;
   mime: string;
-  via: "img" | "css";
+  via: SpAsset["via"];
   uri: string;
+  /** The standalone markup of a vector; what Copy SVG hands out. */
+  svg?: string;
   uses: number[];
 }
 
 /**
  * Joins the board's images against the folder's committed files by content. A generator that
  * re-encodes (a PIL resize) produces bytes that match nothing, so the image's alt text is the
- * fallback, and after that its format and size.
+ * fallback, and after that its format and size. A vector joins on its geometry, and falls back
+ * to the label the agent guessed for it.
  */
 export function assetRows(
   assets: SpAsset[],
@@ -31,19 +37,22 @@ export function assetRows(
 ): AssetRow[] {
   return assets.map((a) => {
     const hit = names?.[a.key];
-    const format = a.mime.replace(/^image\//, "") || "image";
+    const vector = a.via === "svg";
+    const format = a.mime.replace(/^image\//, "").replace(/\+xml$/, "") || "image";
     const name = hit ? hit.name : a.alt || `${format} ${a.w}×${a.h}`;
     return {
       key: a.key,
       name,
-      source: hit ? "file" : a.alt ? "alt" : "none",
-      // A base64 payload decodes to three bytes per four characters, less any padding.
-      bytes: hit ? hit.bytes : Math.floor((a.chars * 3) / 4),
+      source: hit ? "file" : !a.alt ? "none" : vector ? "label" : "alt",
+      // A base64 payload decodes to three bytes per four characters, less any padding; a vector
+      // is its own text.
+      bytes: hit ? hit.bytes : vector ? a.chars : Math.floor((a.chars * 3) / 4),
       w: a.w,
       h: a.h,
       mime: a.mime,
       via: a.via,
       uri: a.uri,
+      svg: a.svg,
       uses: a.uses,
     };
   });
@@ -55,11 +64,11 @@ export function formatBytes(n: number) {
   return `${(n / 1024 / 1024).toFixed(1)} MB`;
 }
 
-export type LayerKind = "frame" | "image" | "text" | "box";
+export type LayerKind = "frame" | "image" | "vector" | "text" | "box";
 
 export function layerKind(node: SpNode): LayerKind {
   if (node.i === 0) return "frame";
-  if (node.img) return "image";
+  if (node.img) return node.tag === "svg" ? "vector" : "image";
   if (node.text) return "text";
   return "box";
 }

--- a/canvas/src/inspectorModel.ts
+++ b/canvas/src/inspectorModel.ts
@@ -36,8 +36,10 @@ export function assetRows(
   names: Record<string, { name: string; bytes: number }> | undefined,
 ): AssetRow[] {
   return assets.map((a) => {
-    const hit = names?.[a.key];
     const vector = a.via === "svg";
+    // A vector's key is its geometry key and then the colours it was drawn in; the file joins on
+    // the geometry alone, so a red and a black instance of one glyph are two rows with one name.
+    const hit = names?.[vector ? a.key.slice(0, a.key.lastIndexOf(":")) : a.key];
     const format = a.mime.replace(/^image\//, "").replace(/\+xml$/, "") || "image";
     const name = hit ? hit.name : a.alt || `${format} ${a.w}×${a.h}`;
     return {

--- a/canvas/src/svgSignature.test.ts
+++ b/canvas/src/svgSignature.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { AGENT } from "./inspectorAgent";
+import { svgSignature } from "./svgSignature";
+
+// The committed file, and the same glyph as apple-photos' icon() writes it into a board: root
+// attributes injected, then the agent's own data-sp marks, then the colour written in.
+const FILE = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="39.397 7.021 28.705 23.719" fill="currentColor">
+  <path id="&#244;&#128;" d="M53.6489 21.5869C54.2853 21.5869
+    54.8319 21.3548 55.2886 20.8906Z" fill="currentColor"/>
+</svg>`;
+const BOARD =
+  '<svg preserveAspectRatio="none" class="" style="width:28.705px;height:23.719px" xmlns="http://www.w3.org/2000/svg" viewBox="39.397 7.021 28.705 23.719" fill="rgb(10, 132, 255)" data-sp="41">' +
+  '<path id="ô" d="M53.6489 21.5869C54.2853 21.5869 54.8319 21.3548 55.2886 20.8906Z" fill="rgb(10, 132, 255)" data-sp="42"></path></svg>';
+
+describe("svgSignature", () => {
+  it("signs the file and the board's rewrite of it alike", () => {
+    expect(svgSignature(BOARD)).toBe(svgSignature(FILE));
+  });
+
+  it("is the geometry: a moved point changes it, a colour does not", () => {
+    expect(svgSignature(FILE.replace("55.2886", "55.3"))).not.toBe(svgSignature(FILE));
+    expect(svgSignature(FILE.replace('fill="currentColor"/>', 'fill="#f00"/>'))).toBe(svgSignature(FILE));
+    expect(svgSignature(FILE.replace('viewBox="39.397', 'viewBox="0'))).not.toBe(svgSignature(FILE));
+  });
+
+  it("reads every shape element, in order, with its own attributes", () => {
+    const a = '<svg viewBox="0 0 4 4"><rect x="1" y="1" width="2" height="2"/><circle cx="2" cy="2" r="1"/></svg>';
+    const b = '<svg viewBox="0 0 4 4"><circle cx="2" cy="2" r="1"/><rect x="1" y="1" width="2" height="2"/></svg>';
+    expect(svgSignature(a)).toBe("0 0 4 4 rect||1|1|2|2|||||||||| circle||||||1|||2|2|||||");
+    expect(svgSignature(a)).not.toBe(svgSignature(b));
+  });
+
+  it("rides in the agent as its own source, so the frame keys a vector as the index does", () => {
+    expect(AGENT).toContain("<script>var svgSignature=function");
+    expect(AGENT).toContain("svg:'+fnv(svgSignature(");
+  });
+});

--- a/canvas/src/svgSignature.test.ts
+++ b/canvas/src/svgSignature.test.ts
@@ -26,8 +26,18 @@ describe("svgSignature", () => {
   it("reads every shape element, in order, with its own attributes", () => {
     const a = '<svg viewBox="0 0 4 4"><rect x="1" y="1" width="2" height="2"/><circle cx="2" cy="2" r="1"/></svg>';
     const b = '<svg viewBox="0 0 4 4"><circle cx="2" cy="2" r="1"/><rect x="1" y="1" width="2" height="2"/></svg>';
-    expect(svgSignature(a)).toBe("0 0 4 4 rect||1|1|2|2|||||||||| circle||||||1|||2|2|||||");
+    expect(svgSignature(a)).toBe("0 0 4 4 rect||1|1|2|2|||||||||||||| circle||||||1|||2|2|||||||||");
     expect(svgSignature(a)).not.toBe(svgSignature(b));
+  });
+
+  it("tells apart a transform, a text's string and a use's reference, which draw differently", () => {
+    const t = '<svg viewBox="0 0 4 4"><path d="M0 0h4"/></svg>';
+    expect(svgSignature(t.replace("<path", '<path transform="rotate(90)"'))).not.toBe(svgSignature(t));
+    const s = '<svg viewBox="0 0 4 4"><text x="1" y="3">A</text></svg>';
+    expect(svgSignature(s.replace(">A<", ">B<"))).not.toBe(svgSignature(s));
+    expect(svgSignature(s.replace(">A<", ">\n  A\n<"))).toBe(svgSignature(s));
+    const u = '<svg viewBox="0 0 4 4"><use href="#a"/></svg>';
+    expect(svgSignature(u.replace("#a", "#b"))).not.toBe(svgSignature(u));
   });
 
   it("rides in the agent as its own source, so the frame keys a vector as the index does", () => {

--- a/canvas/src/svgSignature.ts
+++ b/canvas/src/svgSignature.ts
@@ -3,7 +3,8 @@
  * in document order, whitespace collapsed. Fills, ids, classes and whatever a generator writes
  * into the root tag on the way in (`class`, `style`, `preserveAspectRatio`) are left out, so the
  * `<svg>` on a board and the `assets/icons/*.svg` it was inlined from sign alike although their
- * bytes differ. `svg:<fnv1a of this>` is the asset key on both sides of the join.
+ * bytes differ. `svg:<fnv1a of this>` is the file's key in the index, and the front of a row's key
+ * in the agent, which adds the colours the glyph was drawn in after it.
  *
  * It reads markup, not a DOM, so the build-time index in Node and the inspector's agent in the
  * frame run this one function: the agent splices in its `toString()`. Keep it self-contained,

--- a/canvas/src/svgSignature.ts
+++ b/canvas/src/svgSignature.ts
@@ -1,6 +1,6 @@
 /**
- * A vector's geometry as one string: the viewBox, then every drawing element's shape attributes
- * in document order, whitespace collapsed. Fills, ids, classes and whatever a generator writes
+ * A vector's geometry as one string: the viewBox, then every drawing element's shape attributes,
+ * transform and reference, and a text's string, in document order, whitespace collapsed. Fills, ids, classes and whatever a generator writes
  * into the root tag on the way in (`class`, `style`, `preserveAspectRatio`) are left out, so the
  * `<svg>` on a board and the `assets/icons/*.svg` it was inlined from sign alike although their
  * bytes differ. `svg:<fnv1a of this>` is the file's key in the index, and the front of a row's key
@@ -11,9 +11,10 @@
  * with no reference to anything outside its own body, so that source survives minification.
  */
 export function svgSignature(markup: string): string {
-  const attrs = ["d", "x", "y", "width", "height", "r", "rx", "ry", "cx", "cy", "x1", "y1", "x2", "y2", "points"];
+  const attrs = ["d", "x", "y", "width", "height", "r", "rx", "ry", "cx", "cy", "x1", "y1", "x2", "y2", "points", "transform", "href", "xlink:href"];
   const out = [(/viewBox\s*=\s*["']([^"']*)["']/.exec(markup) || ["", ""])[1]];
-  const re = /<(path|rect|circle|ellipse|line|polygon|polyline)\b([^>]*)>/g;
+  // The text right after the tag is a <text>'s own string, and whitespace for everything else.
+  const re = /<(path|rect|circle|ellipse|line|polygon|polyline|text|image|use)\b([^>]*)>([^<]*)/g;
   let m: RegExpExecArray | null;
   while ((m = re.exec(markup))) {
     const parts = [m[1]];
@@ -21,6 +22,7 @@ export function svgSignature(markup: string): string {
       const a = new RegExp("\\s" + attrs[i] + "\\s*=\\s*[\"']([^\"']*)[\"']").exec(m[2]);
       parts.push(a ? a[1] : "");
     }
+    parts.push(m[3].replace(/^\s+|\s+$/g, ""));
     out.push(parts.join("|"));
   }
   return out.join("\n").replace(/\s+/g, " ");

--- a/canvas/src/svgSignature.ts
+++ b/canvas/src/svgSignature.ts
@@ -1,0 +1,26 @@
+/**
+ * A vector's geometry as one string: the viewBox, then every drawing element's shape attributes
+ * in document order, whitespace collapsed. Fills, ids, classes and whatever a generator writes
+ * into the root tag on the way in (`class`, `style`, `preserveAspectRatio`) are left out, so the
+ * `<svg>` on a board and the `assets/icons/*.svg` it was inlined from sign alike although their
+ * bytes differ. `svg:<fnv1a of this>` is the asset key on both sides of the join.
+ *
+ * It reads markup, not a DOM, so the build-time index in Node and the inspector's agent in the
+ * frame run this one function: the agent splices in its `toString()`. Keep it self-contained,
+ * with no reference to anything outside its own body, so that source survives minification.
+ */
+export function svgSignature(markup: string): string {
+  const attrs = ["d", "x", "y", "width", "height", "r", "rx", "ry", "cx", "cy", "x1", "y1", "x2", "y2", "points"];
+  const out = [(/viewBox\s*=\s*["']([^"']*)["']/.exec(markup) || ["", ""])[1]];
+  const re = /<(path|rect|circle|ellipse|line|polygon|polyline)\b([^>]*)>/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(markup))) {
+    const parts = [m[1]];
+    for (let i = 0; i < attrs.length; i++) {
+      const a = new RegExp("\\s" + attrs[i] + "\\s*=\\s*[\"']([^\"']*)[\"']").exec(m[2]);
+      parts.push(a ? a[1] : "");
+    }
+    out.push(parts.join("|"));
+  }
+  return out.join("\n").replace(/\s+/g, " ");
+}

--- a/canvas/vite.config.ts
+++ b/canvas/vite.config.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import react from "@vitejs/plugin-react";
 import { defineConfig, type Plugin } from "vite";
+import { svgSignature } from "./src/svgSignature.ts";
 
 /**
  * Repo root — vite.config.ts sits in canvas/, one level below it. It is published into the page
@@ -117,14 +118,17 @@ interface AssetName {
  * could have inlined: `assets/**`, `assets-dark/**` and the values of `assets.json`. `refs/` is
  * skipped because it holds third-party captures that are never committed. A generator that
  * re-encodes on the way (a PIL resize) produces bytes that match nothing here, and the
- * inspector then falls back to the image's alt text.
+ * inspector then falls back to the image's alt text. An `.svg` file is indexed twice: by its
+ * bytes like any image, and as `svg:hash` of its geometry, which is how an inline `<svg>` on a
+ * board is keyed, since the generator rewrote its root tag on the way in.
  */
 function assetIndex(folder: string): Record<string, AssetName> {
   const out: Record<string, AssetName> = {};
-  const add = (payload: string, name: string, bytes: number) => {
-    const key = `${payload.length}:${fnv1a(payload)}`;
+  const add = (key: string, name: string, bytes: number) => {
     if (!(key in out)) out[key] = { name, bytes };
   };
+  const addPayload = (payload: string, name: string, bytes: number) =>
+    add(`${payload.length}:${fnv1a(payload)}`, name, bytes);
   const walk = (dir: string, rel: string) => {
     let entries: fs.Dirent[];
     try {
@@ -141,7 +145,9 @@ function assetIndex(folder: string): Record<string, AssetName> {
       }
       if (!ASSET_MIME.has(path.extname(e.name).toLowerCase())) continue;
       const buf = fs.readFileSync(p);
-      add(buf.toString("base64"), rel + e.name, buf.length);
+      addPayload(buf.toString("base64"), rel + e.name, buf.length);
+      if (e.name.toLowerCase().endsWith(".svg"))
+        add(`svg:${fnv1a(svgSignature(buf.toString("utf8")))}`, rel + e.name, buf.length);
     }
   };
   for (const sub of ["assets", "assets-dark"]) walk(path.join(folder, sub), `${sub}/`);
@@ -154,7 +160,7 @@ function assetIndex(folder: string): Record<string, AssetName> {
           if (typeof v !== "string" || !v.startsWith("data:")) continue;
           const payload = v.slice(v.indexOf(",") + 1);
           const pad = payload.endsWith("==") ? 2 : payload.endsWith("=") ? 1 : 0;
-          add(payload, `assets.json#${key}`, Math.floor((payload.length * 3) / 4) - pad);
+          addPayload(payload, `assets.json#${key}`, Math.floor((payload.length * 3) / 4) - pad);
         }
       }
     } catch {

--- a/docs/2026-09-08-vector-assets.md
+++ b/docs/2026-09-08-vector-assets.md
@@ -24,7 +24,8 @@ Measured over the 180 committed boards before deciding (`scratch/svg_census.py`)
 - **Bytes cannot be the key, so geometry is.** Each generator's `icon()` writes `class`, `style`
   and `preserveAspectRatio` into the root tag, so a board's markup is never the file's bytes.
   `svgSignature.ts` reads the viewBox and every `path`/`rect`/`circle`/`ellipse`/`line`/
-  `polygon`/`polyline` with its shape attributes in a fixed order, whitespace collapsed, and
+  `polygon`/`polyline`/`text`/`image`/`use` with its shape attributes, transform and reference,
+  and a text's own string, in a fixed order, whitespace collapsed, and
   `svg:<fnv1a>` of that is the file's key. A row's key adds the root's computed colours after it,
   so a red and a black instance of one glyph, as on `raycast-ios/07-models-sheet`, are two rows
   that join to one file and each copy their own colour. It reads markup rather than a DOM so the
@@ -34,7 +35,8 @@ Measured over the 180 committed boards before deciding (`scratch/svg_census.py`)
   nothing, the one filter-only definitions block on `chatgpt-ios/16-memory-sheet`, is no asset.
 - **The copy stands alone.** The agent strips what the generator and the agent itself injected,
   adds `xmlns` where a literal icon had none, writes the root's computed `fill` and `stroke` in
-  where the markup left them to the cascade, and substitutes `currentColor` and every `var()` with
+  where the markup left them to the cascade, and a child's where a stylesheet rule set it apart
+  from its parent (apple-wallet's `.ds path`), and substitutes `currentColor` and every `var()` with
   the values the board resolved. That string is the preview, as an inert
   `<img src="data:image/svg+xml,…">` in the parent, never live DOM, which matters on a hosted
   canvas where a board is a pull request away; and it is what **Copy SVG** puts on the

--- a/docs/2026-09-08-vector-assets.md
+++ b/docs/2026-09-08-vector-assets.md
@@ -1,0 +1,76 @@
+# An inline svg is a vector asset
+
+2026-09-08. The tab-bar icons on `apple-photos/01-all-photos` are inline `<svg>`, and the
+inspector's Assets tab listed the eleven photos and not one of them. Now an inline vector is
+listed, named, previewed and handed out the way a bitmap already was: one more asset kind,
+`via: "svg"` beside `"img"` and `"css"`, on the pipeline that was there. No board is regenerated
+and no HTML changes.
+
+## What the boards hold
+
+Measured over the 180 committed boards before deciding (`scratch/svg_census.py`):
+
+| | |
+|---|---|
+| inline `<svg>` elements | 1,025, 237 distinct |
+| committed `assets/icons/*.svg` | 36, in `apple-calendar`, `apple-photos`, `apple-settings` |
+| distinct on-board vectors in those folders matched to a file by geometry | 32 of 32 |
+| `<title>` or `aria-label` on any svg | 0 |
+| nested svg, scripts, handlers, references outside the svg | 0 |
+| elements inside svg subtrees | 2,767 of 16,803, a sixth of every layers list |
+
+## What changed
+
+- **Bytes cannot be the key, so geometry is.** Each generator's `icon()` writes `class`, `style`
+  and `preserveAspectRatio` into the root tag, so a board's markup is never the file's bytes.
+  `svgSignature.ts` reads the viewBox and every `path`/`rect`/`circle`/`ellipse`/`line`/
+  `polygon`/`polyline` with its shape attributes in a fixed order, whitespace collapsed, and
+  `svg:<fnv1a>` of that is the key. It reads markup rather than a DOM so the build-time index and
+  the frame's agent run one function: the agent splices in its `toString()`, which is why it is
+  written with no reference outside its own body. The index adds the key beside the byte key it
+  already had for every `.svg` under `assets/`.
+- **The copy stands alone.** The agent strips what the generator and the agent itself injected,
+  adds `xmlns` where a literal icon had none, writes the root's computed `fill` and `stroke` in
+  where the markup left them to the cascade, and substitutes `currentColor` and every `var()` with
+  the values the board resolved. That string is the preview, as an inert
+  `<img src="data:image/svg+xml,…">` in the parent, never live DOM, which matters on a hosted
+  canvas where a board is a pull request away; and it is what **Copy SVG** puts on the
+  clipboard, for Figma or another `gen.py`.
+- **A name comes from the file, else from context, else nowhere.** No board writes a title on an
+  icon. With no file the agent takes an `aria-label` or `<title>` if one ever appears, else a class
+  that is a word (`logo`, not a generator's `i` or `mk`), else the one short leaf of text beside
+  the icon within two ancestors: the span under a tab icon, the label in a chip. A clock, a
+  keyboard row, a whole composer or a screen of text is not a caption, and the icon reads
+  `svg 27×27` in italics rather than take a wrong name. A guess is badged `label` the way a
+  bitmap's is badged `alt`.
+- **An icon is one layer.** Nodes inside an svg stay indexed, because the Tokens tab counts uses
+  on `path` elements, but the layers list hides them, and a click on a path in the preview selects
+  its svg.
+- Rows and the selected view read the viewBox size and `svg`; the summary reads
+  `Images N` and `Vectors M`; the vector row's thumb sits on the checkerboard, since a black
+  glyph on the photos' dark ground is invisible.
+
+## Not done
+
+- **Moving the 205 literal glyphs into `assets/icons/` files.** Per-generator work in ten folders.
+  The caption rule names the ones people point at most; a folder gets file names the day its
+  generator is next touched, and the skill docs now say to keep icons as files.
+- **Writing an extracted svg into the repo from the panel.** The browser cannot write into the
+  checkout. Copy SVG covers a person; an agent-bridge op can return a board's assets when an agent
+  needs it.
+- **SVG as a data URI in `<img>` or CSS.** No board does it; if one did, the bitmap path already
+  lists it as `image/svg+xml`.
+
+## Checked
+
+`tsc -b`, `oxlint`, `vitest` (the signature signs the file and the board's rewrite of it alike;
+a moved point changes it and a colour does not; the model names, badges and sizes a vector; the
+agent carries the function). Headless Chrome against the dev server: `apple-photos#01-all-photos`
+lists its four tab icons and three status-bar glyphs as `assets/icons/<name>.svg`, every preview
+loaded, the eleven photos unchanged; the selected view shows the vector with its size and Copy SVG,
+and the clipboard holds the same standalone markup the preview draws; no `path` rows in the layers
+list; a click on a path in the preview selects the svg. `raycast-ios/01-ask-anything` names the
+composer chip's icon `Full Note` in italics and leaves the status bar, keyboard and composer icons
+nameless; `chatgpt-ios`, whose icons float absolutely under `.phone`, names none after the screen's
+text. The board's on-tab `tab-photos` and its copy, rendered at the same size, diff to nothing
+beyond antialiasing in `refkit diff`.

--- a/docs/2026-09-08-vector-assets.md
+++ b/docs/2026-09-08-vector-assets.md
@@ -25,10 +25,13 @@ Measured over the 180 committed boards before deciding (`scratch/svg_census.py`)
   and `preserveAspectRatio` into the root tag, so a board's markup is never the file's bytes.
   `svgSignature.ts` reads the viewBox and every `path`/`rect`/`circle`/`ellipse`/`line`/
   `polygon`/`polyline` with its shape attributes in a fixed order, whitespace collapsed, and
-  `svg:<fnv1a>` of that is the key. It reads markup rather than a DOM so the build-time index and
-  the frame's agent run one function: the agent splices in its `toString()`, which is why it is
-  written with no reference outside its own body. The index adds the key beside the byte key it
-  already had for every `.svg` under `assets/`.
+  `svg:<fnv1a>` of that is the file's key. A row's key adds the root's computed colours after it,
+  so a red and a black instance of one glyph, as on `raycast-ios/07-models-sheet`, are two rows
+  that join to one file and each copy their own colour. It reads markup rather than a DOM so the
+  build-time index and the frame's agent run one function: the agent splices in its
+  `toString()`, which is why it is written with no reference outside its own body. The index adds
+  the key beside the byte key it already had for every `.svg` under `assets/`. An svg that draws
+  nothing, the one filter-only definitions block on `chatgpt-ios/16-memory-sheet`, is no asset.
 - **The copy stands alone.** The agent strips what the generator and the agent itself injected,
   adds `xmlns` where a literal icon had none, writes the root's computed `fill` and `stroke` in
   where the markup left them to the cascade, and substitutes `currentColor` and every `var()` with

--- a/mockups/canvases/README.md
+++ b/mockups/canvases/README.md
@@ -28,7 +28,10 @@ A folder is an unzipped Sketch file: `layout.json` plays `document.json` and
 pre-encoded images the generator inlines; commit it too, it is the only
 copy of those images. The canvas's inspector names a board's images by
 content, from `assets/` first and `assets.json` second, and falls back to
-the image's `alt` when a generator re-encoded it. Everything a run makes on the way, grids, shots, montages,
+the image's `alt` when a generator re-encoded it. An inline `<svg>` is
+named the same way from `assets/icons/`, by its geometry rather than its
+bytes, so keep each icon as a file there and inline it through a helper in
+`gen.py`. Everything a run makes on the way, grids, shots, montages,
 candidate boards, goes in `<slug>/scratch/`. The root `.gitignore` ignores
 `scratch/` at any depth, and `assets/refs/` too, which is where third-party
 captures go. No folder needs a `.gitignore` of its own.
@@ -130,7 +133,8 @@ Boards render inside `<iframe srcDoc sandbox="">`:
 
 - **Fully self-contained.** No external CSS, JS, fonts or images. Inline
   the token block in every file; embed images as `data:` URIs; icons are
-  inline SVG.
+  inline SVG, each kept as `assets/icons/<name>.svg` so the inspector can
+  name it.
 - **The shape box is 478 × 980** (`CANVAS_FILE_DEFAULT_SIZE`). The iframe
   clips anything past that box with no warning, so check every fixed-height
   board after adding a row. `00-welcome` is the one exception, a landscape

--- a/skills/clone-prototype/SKILL.md
+++ b/skills/clone-prototype/SKILL.md
@@ -264,6 +264,10 @@ Hard constraints from the canvas renderer (also in `prototype-canvas`'s
 
 - **Fully self-contained.** The iframe is `sandbox=""`. No external CSS,
   JS, fonts or images. Every image is a `data:` URI; icons are inline SVG.
+  Keep each icon as `assets/icons/<name>.svg` and inline it through a
+  helper in `gen.py`: the canvas's inspector names an inline `<svg>` from
+  that folder by its geometry, and hands it back as a vector asset. A glyph
+  written as a literal in `gen.py` gets no name.
 - **Artboard box is 478 × 980.** Overflow clips silently. Do not check
   this by eye; `refkit shoot ... --check-overflow` asks the layout engine and
   exits non-zero with the exact px, so a clipped board fails in Phase 3

--- a/skills/prototype-canvas/references/layout.md
+++ b/skills/prototype-canvas/references/layout.md
@@ -28,7 +28,9 @@ where a folder has one, is a `name → data URI` map of pre-encoded images the
 generator inlines; commit it too, it is the only copy of those images. The
 canvas's inspector names a board's images by content, from `assets/` first
 and `assets.json` second, and falls back to the image's `alt` when a
-generator re-encoded it.
+generator re-encoded it. An inline `<svg>` is named the same way from
+`assets/icons/`, by its geometry rather than its bytes, so keep each icon
+as a file there and inline it through a helper in `gen.py`.
 Everything a run makes on the way (grids, shots, montages, candidate boards)
 goes in `<slug>/scratch/`, which should be gitignored at any depth, along with
 `assets/refs/` where third-party captures go.
@@ -100,7 +102,8 @@ Boards render inside `<iframe srcDoc sandbox="">`:
 
 - **Fully self-contained.** No external CSS, JS, fonts or images. Inline the
   token block in every file; embed images as `data:` URIs; icons are inline
-  SVG. A sandboxed iframe has no shared stylesheet, so the `:root` block is
+  SVG, each kept as `assets/icons/<name>.svg` so the inspector can name it.
+  A sandboxed iframe has no shared stylesheet, so the `:root` block is
   copied byte-identically into every board rather than imported.
 - **The shape box is 478 × 980** (`CANVAS_FILE_DEFAULT_SIZE`). The iframe
   clips anything past that box with no warning, so check every fixed-height


### PR DESCRIPTION
The Assets tab listed a board's photos and none of its icons. Now an inline `<svg>` is listed, named, previewed and copied the way a bitmap already was: one more asset kind, `via: "svg"`, on the pipeline that was there. No board is regenerated, no HTML changes. Decision note: `docs/2026-09-08-vector-assets.md`.

## What changed

- **Geometry is the key, not bytes.** `svgSignature()` reads the viewBox and every shape element's attributes in a fixed order, so the `<svg>` on a board and the `assets/icons/*.svg` it was inlined from sign alike although the generator rewrote the root tag. The build-time index adds `svg:<fnv1a>` for every `.svg` under `assets/`; the agent splices in the same function's source, so both sides run one function.
- **The copy stands alone.** Injected `class`/`style`/`preserveAspectRatio`/`data-sp` stripped, `xmlns` added, computed `fill`/`stroke` written in, `currentColor` and `var()` resolved to what the board computed. The preview is an inert `<img src="data:image/svg+xml,…">`, and **Copy SVG** puts that same markup on the clipboard.
- **A name from the file, else from context, else nowhere.** A fileless icon takes an `aria-label`, a `<title>`, a word-long class, or the one short caption beside it within two ancestors (the label in a chip), badged `label`. A clock, a keyboard row or a whole composer is not a caption; the icon reads `svg W×H` instead.
- **An icon is one layer.** Nodes inside an svg stay indexed for the Tokens tab but leave the layers list, and a click on a path in the preview selects its svg.
- Summary reads `Images N · Vectors M`; vector thumbs sit on a checkerboard. `AGENTS.md`, the canvases README, the layout reference and the clone-prototype skill now say to keep each icon as `assets/icons/<name>.svg` and inline it through a helper.

## Not done

Moving the 205 literal glyphs in the other generators into `assets/icons/` files (per-generator work; they stay `svg W×H` unless a caption sits beside them). Writing an extracted svg into the repo from the panel.

## Checked

`tsc -b`, `oxlint`, `vitest` 46/46. Headless Chrome against the dev server, 25/25: `apple-photos#01-all-photos` lists its four tab icons and three status-bar glyphs as `assets/icons/<name>.svg` with loaded previews and viewBox sizes, the eleven photos unchanged; Copy SVG puts the preview's standalone markup on the clipboard; no `path` rows in the layers list; a click on a path selects the svg; `raycast-ios` names the chip icon `Full Note` and leaves the clock, keyboard and composer icons nameless; `chatgpt-ios` names none after the screen's text; the board's on-tab `tab-photos` and its copy, rendered at the same size, differ only by antialiasing in `refkit diff` (mean Δ 22.7 at 27×22 px).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
