### PR TITLE
Comments that live in the repo, a board's status, and cloning a canvas

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,9 +49,9 @@ Rules inside a canvas folder:
   `name → data URI` map of pre-encoded images the generator inlines, not
   evidence. The canvas's inspector names a board's images by content, from
   `assets/` first and `assets.json` second, so a re-encoded image that
-  matches neither falls back to its `alt`. An inline `<svg>` is named the
+  matches neither falls back to its `alt`. It names an inline `<svg>` the
   same way from `assets/icons/`, by its geometry rather than its bytes, and
-  handed back as a vector asset.
+  hands it back as a vector asset.
 - Never commit `ref-*.html` or `assets/refs/`. They hold third-party
   captures, the root `.gitignore` already excludes them, and the
   clone-prototype skill rebuilds them. `spotify-ios` is the one exception:

--- a/canvas/bun.lock
+++ b/canvas/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "prototyping-canvas",
       "dependencies": {
+        "@tldraw/commenting": "5.3.2",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
         "tldraw": "^5.3.2",
@@ -266,6 +267,8 @@
 
     "@tiptap/extension-list-keymap": ["@tiptap/extension-list-keymap@3.28.0", "", { "peerDependencies": { "@tiptap/extension-list": "3.28.0" } }, "sha512-u9Wks8c/eQAv0RkULNggOyTKDD69WVbcV9H5cbasPDUbq5XbEFVa9ajxhEGfMmQ5et3EX0QL8qBi50K0GqbIjA=="],
 
+    "@tiptap/extension-mention": ["@tiptap/extension-mention@3.13.0", "", { "peerDependencies": { "@tiptap/core": "^3.13.0", "@tiptap/pm": "^3.13.0", "@tiptap/suggestion": "^3.13.0" } }, "sha512-JcZ9ItaaifurERewyydfj/s52MGcWsCxk5hYdkSohzwa8Ohw4yyghHWCuEl/kvLK+9KhjIDDr1jvAmfZ89I7Fg=="],
+
     "@tiptap/extension-ordered-list": ["@tiptap/extension-ordered-list@3.28.0", "", { "peerDependencies": { "@tiptap/extension-list": "3.28.0" } }, "sha512-OZNYrKKL9D01ySOujlNbKlLS9/3wGgKNYeoHZUg0e+Ta8WPVvL3W1zH6TgiU5sF2ZSGUBoq3w7mdaO/iROlUkw=="],
 
     "@tiptap/extension-paragraph": ["@tiptap/extension-paragraph@3.28.0", "", { "peerDependencies": { "@tiptap/core": "3.28.0" } }, "sha512-8UMlQIjzqf6r2hSJ/VeJ00RqaOrOB1J5rTk02Vcw2pYeHkOqp+B0ff0HFu4abT9x1q4oXrBAgMsxRtgh/kR14Q=="],
@@ -284,9 +287,15 @@
 
     "@tiptap/starter-kit": ["@tiptap/starter-kit@3.28.0", "", { "dependencies": { "@tiptap/core": "^3.28.0", "@tiptap/extension-blockquote": "^3.28.0", "@tiptap/extension-bold": "^3.28.0", "@tiptap/extension-bullet-list": "^3.28.0", "@tiptap/extension-code": "^3.28.0", "@tiptap/extension-code-block": "^3.28.0", "@tiptap/extension-document": "^3.28.0", "@tiptap/extension-dropcursor": "^3.28.0", "@tiptap/extension-gapcursor": "^3.28.0", "@tiptap/extension-hard-break": "^3.28.0", "@tiptap/extension-heading": "^3.28.0", "@tiptap/extension-horizontal-rule": "^3.28.0", "@tiptap/extension-italic": "^3.28.0", "@tiptap/extension-link": "^3.28.0", "@tiptap/extension-list": "^3.28.0", "@tiptap/extension-list-item": "^3.28.0", "@tiptap/extension-list-keymap": "^3.28.0", "@tiptap/extension-ordered-list": "^3.28.0", "@tiptap/extension-paragraph": "^3.28.0", "@tiptap/extension-strike": "^3.28.0", "@tiptap/extension-text": "^3.28.0", "@tiptap/extension-underline": "^3.28.0", "@tiptap/extensions": "^3.28.0", "@tiptap/pm": "^3.28.0" } }, "sha512-pqvFpValV+ONtlu3l4s73ROm/tEjoGMmt6uHmSJaLbqTcMHkdWuR3flJ/5brr4IDHe1foxmNicMbRxlje7yBYw=="],
 
+    "@tiptap/suggestion": ["@tiptap/suggestion@3.13.0", "", { "peerDependencies": { "@tiptap/core": "^3.13.0", "@tiptap/pm": "^3.13.0" } }, "sha512-IXNvyLITpPiuXHn/q1ntztPYJZMFjPAokKj+OQz3MFNYlzAX3I409KD/EwwCubisRIAFiNX0ZjIIXxxZ3AhFTw=="],
+
+    "@tldraw/commenting": ["@tldraw/commenting@5.3.2", "", { "dependencies": { "@tiptap/core": "^3.12.1", "@tiptap/pm": "^3.12.1", "@tiptap/react": "^3.12.1", "@tldraw/mentions": "5.3.2", "@tldraw/utils": "5.3.2", "tldraw": "5.3.2" }, "peerDependencies": { "react": "^18.2.0 || ^19.2.1", "react-dom": "^18.2.0 || ^19.2.1" } }, "sha512-3GIr6nHGStYgYUaRrwN0BxC+x5+WCs5AOd0NYe8f2LjL5tq7C7unkbcCr75w/YIWtH6MZvesnz9bWgaFbYXfvw=="],
+
     "@tldraw/driver": ["@tldraw/driver@5.3.2", "", { "dependencies": { "@tldraw/editor": "5.3.2", "@tldraw/utils": "5.3.2" } }, "sha512-OJJwgdoyJv3G2ejvQoqnNKsLphOE8SBCUkiGSZibUCt8tWFrTjvhn7aLxPcXZXtQlxHWmyE4jBvQ56Swguv/rg=="],
 
     "@tldraw/editor": ["@tldraw/editor@5.3.2", "", { "dependencies": { "@tiptap/core": "^3.12.1", "@tiptap/pm": "^3.12.1", "@tiptap/react": "^3.12.1", "@tldraw/state": "5.3.2", "@tldraw/state-react": "5.3.2", "@tldraw/store": "5.3.2", "@tldraw/tlschema": "5.3.2", "@tldraw/utils": "5.3.2", "@tldraw/validate": "5.3.2", "classnames": "^2.5.1", "eventemitter3": "^4.0.7", "idb": "^7.1.1", "is-plain-object": "^5.0.0", "rbush": "^3.0.1" }, "peerDependencies": { "react": "^18.2.0 || ^19.2.1", "react-dom": "^18.2.0 || ^19.2.1" } }, "sha512-4b3aAXNU/CP2soIBuJmyom9Im5/N5Gm+6nBDbHr2yjQ/4CvP047z8ru97Au0YCvK8hF9sg/Ufk18NrBV/3pqlw=="],
+
+    "@tldraw/mentions": ["@tldraw/mentions@5.3.2", "", { "dependencies": { "@tiptap/core": "^3.12.1", "@tiptap/extension-mention": "3.13.0", "@tiptap/pm": "^3.12.1", "@tiptap/react": "^3.12.1", "@tiptap/suggestion": "3.13.0", "@tldraw/utils": "5.3.2", "tldraw": "5.3.2" }, "peerDependencies": { "react": "^18.2.0 || ^19.2.1", "react-dom": "^18.2.0 || ^19.2.1" } }, "sha512-sYeVlMkRpTSWOf4+CZ9l451yfp4I1/MHka4RRxB/V0Qv06QJHUsvz44wKfIsBQoKRJbtuUp9ssuPi6r/rS7HQQ=="],
 
     "@tldraw/state": ["@tldraw/state@5.3.2", "", { "dependencies": { "@tldraw/utils": "5.3.2" } }, "sha512-kuWsGhao4HkbDwsBfVryRZ8kU6rEWhiA26qpRJ71nS1GXLsQwJarZ5paQzsr14bE27K+D7mJ6qw2couqqKQQJg=="],
 

--- a/canvas/package.json
+++ b/canvas/package.json
@@ -11,6 +11,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@tldraw/commenting": "5.3.2",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
     "tldraw": "^5.3.2"

--- a/canvas/package.json
+++ b/canvas/package.json
@@ -11,7 +11,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@tldraw/commenting": "5.3.2",
+    "@tldraw/commenting": "^5.3.2",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
     "tldraw": "^5.3.2"

--- a/canvas/public/clone.svg
+++ b/canvas/public/clone.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
+  <path d="M16 4H6a2 2 0 0 0-2 2v10" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+  <rect x="8" y="8" width="12" height="12" rx="2" stroke="currentColor" stroke-width="2"/>
+  <path d="M14 11.5v5M11.5 14h5" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+</svg>

--- a/canvas/public/styles.svg
+++ b/canvas/public/styles.svg
@@ -1,5 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
-  <path d="M4 7h10m4 0h2M4 17h2m4 0h10" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
-  <circle cx="16" cy="7" r="2" stroke="currentColor" stroke-width="2"/>
-  <circle cx="8" cy="17" r="2" stroke="currentColor" stroke-width="2"/>
-</svg>

--- a/canvas/src/App.tsx
+++ b/canvas/src/App.tsx
@@ -84,13 +84,6 @@ const PERSISTENCE_KEY = `super-prototyping-canvas-v2${canvasesNamespace}`;
 const SNAP_DEFAULT_KEY = `${PERSISTENCE_KEY}:snap-default`;
 
 /**
- * The store, built here rather than by `<Tldraw persistenceKey>`, because the comment record
- * types have to be registered on it and that component takes no `records` option. `useLocalStore`
- * is the hook it would have called itself, so IndexedDB persistence is unchanged — see
- * tldraw-local-store.d.ts. Module scope, so the options object keeps its identity across renders:
- * the hook rebuilds the store whenever it changes.
- */
-/**
  * The tldraw license, inlined at build time from the Pages project's own environment (it is set on
  * super-prototyping, production and preview both). Commenting is a licensed feature: with no key
  * `CanvasComments` renders nothing at all in production, so the hosted canvas would offer a comment
@@ -102,10 +95,17 @@ const SNAP_DEFAULT_KEY = `${PERSISTENCE_KEY}:snap-default`;
  * commenting. Only the deploy can.
  *
  * The key today is an evaluation license, which grants every feature and expires on 2026-12-12 with
- * no grace period. On that date commenting goes dark again unless it has been replaced.
+ * no grace period. On that date commenting stops working again unless the key has been replaced.
  */
 const TLDRAW_LICENSE_KEY: string | undefined = import.meta.env.VITE_TLDRAW_LICENSE_KEY;
 
+/**
+ * The store, built here rather than by `<Tldraw persistenceKey>`, because the comment record
+ * types have to be registered on it and that component takes no `records` option. `useLocalStore`
+ * is the hook it would have called itself, so IndexedDB persistence is unchanged, see
+ * tldraw-local-store.d.ts. Module scope, so the options object keeps its identity across renders:
+ * the hook rebuilds the store whenever it changes.
+ */
 const storeOptions = {
   persistenceKey: PERSISTENCE_KEY,
   // The same set `<Tldraw>` merges for itself; the schema has to know every type the document
@@ -763,7 +763,7 @@ function pruneEmptyOrphanPages(editor: Editor, libraryPages: Set<TLPageId>) {
   for (const page of editor.getPages()) {
     if (libraryPages.has(page.id)) continue;
     // The boards are gone with the folder, so the shapes the library put here are all that is
-    // keeping the page alive — and nothing else ever reclaims them, because every other sweep
+    // keeping the page alive, and nothing else ever reclaims them, because every other sweep
     // walks the pages the library just filled. Without this, renaming or deleting a folder
     // leaves a page of dead boards behind for good.
     deleteLibraryShapes(
@@ -776,10 +776,10 @@ function pruneEmptyOrphanPages(editor: Editor, libraryPages: Set<TLPageId>) {
 }
 
 /**
- * Whether anything a person would actually see is left on a page.
+ * Whether anything a person would see is left on a page.
  *
  * Text shapes with no text do not count. Clicking the text tool on the canvas and then clicking
- * away leaves one behind — zero-width, nothing rendered — and the page it sits on cannot be told
+ * away leaves one behind, zero-width and rendering nothing, and the page it sits on cannot be told
  * from an empty one by looking at it. Counting those as content kept a folder's page in the menu
  * forever over a shape nobody knew they had made.
  */

--- a/canvas/src/App.tsx
+++ b/canvas/src/App.tsx
@@ -91,14 +91,20 @@ const SNAP_DEFAULT_KEY = `${PERSISTENCE_KEY}:snap-default`;
  * the hook rebuilds the store whenever it changes.
  */
 /**
- * The tldraw license, inlined from the build environment (see vite.config.ts for the two names
- * accepted). Commenting is a licensed feature: without a key `CanvasComments` renders nothing in
- * production. Not in development — tldraw reads the *runtime* host for that, and localhost, a
- * loopback address and any plain-http origin all get every feature. So a built bundle served from
- * 127.0.0.1 cannot tell you whether the deployed site will have commenting; only the deploy can.
+ * The tldraw license, inlined at build time from the Pages project's own environment (it is set on
+ * super-prototyping, production and preview both). Commenting is a licensed feature: with no key
+ * `CanvasComments` renders nothing at all in production, so the hosted canvas would offer a comment
+ * tool that does nothing.
+ *
+ * Not in development, and that is the trap: tldraw decides "development" from the *runtime* host,
+ * so localhost, any loopback address and any plain-http origin get every feature unlicensed. A
+ * production build served from 127.0.0.1 therefore cannot tell you whether the deployed site has
+ * commenting. Only the deploy can.
+ *
+ * The key today is an evaluation license, which grants every feature and expires on 2026-12-12 with
+ * no grace period. On that date commenting goes dark again unless it has been replaced.
  */
-const TLDRAW_LICENSE_KEY: string | undefined =
-  import.meta.env.VITE_TLDRAW_LICENSE_KEY ?? import.meta.env.TLDRAW_LICENSE_KEY;
+const TLDRAW_LICENSE_KEY: string | undefined = import.meta.env.VITE_TLDRAW_LICENSE_KEY;
 
 const storeOptions = {
   persistenceKey: PERSISTENCE_KEY,

--- a/canvas/src/App.tsx
+++ b/canvas/src/App.tsx
@@ -19,7 +19,6 @@ import {
   useLocalStore,
   useValue,
 } from "tldraw";
-import { commentToolOverrides } from "@tldraw/commenting";
 import "tldraw/tldraw.css";
 import "@tldraw/commenting/commenting.css";
 import { installAgentBridge } from "./agentBridge";
@@ -59,6 +58,7 @@ import {
   CanvasChromeContext,
   canvasChromeAssetUrls,
   canvasChromeComponents,
+  canvasCommentOverrides,
   canvasCommentTools,
 } from "./canvasChrome";
 
@@ -1017,7 +1017,7 @@ export default function App() {
             store={store}
             shapeUtils={shapeUtils}
             tools={canvasCommentTools}
-            overrides={commentToolOverrides}
+            overrides={canvasCommentOverrides}
             onMount={handleMount}
           >
             <AgentBridge />

--- a/canvas/src/App.tsx
+++ b/canvas/src/App.tsx
@@ -1,9 +1,14 @@
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import {
   Tldraw,
+  commentSchemaRecords,
   createShapeId,
+  defaultAssetUtils,
+  defaultBindingUtils,
+  defaultShapeUtils,
   getIndices,
   react,
+  renderPlaintextFromRichText,
   toRichText,
   type Editor,
   type TLPageId,
@@ -11,9 +16,12 @@ import {
   type TLDefaultColorStyle,
   type TLTextShape,
   useEditor,
+  useLocalStore,
   useValue,
 } from "tldraw";
+import { commentToolOverrides } from "@tldraw/commenting";
 import "tldraw/tldraw.css";
+import "@tldraw/commenting/commenting.css";
 import { installAgentBridge } from "./agentBridge";
 import { WELCOME_PAGE_SLUG, boardFromUrl, slugFromUrl, urlForSlug } from "./canvasUrl";
 import {
@@ -23,6 +31,12 @@ import {
   CanvasFileShapeUtil,
 } from "./CanvasFileShapeUtil";
 import { InspectorClicks, InspectorPanel } from "./InspectorPanel";
+import {
+  CANVAS_STATUS_BANNER_GAP,
+  CANVAS_STATUS_BANNER_HEIGHT,
+  CANVAS_STATUS_BANNER_SHAPE_TYPE,
+  CanvasStatusBannerShapeUtil,
+} from "./CanvasStatusBannerShapeUtil";
 import {
   CANVAS_LINK_BUTTON_SIZE,
   CANVAS_LINK_CARD_SIZE,
@@ -34,17 +48,25 @@ import {
 import {
   type CanvasLayoutLink,
   type CanvasLibraryFile,
+  LAYOUT_CHANGED,
+  boardTabStatusForPath,
   readCanvasLayout,
   readCanvasLibrary,
 } from "./canvasLibrary";
 import { canvasesDir, canvasesNamespace } from "virtual:canvases";
+import { installCanvasComments, readCommentUser } from "./canvasComments";
 import {
   CanvasChromeContext,
   canvasChromeAssetUrls,
   canvasChromeComponents,
+  canvasCommentTools,
 } from "./canvasChrome";
 
-const shapeUtils = [CanvasFileShapeUtil, CanvasLinkShapeUtil];
+const shapeUtils = [
+  CanvasFileShapeUtil,
+  CanvasLinkShapeUtil,
+  CanvasStatusBannerShapeUtil,
+];
 
 /**
  * Bump the trailing version when a change would leave documents already in a browser's
@@ -60,6 +82,23 @@ const PERSISTENCE_KEY = `super-prototyping-canvas-v2${canvasesNamespace}`;
 
 /** Marks that the snap default below has been applied once in this browser. */
 const SNAP_DEFAULT_KEY = `${PERSISTENCE_KEY}:snap-default`;
+
+/**
+ * The store, built here rather than by `<Tldraw persistenceKey>`, because the comment record
+ * types have to be registered on it and that component takes no `records` option. `useLocalStore`
+ * is the hook it would have called itself, so IndexedDB persistence is unchanged — see
+ * tldraw-local-store.d.ts. Module scope, so the options object keeps its identity across renders:
+ * the hook rebuilds the store whenever it changes.
+ */
+const storeOptions = {
+  persistenceKey: PERSISTENCE_KEY,
+  // The same set `<Tldraw>` merges for itself; the schema has to know every type the document
+  // can hold, hand-drawn annotations included.
+  shapeUtils: [...defaultShapeUtils, ...shapeUtils],
+  bindingUtils: defaultBindingUtils,
+  assetUtils: defaultAssetUtils,
+  records: commentSchemaRecords,
+};
 
 /**
  * Tldraw persists the page menu's drag-resized list height per origin, and its resize handle is
@@ -108,6 +147,7 @@ const LIBRARY_SHAPE_PREFIXES = [
   "shape:canvas-row-heading:",
   "shape:canvas-file-label:",
   "shape:canvas-link:",
+  "shape:canvas-status-banner:",
 ];
 
 function isLibraryShapeId(id: string) {
@@ -247,6 +287,11 @@ function fileShapeId(file: CanvasLibraryFile) {
   return createShapeId(`canvas-file:${file.path}`);
 }
 
+/** The status tab above this board, when it has one. */
+function statusBannerShapeId(file: CanvasLibraryFile) {
+  return createShapeId(`canvas-status-banner:${file.path}`);
+}
+
 function columnX(index: number) {
   return index * (CANVAS_FILE_DEFAULT_SIZE.w + LIBRARY_GAP);
 }
@@ -277,7 +322,15 @@ function layoutRow(
   // The welcome board carries its own title and its own caption, so it gets neither.
   const bare = rowFiles[0].pageSlug === WELCOME_PAGE_SLUG;
   const rowX = (index: number) => index * (size.w + LIBRARY_GAP);
-  const contentY = bare ? rowTop : rowTop + LIBRARY_HEADING_HEIGHT;
+  // A status tab sits above its board, not inside it, so the row reserves the height once for
+  // all of its boards. Reserving per row rather than per board keeps item N of one row aligned
+  // with item N of the next even where only one board in the row carries a tab.
+  const rowStatuses = rowFiles.map((file) => boardTabStatusForPath(file.path));
+  const statusH = rowStatuses.some(Boolean)
+    ? CANVAS_STATUS_BANNER_HEIGHT + CANVAS_STATUS_BANNER_GAP
+    : 0;
+  const contentY =
+    (bare ? rowTop : rowTop + LIBRARY_HEADING_HEIGHT) + statusH;
   const missing = rowFiles.filter((file) => !editor.getShape(fileShapeId(file)));
   if (missing.length) {
     editor.createShapes(
@@ -294,6 +347,33 @@ function layoutRow(
           path: file.path,
         },
       })),
+    );
+  }
+
+  // Idempotent like the boards above: only tabs not on the canvas yet are created, so a
+  // reload never moves one. A status changed in layout.json lands on the next force refresh.
+  const missingBanners = rowFiles.filter(
+    (file, index) =>
+      rowStatuses[index] && !editor.getShape(statusBannerShapeId(file)),
+  );
+  if (missingBanners.length) {
+    editor.createShapes(
+      missingBanners.map((file) => {
+        const index = rowFiles.indexOf(file);
+        return {
+          id: statusBannerShapeId(file),
+          type: CANVAS_STATUS_BANNER_SHAPE_TYPE,
+          parentId: page.id,
+          x: rowX(index),
+          y: contentY - statusH,
+          isLocked: true,
+          props: {
+            w: size.w,
+            h: CANVAS_STATUS_BANNER_HEIGHT,
+            status: rowStatuses[index]!,
+          },
+        };
+      }),
     );
   }
 
@@ -666,9 +746,34 @@ function orderPagesByLibrary(editor: Editor, libraryPages: Set<TLPageId>) {
 function pruneEmptyOrphanPages(editor: Editor, libraryPages: Set<TLPageId>) {
   for (const page of editor.getPages()) {
     if (libraryPages.has(page.id)) continue;
-    if (editor.getPageShapeIds(page.id).size) continue;
+    // The boards are gone with the folder, so the shapes the library put here are all that is
+    // keeping the page alive — and nothing else ever reclaims them, because every other sweep
+    // walks the pages the library just filled. Without this, renaming or deleting a folder
+    // leaves a page of dead boards behind for good.
+    deleteLibraryShapes(
+      editor,
+      [...editor.getPageShapeIds(page.id)].filter(isLibraryShapeId),
+    );
+    if (drawnOn(editor, page.id)) continue;
     if (editor.getPages().length > 1) editor.deletePage(page.id);
   }
+}
+
+/**
+ * Whether anything a person would actually see is left on a page.
+ *
+ * Text shapes with no text do not count. Clicking the text tool on the canvas and then clicking
+ * away leaves one behind — zero-width, nothing rendered — and the page it sits on cannot be told
+ * from an empty one by looking at it. Counting those as content kept a folder's page in the menu
+ * forever over a shape nobody knew they had made.
+ */
+function drawnOn(editor: Editor, pageId: TLPageId) {
+  return [...editor.getPageShapeIds(pageId)].some((id) => {
+    const shape = editor.getShape(id);
+    if (shape?.type !== "text") return true;
+    const { richText } = (shape as TLTextShape).props;
+    return renderPlaintextFromRichText(editor, richText).trim() !== "";
+  });
 }
 
 /**
@@ -808,13 +913,27 @@ export default function App() {
   const [stylesVisible, setStylesVisible] = useState(false);
   /** The board open in the inspector: click any board on the canvas to open it, Escape or × to close. */
   const [inspecting, setInspecting] = useState<CanvasLibraryFile | null>(null);
-  const editorRef = useRef<Editor | null>(null);
+  const [commentUser, setCommentUser] = useState(readCommentUser);
+  /** State rather than a ref: the inspector panel renders outside `<Tldraw>` and needs it. */
+  const [editor, setEditor] = useState<Editor | null>(null);
+  const store = useLocalStore(storeOptions);
   /** The same board, for the address writer, which runs outside React. */
   const inspected = useRef<CanvasLibraryFile | null>(null);
   /** Writes the address from the page and the inspector; installed with the editor. */
   const writeUrl = useRef<(push: boolean) => void>(() => {});
   /** A board the address named, for the camera to go to once the inspector is beside it. */
   const zoomTo = useRef<CanvasLibraryFile | null>(null);
+
+  // A layout.json edit moves boards: a row reserves the height of a status tab for all of its
+  // boards, so a status appearing or disappearing reflows the row. Creation is idempotent and
+  // never moves a shape that is already there, so only the force refresh catches up. This is
+  // what the status control used to get from a full page reload.
+  useEffect(() => {
+    if (!editor) return;
+    const relayout = () => relayoutCanvasLibrary(editor);
+    window.addEventListener(LAYOUT_CHANGED, relayout);
+    return () => window.removeEventListener(LAYOUT_CHANGED, relayout);
+  }, [editor]);
 
   /**
    * Opens a board in the inspector, or closes it. A pick or a close is a new address; applying
@@ -845,7 +964,6 @@ export default function App() {
   // fit the board to the canvas width the panel just took. Every `show` from an address is a
   // fresh library object, so the effect runs even for the board already open.
   useLayoutEffect(() => {
-    const editor = editorRef.current;
     const file = zoomTo.current;
     zoomTo.current = null;
     if (!editor || !file) return;
@@ -853,11 +971,13 @@ export default function App() {
     if (!bounds) return;
     editor.updateViewportScreenBounds(editor.getContainer());
     editor.zoomToBounds(bounds, { inset: BOARD_ZOOM_INSET });
-  }, [inspecting]);
+  }, [inspecting, editor]);
 
   function handleMount(editor: Editor) {
-    editorRef.current = editor;
+    setEditor(editor);
     initializeCanvas(editor);
+    // After the library, which is what creates the pages the comments are keyed to.
+    const disposeComments = installCanvasComments(editor);
     const sync = installCanvasUrlSync(
       editor,
       () => inspected.current,
@@ -869,7 +989,10 @@ export default function App() {
     writeUrl.current = sync.write;
     // The address names a board, or the whole page is the view.
     if (!sync.apply()) requestAnimationFrame(() => editor.zoomToFit());
-    return sync.uninstall;
+    return () => {
+      disposeComments();
+      sync.uninstall();
+    };
   }
 
   return (
@@ -878,8 +1001,12 @@ export default function App() {
         stylesVisible,
         toggleStyles: () => setStylesVisible((visible) => !visible),
         relayoutLibrary: () => {
-          if (editorRef.current) relayoutCanvasLibrary(editorRef.current);
+          if (editor) relayoutCanvasLibrary(editor);
         },
+        editor,
+        commentUser,
+        setCommentUser,
+        inspectBoard: onPick,
       }}
     >
       <div className="canvas-shell">
@@ -887,8 +1014,10 @@ export default function App() {
           <Tldraw
             assetUrls={canvasChromeAssetUrls}
             components={canvasChromeComponents}
-            persistenceKey={PERSISTENCE_KEY}
+            store={store}
             shapeUtils={shapeUtils}
+            tools={canvasCommentTools}
+            overrides={commentToolOverrides}
             onMount={handleMount}
           >
             <AgentBridge />

--- a/canvas/src/App.tsx
+++ b/canvas/src/App.tsx
@@ -910,7 +910,6 @@ function initializeCanvas(editor: Editor) {
 const BOARD_ZOOM_INSET = 80;
 
 export default function App() {
-  const [stylesVisible, setStylesVisible] = useState(false);
   /** The board open in the inspector: click any board on the canvas to open it, Escape or × to close. */
   const [inspecting, setInspecting] = useState<CanvasLibraryFile | null>(null);
   const [commentUser, setCommentUser] = useState(readCommentUser);
@@ -998,8 +997,6 @@ export default function App() {
   return (
     <CanvasChromeContext.Provider
       value={{
-        stylesVisible,
-        toggleStyles: () => setStylesVisible((visible) => !visible),
         relayoutLibrary: () => {
           if (editor) relayoutCanvasLibrary(editor);
         },

--- a/canvas/src/App.tsx
+++ b/canvas/src/App.tsx
@@ -90,6 +90,16 @@ const SNAP_DEFAULT_KEY = `${PERSISTENCE_KEY}:snap-default`;
  * tldraw-local-store.d.ts. Module scope, so the options object keeps its identity across renders:
  * the hook rebuilds the store whenever it changes.
  */
+/**
+ * The tldraw license, inlined from the build environment (see vite.config.ts for the two names
+ * accepted). Commenting is a licensed feature: without a key `CanvasComments` renders nothing in
+ * production. Not in development — tldraw reads the *runtime* host for that, and localhost, a
+ * loopback address and any plain-http origin all get every feature. So a built bundle served from
+ * 127.0.0.1 cannot tell you whether the deployed site will have commenting; only the deploy can.
+ */
+const TLDRAW_LICENSE_KEY: string | undefined =
+  import.meta.env.VITE_TLDRAW_LICENSE_KEY ?? import.meta.env.TLDRAW_LICENSE_KEY;
+
 const storeOptions = {
   persistenceKey: PERSISTENCE_KEY,
   // The same set `<Tldraw>` merges for itself; the schema has to know every type the document
@@ -1015,6 +1025,7 @@ export default function App() {
             shapeUtils={shapeUtils}
             tools={canvasCommentTools}
             overrides={canvasCommentOverrides}
+            licenseKey={TLDRAW_LICENSE_KEY}
             onMount={handleMount}
           >
             <AgentBridge />

--- a/canvas/src/CanvasFileShapeUtil.tsx
+++ b/canvas/src/CanvasFileShapeUtil.tsx
@@ -53,7 +53,7 @@ function CanvasFile({ shape }: { shape: CanvasFileShape }) {
             display: "block",
             pointerEvents: isEditing ? "auto" : "none",
             // Safari routes a wheel to an iframe's own scrolling area whatever pointer-events
-            // says, so a two-finger pan over a board did nothing there — and a horizontal one
+            // says, so a two-finger pan over a board did nothing there, and a horizontal one
             // chained out to the browser's back gesture. Behind its container it is not a scroll
             // target, and the pan reaches tldraw wherever the cursor is. tldraw's own embed shape
             // carries this same line: <https://stackoverflow.com/a/49150908>.

--- a/canvas/src/CanvasFileShapeUtil.tsx
+++ b/canvas/src/CanvasFileShapeUtil.tsx
@@ -52,6 +52,12 @@ function CanvasFile({ shape }: { shape: CanvasFileShape }) {
             border: 0,
             display: "block",
             pointerEvents: isEditing ? "auto" : "none",
+            // Safari routes a wheel to an iframe's own scrolling area whatever pointer-events
+            // says, so a two-finger pan over a board did nothing there — and a horizontal one
+            // chained out to the browser's back gesture. Behind its container it is not a scroll
+            // target, and the pan reaches tldraw wherever the cursor is. tldraw's own embed shape
+            // carries this same line: <https://stackoverflow.com/a/49150908>.
+            zIndex: isEditing ? undefined : -1,
           }}
         />
       ) : hasCanvasFile(shape.props.path) ? null : (
@@ -83,10 +89,6 @@ export class CanvasFileShapeUtil extends BaseBoxShapeUtil<CanvasFileShape> {
   }
 
   override canResize() {
-    return true;
-  }
-
-  override canScroll() {
     return true;
   }
 

--- a/canvas/src/CanvasStatusBannerShapeUtil.tsx
+++ b/canvas/src/CanvasStatusBannerShapeUtil.tsx
@@ -1,0 +1,105 @@
+import {
+  BaseBoxShapeUtil,
+  HTMLContainer,
+  T,
+  type RecordProps,
+  type TLShape,
+} from "tldraw";
+
+import type { CanvasBoardStatus } from "./canvasLibrary";
+
+export const CANVAS_STATUS_BANNER_SHAPE_TYPE = "canvas-status-banner" as const;
+
+/**
+ * The tab's own height, and the gap it leaves above the board. Together they are the space a
+ * row reserves above its boards when anything in it carries a status, which is why they are
+ * one number as far as the layout is concerned.
+ */
+export const CANVAS_STATUS_BANNER_HEIGHT = 110;
+export const CANVAS_STATUS_BANNER_GAP = 24;
+
+/**
+ * A board's maturity, drawn as a tab above it. `live` is the default and draws nothing: most
+ * boards on a shipped page are live, and a tab on every one of them would say nothing while
+ * costing 134px of every row.
+ *
+ * Geist's solid badge colours, not its subtle ones. The inspector's badge can be a tinted pill
+ * because it sits at 100% next to one board; this is read across a page zoomed out to 34%,
+ * where a pale fill and a dark rule collapse into the same grey smudge.
+ */
+const STATUS_STYLE: Record<
+  Exclude<CanvasBoardStatus, "live">,
+  { label: string; fill: string; ink: string }
+> = {
+  exploring: { label: "EXPLORING", fill: "#FFB224", ink: "#171717" },
+  outdated: { label: "OUTDATED", fill: "#4D4D4D", ink: "#FFFFFF" },
+};
+
+declare module "tldraw" {
+  export interface TLGlobalShapePropsMap {
+    [CANVAS_STATUS_BANNER_SHAPE_TYPE]: {
+      w: number;
+      h: number;
+      status: string;
+    };
+  }
+}
+
+export type CanvasStatusBannerShape = TLShape<
+  typeof CANVAS_STATUS_BANNER_SHAPE_TYPE
+>;
+
+export class CanvasStatusBannerShapeUtil extends BaseBoxShapeUtil<CanvasStatusBannerShape> {
+  static override type = CANVAS_STATUS_BANNER_SHAPE_TYPE;
+  static override props: RecordProps<CanvasStatusBannerShape> = {
+    w: T.number,
+    h: T.number,
+    status: T.string,
+  };
+
+  override getDefaultProps(): CanvasStatusBannerShape["props"] {
+    return {
+      w: 478,
+      h: CANVAS_STATUS_BANNER_HEIGHT,
+      status: "exploring",
+    };
+  }
+
+  override canResize() {
+    return false;
+  }
+
+  override component(shape: CanvasStatusBannerShape) {
+    const style =
+      STATUS_STYLE[shape.props.status as keyof typeof STATUS_STYLE] ??
+      STATUS_STYLE.exploring;
+    return (
+      <HTMLContainer
+        style={{
+          width: shape.props.w,
+          height: shape.props.h,
+          background: style.fill,
+          color: style.ink,
+          font: `800 42px/${shape.props.h}px -apple-system, BlinkMacSystemFont, sans-serif`,
+          letterSpacing: ".14em",
+          textAlign: "center",
+        }}
+      >
+        {style.label}
+      </HTMLContainer>
+    );
+  }
+
+  override getIndicatorPath(shape: CanvasStatusBannerShape) {
+    const path = new Path2D();
+    path.rect(0, 0, shape.props.w, shape.props.h);
+    return path;
+  }
+
+  override getText(shape: CanvasStatusBannerShape) {
+    return (
+      STATUS_STYLE[shape.props.status as keyof typeof STATUS_STYLE]?.label ??
+      shape.props.status
+    );
+  }
+}

--- a/canvas/src/CloneCanvasDialog.tsx
+++ b/canvas/src/CloneCanvasDialog.tsx
@@ -25,8 +25,8 @@ export function CloneCanvasDialog({ slug, onClose }: TLUiDialogProps & { slug: s
   const [error, setError] = useState("");
   const [cloning, setCloning] = useState(false);
   const folder = canvasSlug(name);
-  // Empty in a production build, which does not ship the build machine's paths — the same
-  // fallback the no-boards notice uses, so the sentence still says where boards live.
+  // Empty in a production build, which does not ship the build machine's paths, so this falls
+  // back to what the no-boards notice uses and the sentence still says where boards live.
   const dir = canvasesDir || "mockups/canvases";
 
   const clone = () => {
@@ -35,7 +35,7 @@ export function CloneCanvasDialog({ slug, onClose }: TLUiDialogProps & { slug: s
     setError("");
     cloneCanvas(slug, name.trim()).then(
       // A new folder is a new page, and a page only exists once the index has been rebuilt, so
-      // the clone is opened by navigating to it — that load is the rebuild.
+      // the clone is opened by navigating to it. That load is the rebuild.
       (created) => window.location.assign(urlForSlug(window.location.href, created)),
       (reason: Error) => {
         setError(reason.message);
@@ -60,7 +60,7 @@ export function CloneCanvasDialog({ slug, onClose }: TLUiDialogProps & { slug: s
           onComplete={clone}
         />
         {/* The destination written out as a path, because a clone copies a real folder in the
-            project — this is not a page that lives only in the canvas. */}
+            project. This is not a page that lives only in the canvas. */}
         <div className="canvas-clone-hint">
           Copies every board of <b>{slug}</b> into a new folder on disk:
           <code className="canvas-clone-path">

--- a/canvas/src/CloneCanvasDialog.tsx
+++ b/canvas/src/CloneCanvasDialog.tsx
@@ -1,0 +1,88 @@
+import { useState } from "react";
+import {
+  TldrawUiButton,
+  TldrawUiButtonLabel,
+  TldrawUiDialogBody,
+  TldrawUiDialogCloseButton,
+  TldrawUiDialogFooter,
+  TldrawUiDialogHeader,
+  TldrawUiDialogTitle,
+  TldrawUiInput,
+  type TLUiDialogProps,
+} from "tldraw";
+import { canvasesDir } from "virtual:canvases";
+import { canvasSlug } from "./boardStatusEdit";
+import { cloneCanvas } from "./canvasLibrary";
+import { urlForSlug } from "./canvasUrl";
+
+/**
+ * Asking for the new canvas's name, which is the only thing cloning a folder needs that the
+ * canvas cannot work out for itself. The typed name is what the page is called; the server
+ * answers with the folder name it turned into, because only the server knows what is free.
+ */
+export function CloneCanvasDialog({ slug, onClose }: TLUiDialogProps & { slug: string }) {
+  const [name, setName] = useState("");
+  const [error, setError] = useState("");
+  const [cloning, setCloning] = useState(false);
+  const folder = canvasSlug(name);
+  // Empty in a production build, which does not ship the build machine's paths — the same
+  // fallback the no-boards notice uses, so the sentence still says where boards live.
+  const dir = canvasesDir || "mockups/canvases";
+
+  const clone = () => {
+    if (!folder || cloning) return;
+    setCloning(true);
+    setError("");
+    cloneCanvas(slug, name.trim()).then(
+      // A new folder is a new page, and a page only exists once the index has been rebuilt, so
+      // the clone is opened by navigating to it — that load is the rebuild.
+      (created) => window.location.assign(urlForSlug(window.location.href, created)),
+      (reason: Error) => {
+        setError(reason.message);
+        setCloning(false);
+      },
+    );
+  };
+
+  return (
+    <>
+      <TldrawUiDialogHeader>
+        <TldrawUiDialogTitle>Clone this canvas</TldrawUiDialogTitle>
+        <TldrawUiDialogCloseButton />
+      </TldrawUiDialogHeader>
+      <TldrawUiDialogBody style={{ display: "grid", gap: 8, width: 460 }}>
+        <TldrawUiInput
+          autoFocus
+          className="canvas-clone-name"
+          placeholder="New canvas name"
+          value={name}
+          onValueChange={setName}
+          onComplete={clone}
+        />
+        {/* The destination written out as a path, because a clone copies a real folder in the
+            project — this is not a page that lives only in the canvas. */}
+        <div className="canvas-clone-hint">
+          Copies every board of <b>{slug}</b> into a new folder on disk:
+          <code className="canvas-clone-path">
+            {dir}/<b>{folder || "new-canvas-name"}</b>/
+          </code>
+          {/* Only once the field says something: an empty one is not yet a mistake, a name with
+              no ASCII in it is, and either way this is why the button below is disabled. */}
+          {(error || (name.trim() && !folder)) && (
+            <div className="canvas-clone-hint__error">
+              {error || "A folder name is ASCII: letters, digits, dots and dashes."}
+            </div>
+          )}
+        </div>
+      </TldrawUiDialogBody>
+      <TldrawUiDialogFooter className="tlui-dialog__footer__actions">
+        <TldrawUiButton type="normal" onClick={onClose}>
+          <TldrawUiButtonLabel>Cancel</TldrawUiButtonLabel>
+        </TldrawUiButton>
+        <TldrawUiButton type="primary" disabled={!folder || cloning} onClick={clone}>
+          <TldrawUiButtonLabel>{cloning ? "Cloning…" : "Clone"}</TldrawUiButtonLabel>
+        </TldrawUiButton>
+      </TldrawUiDialogFooter>
+    </>
+  );
+}

--- a/canvas/src/CommentUserDialog.tsx
+++ b/canvas/src/CommentUserDialog.tsx
@@ -1,0 +1,90 @@
+import { useState } from "react";
+import {
+  TldrawUiButton,
+  TldrawUiButtonLabel,
+  TldrawUiDialogBody,
+  TldrawUiDialogCloseButton,
+  TldrawUiDialogFooter,
+  TldrawUiDialogHeader,
+  TldrawUiDialogTitle,
+  TldrawUiInput,
+  type TLUiDialogProps,
+} from "tldraw";
+import {
+  readCommentUser,
+  resolveGithubUser,
+  writeCommentUser,
+  type CommentUser,
+} from "./canvasComments";
+
+/**
+ * Asking who is commenting. There is no account here and there is not going to be one — the
+ * canvas serves one repo on 127.0.0.1 — but a comment with no name on it is not worth much in a
+ * review, so a GitHub handle is asked for once and remembered in this browser. The handle rather
+ * than a free-typed name because it is what a pull request will call the same person, and because
+ * it comes with a face: GitHub serves the avatar for a login without being asked for a token.
+ */
+export function CommentUserDialog({
+  onClose,
+  onSave,
+}: TLUiDialogProps & { onSave: (user: CommentUser) => void }) {
+  const [handle, setHandle] = useState(readCommentUser()?.name ?? "");
+  const [checking, setChecking] = useState(false);
+  const [failed, setFailed] = useState("");
+
+  const save = async () => {
+    if (checking) return;
+    setChecking(true);
+    setFailed("");
+    const user = await resolveGithubUser(handle);
+    setChecking(false);
+    if (!user) {
+      setFailed(`No GitHub avatar for “${handle.trim()}” — check the spelling.`);
+      return;
+    }
+    writeCommentUser(user);
+    onSave(user);
+    onClose();
+  };
+
+  return (
+    <>
+      <TldrawUiDialogHeader>
+        <TldrawUiDialogTitle>Who is commenting?</TldrawUiDialogTitle>
+        <TldrawUiDialogCloseButton />
+      </TldrawUiDialogHeader>
+      <TldrawUiDialogBody style={{ display: "grid", gap: 8, width: 460 }}>
+        <TldrawUiInput
+          autoFocus
+          className="canvas-clone-name"
+          placeholder="GitHub username"
+          value={handle}
+          onValueChange={(value) => {
+            setHandle(value);
+            setFailed("");
+          }}
+          onComplete={save}
+        />
+        {/* Same warning the clone dialog gives, for the same reason: this writes files someone
+            else will read in a pull request, not a document in this browser. */}
+        <div className="canvas-clone-hint">
+          {failed || (
+            <>
+              Comments are saved into each board&rsquo;s folder as <code>comments.json</code> and go
+              into Git with the boards. Your handle and your GitHub avatar are written next to what
+              you post — no account, no sign-in.
+            </>
+          )}
+        </div>
+      </TldrawUiDialogBody>
+      <TldrawUiDialogFooter className="tlui-dialog__footer__actions">
+        <TldrawUiButton type="normal" onClick={onClose}>
+          <TldrawUiButtonLabel>Cancel</TldrawUiButtonLabel>
+        </TldrawUiButton>
+        <TldrawUiButton type="primary" disabled={!handle.trim() || checking} onClick={save}>
+          <TldrawUiButtonLabel>{checking ? "Checking…" : "Save"}</TldrawUiButtonLabel>
+        </TldrawUiButton>
+      </TldrawUiDialogFooter>
+    </>
+  );
+}

--- a/canvas/src/CommentUserDialog.tsx
+++ b/canvas/src/CommentUserDialog.tsx
@@ -19,8 +19,8 @@ import {
 } from "./canvasComments";
 
 /**
- * Asking who is commenting. There is no account here and there is not going to be one — the
- * canvas serves one repo on 127.0.0.1 — but a comment with no name on it is not worth much in a
+ * Asking who is commenting. There is no account here and there is not going to be one, since the
+ * canvas serves one repo on 127.0.0.1, but a comment with no name on it is not worth much in a
  * review, so a GitHub handle is asked for once and remembered in this browser. The handle rather
  * than a free-typed name because it is what a pull request will call the same person, and because
  * it comes with a face: GitHub serves the avatar for a login without being asked for a token.
@@ -36,7 +36,7 @@ export function CommentUserDialog({
 
   // A field called "GitHub username" is exactly what a password manager offers to fill, and an
   // offer to sign in is the one thing this dialog is not. Each manager reads its own opt-out
-  // attribute, and TldrawUiInput passes none of them through — so set them on the element it
+  // attribute, and TldrawUiInput passes none of them through, so set them on the element it
   // hands back. `name` matters too: managers match on it before they read anything else.
   useEffect(() => {
     const el = input.current;
@@ -63,7 +63,7 @@ export function CommentUserDialog({
     const user = await resolveGithubUser(handle);
     setChecking(false);
     if (!user) {
-      setFailed(`No GitHub avatar for “${handle.trim()}” — check the spelling.`);
+      setFailed(`No GitHub avatar for “${handle.trim()}”. Check the spelling.`);
       return;
     }
     writeCommentUser(user);

--- a/canvas/src/CommentUserDialog.tsx
+++ b/canvas/src/CommentUserDialog.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
   TldrawUiButton,
   TldrawUiButtonLabel,
@@ -11,6 +11,7 @@ import {
   type TLUiDialogProps,
 } from "tldraw";
 import {
+  GITHUB_PATH,
   readCommentUser,
   resolveGithubUser,
   writeCommentUser,
@@ -31,6 +32,29 @@ export function CommentUserDialog({
   const [handle, setHandle] = useState(readCommentUser()?.name ?? "");
   const [checking, setChecking] = useState(false);
   const [failed, setFailed] = useState("");
+  const input = useRef<HTMLInputElement>(null);
+
+  // A field called "GitHub username" is exactly what a password manager offers to fill, and an
+  // offer to sign in is the one thing this dialog is not. Each manager reads its own opt-out
+  // attribute, and TldrawUiInput passes none of them through — so set them on the element it
+  // hands back. `name` matters too: managers match on it before they read anything else.
+  useEffect(() => {
+    const el = input.current;
+    if (!el) return;
+    for (const [key, value] of Object.entries({
+      name: "sp-comment-handle",
+      autocomplete: "off",
+      autocapitalize: "off",
+      autocorrect: "off",
+      spellcheck: "false",
+      "data-1p-ignore": "true",
+      "data-lpignore": "true",
+      "data-bwignore": "true",
+      "data-form-type": "other",
+    })) {
+      el.setAttribute(key, value);
+    }
+  }, []);
 
   const save = async () => {
     if (checking) return;
@@ -54,27 +78,42 @@ export function CommentUserDialog({
         <TldrawUiDialogCloseButton />
       </TldrawUiDialogHeader>
       <TldrawUiDialogBody style={{ display: "grid", gap: 8, width: 460 }}>
-        <TldrawUiInput
-          autoFocus
-          className="canvas-clone-name"
-          placeholder="GitHub username"
-          value={handle}
-          onValueChange={(value) => {
-            setHandle(value);
-            setFailed("");
-          }}
-          onComplete={save}
-        />
-        {/* Same warning the clone dialog gives, for the same reason: this writes files someone
-            else will read in a pull request, not a document in this browser. */}
+        {/* The mark inside the field, the way a sign-in box wears it: this is the one place the
+            canvas asks for an account, and whose account is the whole question. It goes in as the
+            input's children, which tldraw lays out inside the field's own flex row, so the border
+            moves to that row and the mark sits within it rather than floating over the text. */}
+        <div className="canvas-gh-field">
+          <TldrawUiInput
+            ref={input}
+            autoFocus
+            placeholder="GitHub username"
+            value={handle}
+            onValueChange={(value) => {
+              setHandle(value);
+              setFailed("");
+            }}
+            onComplete={save}
+          >
+            <svg viewBox="0 0 24 24" width="16" height="16" fillRule="evenodd" aria-hidden>
+              <path d={GITHUB_PATH} />
+            </svg>
+          </TldrawUiInput>
+        </div>
+        {/* Where a comment ends up is the thing worth saying before someone writes one, and it
+            is not the same in both places. Lead with that, in one sentence. */}
         <div className="canvas-clone-hint">
-          {failed || (
-            <>
-              Comments are saved into each board&rsquo;s folder as <code>comments.json</code> and go
-              into Git with the boards. Your handle and your GitHub avatar are written next to what
-              you post — no account, no sign-in.
-            </>
-          )}
+          {failed ||
+            (import.meta.env.DEV ? (
+              <>
+                <strong>Comments go into Git</strong>, as <code>comments.json</code> in the
+                board&rsquo;s folder, signed with your handle and avatar.
+              </>
+            ) : (
+              <>
+                <strong>Comments stay in this browser.</strong> Run the canvas on your own project
+                to save them into the board&rsquo;s folder instead.
+              </>
+            ))}
         </div>
       </TldrawUiDialogBody>
       <TldrawUiDialogFooter className="tlui-dialog__footer__actions">

--- a/canvas/src/InspectorComments.tsx
+++ b/canvas/src/InspectorComments.tsx
@@ -35,6 +35,10 @@ import { boardPin, type BoardPin } from "./inspectorModel";
  * comment components (they want the UI context for tooltips and translations). The editor arrives
  * through `CanvasChromeContext` instead, and the rest is the panel's own chrome — which is what
  * it should look like anyway, next to the layers list rather than out on the canvas.
+ *
+ * Writing needs the dev server a plugin install runs, because that is what puts a comment in the
+ * repo. A built canvas has no repo behind it, so there the composer and the per-comment actions
+ * are gone and the committed threads are left to read.
  */
 
 const cx = (...parts: (string | false | null | undefined)[]) => parts.filter(Boolean).join(" ");
@@ -169,10 +173,12 @@ export function BoardComments({
           <div className="sp-empty">No comments on this board.</div>
         )}
       </div>
-      <Composer
-        placeholder={pinAt.x === 0.5 && pinAt.y === 0.5 ? "Comment on this board…" : "Comment on the selected layer…"}
-        onPost={post}
-      />
+      {import.meta.env.DEV ? (
+        <Composer
+          placeholder={pinAt.x === 0.5 && pinAt.y === 0.5 ? "Comment on this board…" : "Comment on the selected layer…"}
+          onPost={post}
+        />
+      ) : null}
     </section>
   );
 }
@@ -253,30 +259,34 @@ function Thread({
               />
             </div>
           ))}
-          <div className="sp-note-actions">
-            <button
-              type="button"
-              onClick={() =>
-                me && (thread.resolved ? reopenThread(editor, thread) : resolveThread(editor, thread, me.id))
-              }
-              disabled={!me}
-            >
-              {thread.resolved ? "Reopen" : "Resolve"}
-            </button>
-            {/* Deleting is the one thing that takes someone else's words out of Git. */}
-            {me?.id === thread.createdBy ? (
-              <button
-                type="button"
-                onClick={() => {
-                  onOpen(null);
-                  deleteThread(editor, thread);
-                }}
-              >
-                Delete thread
-              </button>
-            ) : null}
-          </div>
-          <Composer placeholder="Reply…" onPost={reply} />
+          {import.meta.env.DEV ? (
+            <>
+              <div className="sp-note-actions">
+                <button
+                  type="button"
+                  onClick={() =>
+                    me && (thread.resolved ? reopenThread(editor, thread) : resolveThread(editor, thread, me.id))
+                  }
+                  disabled={!me}
+                >
+                  {thread.resolved ? "Reopen" : "Resolve"}
+                </button>
+                {/* Deleting is the one thing that takes someone else's words out of Git. */}
+                {me?.id === thread.createdBy ? (
+                  <button
+                    type="button"
+                    onClick={() => {
+                      onOpen(null);
+                      deleteThread(editor, thread);
+                    }}
+                  >
+                    Delete thread
+                  </button>
+                ) : null}
+              </div>
+              <Composer placeholder="Reply…" onPost={reply} />
+            </>
+          ) : null}
         </>
       ) : null}
     </article>
@@ -322,7 +332,7 @@ function Comment({
     <>
       <p className={cx("sp-note-body", clamp && "sp-note-body--clamp")}>{text}</p>
       {/* Someone else's words are theirs to change, here as on the canvas. */}
-      {actions && me?.id === comment.authorId ? (
+      {actions && import.meta.env.DEV && me?.id === comment.authorId ? (
         <div className="sp-note-actions">
           <button type="button" onClick={() => setEditing(true)}>
             Edit

--- a/canvas/src/InspectorComments.tsx
+++ b/canvas/src/InspectorComments.tsx
@@ -173,12 +173,10 @@ export function BoardComments({
           <div className="sp-empty">No comments on this board.</div>
         )}
       </div>
-      {import.meta.env.DEV ? (
-        <Composer
-          placeholder={pinAt.x === 0.5 && pinAt.y === 0.5 ? "Comment on this board…" : "Comment on the selected layer…"}
-          onPost={post}
-        />
-      ) : null}
+      <Composer
+        placeholder={pinAt.x === 0.5 && pinAt.y === 0.5 ? "Comment on this board…" : "Comment on the selected layer…"}
+        onPost={post}
+      />
     </section>
   );
 }
@@ -259,34 +257,30 @@ function Thread({
               />
             </div>
           ))}
-          {import.meta.env.DEV ? (
-            <>
-              <div className="sp-note-actions">
-                <button
-                  type="button"
-                  onClick={() =>
-                    me && (thread.resolved ? reopenThread(editor, thread) : resolveThread(editor, thread, me.id))
-                  }
-                  disabled={!me}
-                >
-                  {thread.resolved ? "Reopen" : "Resolve"}
-                </button>
-                {/* Deleting is the one thing that takes someone else's words out of Git. */}
-                {me?.id === thread.createdBy ? (
-                  <button
-                    type="button"
-                    onClick={() => {
-                      onOpen(null);
-                      deleteThread(editor, thread);
-                    }}
-                  >
-                    Delete thread
-                  </button>
-                ) : null}
-              </div>
-              <Composer placeholder="Reply…" onPost={reply} />
-            </>
-          ) : null}
+          <div className="sp-note-actions">
+            <button
+              type="button"
+              onClick={() =>
+                me && (thread.resolved ? reopenThread(editor, thread) : resolveThread(editor, thread, me.id))
+              }
+              disabled={!me}
+            >
+              {thread.resolved ? "Reopen" : "Resolve"}
+            </button>
+            {/* Deleting is the one thing that takes someone else's words away. */}
+            {me?.id === thread.createdBy ? (
+              <button
+                type="button"
+                onClick={() => {
+                  onOpen(null);
+                  deleteThread(editor, thread);
+                }}
+              >
+                Delete thread
+              </button>
+            ) : null}
+          </div>
+          <Composer placeholder="Reply…" onPost={reply} />
         </>
       ) : null}
     </article>
@@ -332,7 +326,7 @@ function Comment({
     <>
       <p className={cx("sp-note-body", clamp && "sp-note-body--clamp")}>{text}</p>
       {/* Someone else's words are theirs to change, here as on the canvas. */}
-      {actions && import.meta.env.DEV && me?.id === comment.authorId ? (
+      {actions && me?.id === comment.authorId ? (
         <div className="sp-note-actions">
           <button type="button" onClick={() => setEditing(true)}>
             Edit

--- a/canvas/src/InspectorComments.tsx
+++ b/canvas/src/InspectorComments.tsx
@@ -1,0 +1,406 @@
+import { useContext, useMemo, useState } from "react";
+import {
+  createComment,
+  createCommentThread,
+  toRichText,
+  type Editor,
+  type TLComment,
+  type TLCommentThread,
+  type TLCommentThreadId,
+  type TLShapeId,
+} from "tldraw";
+import {
+  deleteComment,
+  deleteThread,
+  editComment,
+  formatRelativeTime,
+  putCommentRecords,
+  reopenThread,
+  resolveThread,
+  richTextToPlaintext,
+  useCommentThreads,
+  useThreadComments,
+} from "@tldraw/commenting";
+import { ASK_COMMENT_USER, CanvasChromeContext } from "./canvasChrome";
+import { resolveAuthor } from "./canvasComments";
+import { boardPin, type BoardPin } from "./inspectorModel";
+
+/**
+ * The board's comments, in the inspector: the same threads the canvas pins, listed under the
+ * preview and drawn on it at the spot they mark. They are the same records either way — one board
+ * folder's `comments.json` — so a note written here appears on the canvas and goes into Git with
+ * the board, and one written out on the canvas is here when the board is opened.
+ *
+ * The panel renders outside `<Tldraw>`, so none of this can reach `useEditor` or the toolkit's
+ * comment components (they want the UI context for tooltips and translations). The editor arrives
+ * through `CanvasChromeContext` instead, and the rest is the panel's own chrome — which is what
+ * it should look like anyway, next to the layers list rather than out on the canvas.
+ */
+
+const cx = (...parts: (string | false | null | undefined)[]) => parts.filter(Boolean).join(" ");
+
+/** A thread on this board, and where it points at it. */
+export interface BoardThread {
+  thread: TLCommentThread;
+  pin: BoardPin;
+}
+
+function useBoardThreads(editor: Editor, shapeId: TLShapeId): BoardThread[] {
+  const threads = useCommentThreads(editor);
+  return useMemo(() => {
+    const rows: BoardThread[] = [];
+    for (const thread of threads) {
+      const pin = boardPin(thread.anchor, shapeId);
+      if (pin) rows.push({ thread, pin });
+    }
+    return rows.sort((a, b) => a.thread.createdAt - b.thread.createdAt);
+  }, [threads, shapeId]);
+}
+
+/** The author of a thread's first comment, which is who the list calls the thread's. */
+const openedBy = (thread: TLCommentThread) => resolveAuthor(thread.createdBy);
+
+const when = (at: number) => formatRelativeTime(new Date(at).toISOString());
+
+/**
+ * The pins, over the preview. Positioned in the artboard's own coordinates — the anchor is a
+ * fraction of the board, and the board is drawn at its own size — then counter-scaled, so a pin
+ * is the same size whether the preview is at 100% or fitted to a third of that.
+ */
+export function BoardPins({
+  editor,
+  shapeId,
+  scale,
+  open,
+  onOpen,
+}: {
+  editor: Editor;
+  shapeId: TLShapeId;
+  scale: number;
+  open: TLCommentThreadId | null;
+  onOpen: (id: TLCommentThreadId | null) => void;
+}) {
+  const rows = useBoardThreads(editor, shapeId);
+  return (
+    <>
+      {rows.map(({ thread, pin }, i) =>
+        // A thread anchored beside the board rather than on it is in the list but has no spot on
+        // the preview to point at, so it gets no pin.
+        pin.inside ? (
+          <div
+            key={thread.id}
+            className="sp-pin-at"
+            style={{ left: `${pin.x * 100}%`, top: `${pin.y * 100}%` }}
+          >
+            <button
+              type="button"
+              className={cx(
+                "sp-pin",
+                thread.resolved && "sp-pin--done",
+                open === thread.id && "on",
+              )}
+              style={{ transform: `scale(${1 / scale})` }}
+              title={`${openedBy(thread).name}: comment ${i + 1}`}
+              onClick={() => onOpen(open === thread.id ? null : thread.id)}
+            >
+              {i + 1}
+            </button>
+          </div>
+        ) : null,
+      )}
+    </>
+  );
+}
+
+/** The strip under the preview: every thread on this board, and the field for a new one. */
+export function BoardComments({
+  editor,
+  shapeId,
+  open,
+  onOpen,
+  pinAt,
+}: {
+  editor: Editor;
+  shapeId: TLShapeId;
+  open: TLCommentThreadId | null;
+  onOpen: (id: TLCommentThreadId | null) => void;
+  /** Where a comment written here is pinned: the selected layer's middle, or the board's. */
+  pinAt: { x: number; y: number };
+}) {
+  const me = useContext(CanvasChromeContext).commentUser;
+  const rows = useBoardThreads(editor, shapeId);
+
+  const post = (body: string) => {
+    // Not the current page: the panel outlives a page change, and a thread on the wrong page
+    // would be written into the wrong folder's file.
+    const pageId = editor.getAncestorPageId(shapeId);
+    if (!me || !pageId) return;
+    const thread = createCommentThread({
+      pageId,
+      anchor: { type: "shape", shapeId, x: pinAt.x, y: pinAt.y, isPrecise: true },
+      createdBy: me.id,
+    });
+    putCommentRecords(editor, [
+      thread,
+      createComment({ threadId: thread.id, pageId, authorId: me.id, body: toRichText(body) }),
+    ]);
+    onOpen(thread.id);
+  };
+
+  return (
+    <section className="sp-notes">
+      <div className="sp-sh sp-sh--pad">
+        <span className="sp-sh-t">Comments</span>
+        <span className="sp-sh-s">{rows.length || ""}</span>
+      </div>
+      <div className="sp-notes-list">
+        {rows.length ? (
+          rows.map((row, i) => (
+            <Thread
+              key={row.thread.id}
+              editor={editor}
+              row={row}
+              n={i + 1}
+              open={open === row.thread.id}
+              onOpen={onOpen}
+            />
+          ))
+        ) : (
+          <div className="sp-empty">No comments on this board.</div>
+        )}
+      </div>
+      <Composer
+        placeholder={pinAt.x === 0.5 && pinAt.y === 0.5 ? "Comment on this board…" : "Comment on the selected layer…"}
+        onPost={post}
+      />
+    </section>
+  );
+}
+
+function Thread({
+  editor,
+  row: { thread, pin },
+  n,
+  open,
+  onOpen,
+}: {
+  editor: Editor;
+  row: BoardThread;
+  n: number;
+  open: boolean;
+  onOpen: (id: TLCommentThreadId | null) => void;
+}) {
+  const me = useContext(CanvasChromeContext).commentUser;
+  const comments = useThreadComments(editor, thread.id);
+  const [first, ...replies] = comments;
+  const author = openedBy(thread);
+
+  // The last comment takes its thread with it: what would be left is a pin with nothing behind
+  // it. Any other one is just a message leaving the conversation.
+  const remove = (comment: TLComment) => {
+    if (comments.length > 1) return deleteComment(editor, comment);
+    onOpen(null);
+    deleteThread(editor, thread);
+  };
+
+  const reply = (body: string) => {
+    if (!me) return;
+    putCommentRecords(editor, [
+      createComment({
+        threadId: thread.id,
+        pageId: thread.pageId,
+        authorId: me.id,
+        body: toRichText(body),
+      }),
+    ]);
+  };
+
+  return (
+    <article className={cx("sp-note", open && "on", thread.resolved && "sp-note--done")}>
+      <button
+        type="button"
+        className="sp-note-head"
+        aria-expanded={open}
+        onClick={() => onOpen(open ? null : thread.id)}
+      >
+        <span className={cx("sp-note-n", !pin.inside && "sp-note-n--off")}>{n}</span>
+        <img className="sp-note-av" src={author.image} alt="" />
+        <span className="sp-note-who">{author.name}</span>
+        <span className="sp-note-when">{when(thread.createdAt)}</span>
+        {replies.length ? <span className="sp-note-count">{replies.length}</span> : null}
+      </button>
+      {first ? (
+        <Comment
+          editor={editor}
+          comment={first}
+          clamp={!open}
+          actions={open}
+          onDelete={() => remove(first)}
+        />
+      ) : null}
+      {open ? (
+        <>
+          {replies.map((comment) => (
+            <div key={comment.id} className="sp-note-reply">
+              <span className="sp-note-who">{resolveAuthor(comment.authorId).name}</span>
+              <span className="sp-note-when">{when(comment.createdAt)}</span>
+              <Comment
+                editor={editor}
+                comment={comment}
+                clamp={false}
+                actions
+                onDelete={() => remove(comment)}
+              />
+            </div>
+          ))}
+          <div className="sp-note-actions">
+            <button
+              type="button"
+              onClick={() =>
+                me && (thread.resolved ? reopenThread(editor, thread) : resolveThread(editor, thread, me.id))
+              }
+              disabled={!me}
+            >
+              {thread.resolved ? "Reopen" : "Resolve"}
+            </button>
+            {/* Deleting is the one thing that takes someone else's words out of Git. */}
+            {me?.id === thread.createdBy ? (
+              <button
+                type="button"
+                onClick={() => {
+                  onOpen(null);
+                  deleteThread(editor, thread);
+                }}
+              >
+                Delete thread
+              </button>
+            ) : null}
+          </div>
+          <Composer placeholder="Reply…" onPost={reply} />
+        </>
+      ) : null}
+    </article>
+  );
+}
+
+/** One comment: its words, and — for whoever wrote them — the two things they can do to them. */
+function Comment({
+  editor,
+  comment,
+  clamp,
+  actions,
+  onDelete,
+}: {
+  editor: Editor;
+  comment: TLComment;
+  clamp: boolean;
+  /** Only while the thread is open: a collapsed row is a preview, not somewhere to edit. */
+  actions: boolean;
+  onDelete: () => void;
+}) {
+  const me = useContext(CanvasChromeContext).commentUser;
+  const [editing, setEditing] = useState(false);
+  // Plain text in and out, like the composer below: a comment edited here reads the same on the
+  // canvas, and one written there flattens to what this panel can show of it.
+  const text = richTextToPlaintext(comment.body, (id) => resolveAuthor(id).name);
+
+  if (editing) {
+    return (
+      <Composer
+        placeholder="Edit…"
+        initial={text}
+        onPost={(body) => {
+          setEditing(false);
+          editComment(editor, comment, toRichText(body));
+        }}
+        onCancel={() => setEditing(false)}
+      />
+    );
+  }
+
+  return (
+    <>
+      <p className={cx("sp-note-body", clamp && "sp-note-body--clamp")}>{text}</p>
+      {/* Someone else's words are theirs to change, here as on the canvas. */}
+      {actions && me?.id === comment.authorId ? (
+        <div className="sp-note-actions">
+          <button type="button" onClick={() => setEditing(true)}>
+            Edit
+          </button>
+          <button type="button" onClick={onDelete}>
+            Delete
+          </button>
+        </div>
+      ) : null}
+    </>
+  );
+}
+
+/**
+ * The field. Plain text, because that is what the whole panel is — the canvas composer is a rich
+ * text editor, and a note typed here reads the same in both.
+ */
+function Composer({
+  placeholder,
+  initial,
+  onPost,
+  onCancel,
+}: {
+  placeholder: string;
+  /** The text an edit starts from. A new comment has none: it starts empty and clears on post. */
+  initial?: string;
+  onPost: (body: string) => void;
+  onCancel?: () => void;
+}) {
+  const me = useContext(CanvasChromeContext).commentUser;
+  const [text, setText] = useState(initial ?? "");
+
+  const post = () => {
+    const body = text.trim();
+    if (!body) return;
+    if (initial === undefined) setText("");
+    onPost(body);
+  };
+
+  return (
+    <div
+      className="sp-note-new"
+      // The identity dialog is a tldraw dialog, and those can only be opened from inside
+      // <Tldraw>. Asking for one is the first thing a click here does, when there is no name yet.
+      onPointerDown={me ? undefined : () => window.dispatchEvent(new Event(ASK_COMMENT_USER))}
+    >
+      {me ? <img className="sp-note-av" src={me.image} alt="" /> : null}
+      <textarea
+        rows={1}
+        autoFocus={initial !== undefined}
+        value={text}
+        disabled={!me}
+        placeholder={me ? placeholder : "Add your GitHub username to comment"}
+        onChange={(event) => setText(event.currentTarget.value)}
+        // An edit continues from the end of what is there, rather than in front of it. A click
+        // into the field still puts the caret where it was clicked.
+        onFocus={(event) => {
+          const end = event.currentTarget.value.length;
+          event.currentTarget.setSelectionRange(end, end);
+        }}
+        onKeyDown={(event) => {
+          if (event.key === "Enter" && !event.shiftKey) {
+            event.preventDefault();
+            post();
+          }
+          // Out of the field, rather than through to the panel's own Escape, which would close it.
+          if (event.key === "Escape") {
+            event.preventDefault();
+            if (onCancel) onCancel();
+            else event.currentTarget.blur();
+          }
+        }}
+      />
+      {text.trim() ? (
+        <button type="button" className="sp-note-send" onClick={post}>
+          {initial === undefined ? "Post" : "Save"}
+        </button>
+      ) : null}
+    </div>
+  );
+}

--- a/canvas/src/InspectorComments.tsx
+++ b/canvas/src/InspectorComments.tsx
@@ -23,25 +23,22 @@ import {
 } from "@tldraw/commenting";
 import { ASK_COMMENT_USER, CanvasChromeContext } from "./canvasChrome";
 import { resolveAuthor } from "./canvasComments";
-import { boardPin, type BoardPin } from "./inspectorModel";
+import { boardPin, cx, type BoardPin } from "./inspectorModel";
 
 /**
  * The board's comments, in the inspector: the same threads the canvas pins, listed under the
- * preview and drawn on it at the spot they mark. They are the same records either way — one board
- * folder's `comments.json` — so a note written here appears on the canvas and goes into Git with
+ * preview and drawn on it at the spot they mark. They are the same records either way, one board
+ * folder's `comments.json`, so a note written here appears on the canvas and goes into Git with
  * the board, and one written out on the canvas is here when the board is opened.
  *
  * The panel renders outside `<Tldraw>`, so none of this can reach `useEditor` or the toolkit's
  * comment components (they want the UI context for tooltips and translations). The editor arrives
- * through `CanvasChromeContext` instead, and the rest is the panel's own chrome — which is what
+ * through `CanvasChromeContext` instead, and the rest is the panel's own chrome, which is what
  * it should look like anyway, next to the layers list rather than out on the canvas.
  *
- * Writing needs the dev server a plugin install runs, because that is what puts a comment in the
- * repo. A built canvas has no repo behind it, so there the composer and the per-comment actions
- * are gone and the committed threads are left to read.
+ * Where a write goes is decided in canvasComments.ts: the board's folder against a dev server,
+ * this browser on a built canvas. The composer and the per-comment actions are the same in both.
  */
-
-const cx = (...parts: (string | false | null | undefined)[]) => parts.filter(Boolean).join(" ");
 
 /** A thread on this board, and where it points at it. */
 export interface BoardThread {
@@ -67,8 +64,8 @@ const openedBy = (thread: TLCommentThread) => resolveAuthor(thread.createdBy);
 const when = (at: number) => formatRelativeTime(new Date(at).toISOString());
 
 /**
- * The pins, over the preview. Positioned in the artboard's own coordinates — the anchor is a
- * fraction of the board, and the board is drawn at its own size — then counter-scaled, so a pin
+ * The pins, over the preview. Positioned in the artboard's own coordinates, since the anchor is a
+ * fraction of the board and the board is drawn at its own size, then counter-scaled, so a pin
  * is the same size whether the preview is at 100% or fitted to a third of that.
  */
 export function BoardPins({
@@ -200,7 +197,7 @@ function Thread({
   const author = openedBy(thread);
 
   // The last comment takes its thread with it: what would be left is a pin with nothing behind
-  // it. Any other one is just a message leaving the conversation.
+  // it. Any other one is a message leaving the conversation.
   const remove = (comment: TLComment) => {
     if (comments.length > 1) return deleteComment(editor, comment);
     onOpen(null);
@@ -287,7 +284,7 @@ function Thread({
   );
 }
 
-/** One comment: its words, and — for whoever wrote them — the two things they can do to them. */
+/** One comment: its words, and for whoever wrote them, the two things they can do to them. */
 function Comment({
   editor,
   comment,
@@ -341,7 +338,7 @@ function Comment({
 }
 
 /**
- * The field. Plain text, because that is what the whole panel is — the canvas composer is a rich
+ * The field. Plain text, because that is what the whole panel is. The canvas composer is a rich
  * text editor, and a note typed here reads the same in both.
  */
 function Composer({

--- a/canvas/src/InspectorPanel.tsx
+++ b/canvas/src/InspectorPanel.tsx
@@ -1,7 +1,18 @@
-import { useEffect, useMemo, useRef, useState } from "react";
-import { useEditor } from "tldraw";
+import { useContext, useEffect, useMemo, useRef, useState } from "react";
+import { createShapeId, useEditor, type TLCommentThreadId } from "tldraw";
+import { BoardComments, BoardPins } from "./InspectorComments";
+import { CanvasChromeContext } from "./canvasChrome";
 import type { CanvasFileShape } from "./CanvasFileShapeUtil";
-import { readCanvasAssetNames, useCanvasFileHtml } from "./canvasLibrary";
+import {
+  BOARD_STATUSES,
+  BOARD_STATUS_LABEL,
+  LAYOUT_CHANGED,
+  type CanvasBoardStatus,
+  boardStatusForPath,
+  readCanvasAssetNames,
+  useCanvasFileHtml,
+  writeBoardStatus,
+} from "./canvasLibrary";
 import {
   injectAgent,
   type SpBinding,
@@ -29,6 +40,7 @@ import {
   layerName,
   layerSelector,
   nextLayersH,
+  newBoardPin,
   nextPanelW,
   nextRailW,
   panelBounds,
@@ -36,6 +48,178 @@ import {
   tokenGroups,
   tokenVia,
 } from "./inspectorModel";
+
+/**
+ * Panel state that outlives the board it was set on.
+ *
+ * The panel is keyed by path, so clicking a different board mounts a fresh one. That is right for
+ * the selection and the report, which are about the board — and wrong for how the panel is
+ * arranged, which is about the person: collapsing the rail or dragging it narrower only to have
+ * the next board undo it is the panel arguing with the user. Kept in sessionStorage, next to the
+ * board the inspector had open, so a reload does not undo it either.
+ */
+function useStickyPanelState<T>(key: string, initial: T) {
+  const [value, setValue] = useState<T>(() => {
+    try {
+      const saved = sessionStorage.getItem(key);
+      return saved === null ? initial : (JSON.parse(saved) as T);
+    } catch {
+      return initial;
+    }
+  });
+  useEffect(() => {
+    try {
+      sessionStorage.setItem(key, JSON.stringify(value));
+    } catch {
+      // No storage to write to: the panel goes back to forgetting between boards.
+    }
+  }, [key, value]);
+  return [value, setValue] as const;
+}
+
+/** How long the Undo beside the badge stays up after a status has been written. */
+const UNDO_MS = 10_000;
+
+/**
+ * The board's status, top-left of the stage, where the badge is also the control that sets it.
+ *
+ * On the stage rather than in the rail so it stays with the board when the rail is collapsed —
+ * and it is the only place a status can be changed: the coloured tab above a board out on the
+ * canvas is a read-only echo of the same value in layout.json.
+ *
+ * `import.meta.env.DEV` is the whole of the read-only rule. Writing means editing layout.json
+ * through the dev server, and a built canvas is static files on a host with no repo behind them,
+ * so there it is a badge and nothing more.
+ */
+function BoardStatus({ path }: { path: string }) {
+  const [status, setStatus] = useState(() => boardStatusForPath(path));
+  const [open, setOpen] = useState(false);
+  const [failed, setFailed] = useState(false);
+  const [undo, setUndo] = useState<{ back: CanvasBoardStatus } | null>(null);
+
+  // Anywhere outside closes it, including the board: the preview is an iframe, so a click that
+  // lands in it never reaches this document, which is why the frame is watched separately.
+  useEffect(() => {
+    if (!open) return;
+    const close = () => setOpen(false);
+    window.addEventListener("pointerdown", close);
+    window.addEventListener("blur", close);
+    return () => {
+      window.removeEventListener("pointerdown", close);
+      window.removeEventListener("blur", close);
+    };
+  }, [open]);
+
+  // The file, edited from anywhere: this control, an agent, or the editor it is open in. The
+  // badge reads it back rather than trusting what it last set, so the two cannot disagree.
+  useEffect(() => {
+    const reread = () => setStatus(boardStatusForPath(path));
+    window.addEventListener(LAYOUT_CHANGED, reread);
+    return () => window.removeEventListener(LAYOUT_CHANGED, reread);
+  }, [path]);
+
+  // The offer expires. A stale Undo next to a badge someone has since stopped looking at is a
+  // trap: it would write a status back over whatever the file says by then.
+  useEffect(() => {
+    if (!undo) return;
+    const timer = setTimeout(() => setUndo(null), UNDO_MS);
+    return () => clearTimeout(timer);
+  }, [undo]);
+
+  const pick = async (next: CanvasBoardStatus) => {
+    setOpen(false);
+    if (next === status) return;
+    const previous = status;
+    // Optimistic, so the badge answers the click at once rather than at the end of a round trip
+    // through the file. The write comes back over HMR and the effect above confirms it — or the
+    // failure notice below says it never landed.
+    setStatus(next);
+    const ok = await writeBoardStatus(path, next);
+    setFailed(!ok);
+    // A status click edits a file in the user's repo, and nothing else on the canvas undoes it —
+    // tldraw's history knows only about shapes. So the way back is offered here, briefly, rather
+    // than left to be typed back into layout.json by hand.
+    setUndo(ok ? { back: previous } : null);
+  };
+
+  const revert = async () => {
+    if (!undo) return;
+    setUndo(null);
+    setStatus(undo.back);
+    setFailed(!(await writeBoardStatus(path, undo.back)));
+  };
+
+  const badge = (
+    <>
+      <i className="sp-status-dot" />
+      {BOARD_STATUS_LABEL[status]}
+    </>
+  );
+
+  if (!import.meta.env.DEV) {
+    return <span className={`sp-status sp-status--${status}`}>{badge}</span>;
+  }
+
+  return (
+    // The menu is dismissed by any pointerdown on the window, so the control has to keep its own
+    // out of that — otherwise opening it closes it in the same gesture.
+    <div className="sp-status-wrap" onPointerDown={(event) => event.stopPropagation()}>
+      <button
+        type="button"
+        className={`sp-status sp-status--${status}`}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        title={`Status: ${BOARD_STATUS_LABEL[status]} — click to change`}
+        onClick={() => setOpen((v) => !v)}
+      >
+        {badge}
+        <svg className="sp-status-chev" width="11" height="11" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.4">
+          <path d="M2.5 4.5L6 8l3.5-3.5" />
+        </svg>
+      </button>
+      {open ? (
+        <div className="sp-menu" role="menu">
+          {BOARD_STATUSES.map((option) => (
+            <button
+              key={option}
+              type="button"
+              role="menuitemradio"
+              aria-checked={option === status}
+              className="sp-menu-row"
+              onClick={() => pick(option)}
+            >
+              <i className={`sp-status-dot sp-status--${option}`} />
+              {BOARD_STATUS_LABEL[option]}
+              {option === status ? (
+                <svg className="sp-menu-ck" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.5">
+                  <path d="M2 6.4l2.6 2.6L10 3.6" />
+                </svg>
+              ) : null}
+            </button>
+          ))}
+          <div className="sp-menu-foot">
+            Writes <code>{`${/canvases\/([^/]+)\//.exec(path)?.[1] ?? ""}/layout.json`}</code>
+          </div>
+        </div>
+      ) : null}
+      {undo ? (
+        <button
+          type="button"
+          className="sp-status-undo"
+          title={`Back to ${BOARD_STATUS_LABEL[undo.back]}`}
+          onClick={revert}
+        >
+          <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M3.2 4.6H7.6a2.6 2.6 0 010 5.2H5.2" />
+            <path d="M5 2.4L3 4.6l2 2.2" />
+          </svg>
+          Undo
+        </button>
+      ) : null}
+      {failed ? <span className="sp-status-err">layout.json not written</span> : null}
+    </div>
+  );
+}
 
 /**
  * The docked inspector: a large preview of the clicked board on the left, a resizable and
@@ -132,12 +316,20 @@ export function InspectorPanel({
   const [bindings, setBindings] = useState<SpBindings | null>(null);
   const [tab, setTab] = useState<Tab>("inspect");
   const [focusToken, setFocusToken] = useState<string | null>(null);
-  const [panelW, setPanelW] = useState(PANEL_W);
-  const [railW, setRailW] = useState(RAIL_W);
-  const [layersH, setLayersH] = useState(() => initialLayersH(window.innerHeight));
+  const [panelW, setPanelW] = useStickyPanelState("sp:panel-w", PANEL_W);
+  const [railW, setRailW] = useStickyPanelState("sp:rail-w", RAIL_W);
+  const [layersH, setLayersH] = useStickyPanelState(
+    "sp:layers-h",
+    initialLayersH(window.innerHeight),
+  );
   const [win, setWin] = useState(() => ({ w: window.innerWidth, h: window.innerHeight }));
-  const [railOpen, setRailOpen] = useState(true);
+  const [railOpen, setRailOpen] = useStickyPanelState("sp:rail-open", true);
   const stage = useRef<HTMLDivElement>(null);
+  // The comments on this board are the canvas's own, reached through the chrome context
+  // because the panel renders beside `<Tldraw>` rather than under it.
+  const editor = useContext(CanvasChromeContext).editor;
+  const shapeId = useMemo(() => createShapeId(`canvas-file:${path}`), [path]);
+  const [openThread, setOpenThread] = useState<TLCommentThreadId | null>(null);
 
   useEffect(() => {
     const onResize = () => setWin({ w: window.innerWidth, h: window.innerHeight });
@@ -261,48 +453,69 @@ export function InspectorPanel({
         onPointerDown={divider("x", setPanel.from, setPanel.apply)}
         onKeyDown={dividerKeys("x", setPanel.from, setPanel.apply)}
       />
-      <div className="sp-stage" ref={stage}>
-        <div
-          className="sp-board"
-          style={{ width: size.w, height: size.h, transform: `scale(${scale})` }}
-        >
+      <div className="sp-preview">
+        <div className="sp-stage" ref={stage}>
+          <div
+            className="sp-board"
+            style={{ width: size.w, height: size.h, transform: `scale(${scale})` }}
+          >
+            {/*
+              Mounted only once the HTML is here, and keyed by path so a different board is a
+              different element. A board arrives asynchronously, so rendering the frame eagerly
+              gives it `srcdoc=""` and then mutates the attribute a tick later — and Chrome drops
+              that second navigation while the first is still pending, leaving a frame that is
+              permanently blank. Creating the element with its final srcdoc avoids the mutation.
+            */}
+            {srcDoc ? (
+              <iframe
+                key={path}
+                ref={frame}
+                title={name}
+                srcDoc={srcDoc}
+                sandbox="allow-scripts"
+                onLoad={() => frame.current?.contentWindow?.postMessage({ type: "sp:hello" }, "*")}
+                style={{ width: size.w, height: size.h, border: 0, display: "block" }}
+              />
+            ) : null}
+            {editor ? (
+              <BoardPins
+                editor={editor}
+                shapeId={shapeId}
+                scale={scale}
+                open={openThread}
+                onOpen={setOpenThread}
+              />
+            ) : null}
+          </div>
+          <BoardStatus path={path} />
+          <span className="sp-zoom">{Math.round(scale * 100)}%</span>
           {/*
-            Mounted only once the HTML is here, and keyed by path so a different board is a
-            different element. A board arrives asynchronously, so rendering the frame eagerly
-            gives it `srcdoc=""` and then mutates the attribute a tick later — and Chrome drops
-            that second navigation while the first is still pending, leaving a frame that is
-            permanently blank. Creating the element with its final srcdoc avoids the mutation.
+            Lives on the stage, not in the rail, so that collapsing the rail does not also hide the
+            only way back — Escape does not help here, because clicking the preview moves focus into
+            the frame and the agent forwards no keys.
           */}
-          {srcDoc ? (
-            <iframe
-              key={path}
-              ref={frame}
-              title={name}
-              srcDoc={srcDoc}
-              sandbox="allow-scripts"
-              onLoad={() => frame.current?.contentWindow?.postMessage({ type: "sp:hello" }, "*")}
-              style={{ width: size.w, height: size.h, border: 0, display: "block" }}
-            />
-          ) : null}
+          <button
+            type="button"
+            className="sp-collapse"
+            aria-expanded={railOpen}
+            title={railOpen ? "Hide details" : "Show details"}
+            aria-label={railOpen ? "Hide details" : "Show details"}
+            onClick={() => setRailOpen((v) => !v)}
+          >
+            <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.2">
+              <path d={railOpen ? "M7.5 2l4 4-4 4M4.5 2l-4 4 4 4" : "M2 2l4 4-4 4M7.5 2l4 4-4 4"} />
+            </svg>
+          </button>
         </div>
-        <span className="sp-zoom">{Math.round(scale * 100)}%</span>
-        {/*
-          Lives on the stage, not in the rail, so that collapsing the rail does not also hide the
-          only way back — Escape does not help here, because clicking the preview moves focus into
-          the frame and the agent forwards no keys.
-        */}
-        <button
-          type="button"
-          className="sp-collapse"
-          aria-expanded={railOpen}
-          title={railOpen ? "Hide details" : "Show details"}
-          aria-label={railOpen ? "Hide details" : "Show details"}
-          onClick={() => setRailOpen((v) => !v)}
-        >
-          <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.2">
-            <path d={railOpen ? "M7.5 2l4 4-4 4M4.5 2l-4 4 4 4" : "M2 2l4 4-4 4M7.5 2l4 4-4 4"} />
-          </svg>
-        </button>
+        {editor ? (
+          <BoardComments
+            editor={editor}
+            shapeId={shapeId}
+            open={openThread}
+            onOpen={setOpenThread}
+            pinAt={newBoardPin(node?.box, size)}
+          />
+        ) : null}
       </div>
 
       {railOpen ? (

--- a/canvas/src/InspectorPanel.tsx
+++ b/canvas/src/InspectorPanel.tsx
@@ -35,6 +35,7 @@ import {
   formatBytes,
   initialLayersH,
   isColorValue,
+  cx,
   layersBounds,
   layerKind,
   layerName,
@@ -53,10 +54,10 @@ import {
  * Panel state that outlives the board it was set on.
  *
  * The panel is keyed by path, so clicking a different board mounts a fresh one. That is right for
- * the selection and the report, which are about the board — and wrong for how the panel is
- * arranged, which is about the person: collapsing the rail or dragging it narrower only to have
- * the next board undo it is the panel arguing with the user. Kept in sessionStorage, next to the
- * board the inspector had open, so a reload does not undo it either.
+ * the selection and the report, which are about the board, and wrong for how the panel is
+ * arranged, which is about the person: a rail collapsed or dragged narrower should stay that way
+ * for the next board. Kept in sessionStorage, next to the board the inspector had open, so a
+ * reload does not undo it either.
  */
 function useStickyPanelState<T>(key: string, initial: T) {
   const [value, setValue] = useState<T>(() => {
@@ -83,7 +84,7 @@ const UNDO_MS = 10_000;
 /**
  * The board's status, top-left of the stage, where the badge is also the control that sets it.
  *
- * On the stage rather than in the rail so it stays with the board when the rail is collapsed —
+ * On the stage rather than in the rail so it stays with the board when the rail is collapsed,
  * and it is the only place a status can be changed: the coloured tab above a board out on the
  * canvas is a read-only echo of the same value in layout.json.
  *
@@ -98,7 +99,8 @@ function BoardStatus({ path }: { path: string }) {
   const [undo, setUndo] = useState<{ back: CanvasBoardStatus } | null>(null);
 
   // Anywhere outside closes it, including the board: the preview is an iframe, so a click that
-  // lands in it never reaches this document, which is why the frame is watched separately.
+  // lands in it never reaches this document as a pointerdown, but it does take the window's
+  // focus, which is what `blur` catches.
   useEffect(() => {
     if (!open) return;
     const close = () => setOpen(false);
@@ -131,14 +133,14 @@ function BoardStatus({ path }: { path: string }) {
     if (next === status) return;
     const previous = status;
     // Optimistic, so the badge answers the click at once rather than at the end of a round trip
-    // through the file. The write comes back over HMR and the effect above confirms it — or the
+    // through the file. The write comes back over HMR and the effect above confirms it, or the
     // failure notice below says it never landed.
     setStatus(next);
     const ok = await writeBoardStatus(path, next);
     setFailed(!ok);
-    // A status click edits a file in the user's repo, and nothing else on the canvas undoes it —
-    // tldraw's history knows only about shapes. So the way back is offered here, briefly, rather
-    // than left to be typed back into layout.json by hand.
+    // A status click edits a file in the user's repo, and nothing else on the canvas undoes it,
+    // because tldraw's history knows only about shapes. So the way back is offered here, briefly,
+    // rather than left to be typed back into layout.json by hand.
     setUndo(ok ? { back: previous } : null);
   };
 
@@ -162,14 +164,14 @@ function BoardStatus({ path }: { path: string }) {
 
   return (
     // The menu is dismissed by any pointerdown on the window, so the control has to keep its own
-    // out of that — otherwise opening it closes it in the same gesture.
+    // out of that. Otherwise opening it closes it in the same gesture.
     <div className="sp-status-wrap" onPointerDown={(event) => event.stopPropagation()}>
       <button
         type="button"
         className={`sp-status sp-status--${status}`}
         aria-haspopup="menu"
         aria-expanded={open}
-        title={`Status: ${BOARD_STATUS_LABEL[status]} — click to change`}
+        title={`Status: ${BOARD_STATUS_LABEL[status]}. Click to change`}
         onClick={() => setOpen((v) => !v)}
       >
         {badge}
@@ -286,8 +288,6 @@ function dividerKeys(
 type Tab = "inspect" | "assets" | "tokens";
 
 const fmt = (n: number) => String(Math.round(n * 100) / 100);
-const cx = (...parts: (string | false | null | undefined)[]) => parts.filter(Boolean).join(" ");
-
 /** Wiring component: lives inside <Tldraw> so it can reach the editor. */
 export function InspectorClicks({ onPick }: { onPick: (shape: CanvasFileShape) => void }) {
   const editor = useEditor();
@@ -646,7 +646,7 @@ export function InspectorPanel({
   );
 }
 
-/** The vector asset, to the clipboard: the markup as it stands alone, for Figma or another gen.py. */
+/** The vector asset, to the clipboard: the standalone markup, for Figma or another gen.py. */
 function CopySvg({ svg }: { svg: string }) {
   const [copied, setCopied] = useState(false);
   useEffect(() => {

--- a/canvas/src/boardStatusEdit.test.ts
+++ b/canvas/src/boardStatusEdit.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from 'vitest'
+import { canvasSlug, withBoardStatus, withCanvasName } from './boardStatusEdit'
+
+/** A layout shaped like the ones in the wild: bare names, objects, and a folder default. */
+const LAYOUT = `{
+  "cover": "home",
+  "status": "exploring",
+  "rows": [
+    { "title": "Legend", "files": ["status-legend"] },
+    {
+      "title": "Main Tabs",
+      "files": ["home", "collection", "timeline"]
+    },
+    {
+      "title": "Capture",
+      "files": [
+        { "file": "capture-compose-done", "label": "Compose Done", "status": "outdated" },
+        { "file": "timeline-fab-radial-menu", "label": "Timeline FAB Radial Menu" }
+      ]
+    }
+  ]
+}
+`
+
+/** The common shape: no folder default, so an unmarked board is live. */
+const PLAIN = `{
+  "rows": [
+    { "title": "Main Tabs", "files": ["home", "collection"] }
+  ]
+}
+`
+
+/** The one changed line, so a test says what moved instead of comparing two walls of JSON. */
+const diff = (before: string, after: string) =>
+  after.split('\n').filter((line, i) => line !== before.split('\n')[i])
+
+describe('withBoardStatus', () => {
+  it('replaces the status an object entry already carries, and nothing else on the line', () => {
+    const after = withBoardStatus(LAYOUT, 'capture-compose-done', 'live')!
+    expect(diff(LAYOUT, after)).toEqual([
+      '        { "file": "capture-compose-done", "label": "Compose Done", "status": "live" },',
+    ])
+  })
+
+  it('adds a status to an object entry that has none, keeping its other keys in order', () => {
+    const after = withBoardStatus(LAYOUT, 'timeline-fab-radial-menu', 'outdated')!
+    expect(diff(LAYOUT, after)).toEqual([
+      '        { "file": "timeline-fab-radial-menu", "label": "Timeline FAB Radial Menu", "status": "outdated" }',
+    ])
+  })
+
+  it('grows a bare name into an object, in place', () => {
+    const after = withBoardStatus(LAYOUT, 'collection', 'outdated')!
+    expect(diff(LAYOUT, after)).toEqual([
+      '      "files": ["home", { "file": "collection", "status": "outdated" }, "timeline"]',
+    ])
+  })
+
+  it('leaves a bare name alone when it already means what is being asked for', () => {
+    // The folder is `exploring`, so a bare entry is exploring: expanding it would add an
+    // object that says what the line above it already said.
+    expect(withBoardStatus(LAYOUT, 'home', 'exploring')).toBe(LAYOUT)
+  })
+
+  it('drops the override when a board is set back to what the folder says', () => {
+    const after = withBoardStatus(LAYOUT, 'capture-compose-done', 'exploring')!
+    expect(diff(LAYOUT, after)).toEqual([
+      '        { "file": "capture-compose-done", "label": "Compose Done" },',
+    ])
+  })
+
+  it('shrinks an entry back to a bare name when the status was all it carried', () => {
+    const marked = withBoardStatus(LAYOUT, 'collection', 'outdated')!
+    expect(withBoardStatus(marked, 'collection', 'exploring')).toBe(LAYOUT)
+  })
+
+  it('round-trips a live-by-default board back to the bare name it started as', () => {
+    const marked = withBoardStatus(PLAIN, 'home', 'outdated')!
+    expect(marked).toContain('{ "file": "home", "status": "outdated" }')
+    expect(withBoardStatus(marked, 'home', 'live')).toBe(PLAIN)
+  })
+
+  it('does not mistake the `cover` for a row entry', () => {
+    const after = withBoardStatus(LAYOUT, 'home', 'outdated')!
+    expect(after).toContain('"cover": "home"')
+    expect(diff(LAYOUT, after)).toEqual([
+      '      "files": [{ "file": "home", "status": "outdated" }, "collection", "timeline"]',
+    ])
+  })
+
+  it('returns null for a board the layout never lists', () => {
+    expect(withBoardStatus(LAYOUT, 'not-in-here', 'live')).toBeNull()
+  })
+
+  it('rewrites one line of a real layout and leaves every other byte alone', () => {
+    const after = withBoardStatus(LAYOUT, 'capture-compose-done', 'exploring')!
+    expect(after.split('\n')).toHaveLength(LAYOUT.split('\n').length)
+    expect(diff(LAYOUT, after)).toHaveLength(1)
+  })
+})
+
+describe('canvasSlug', () => {
+  it('keeps a name that is already a folder name', () => {
+    expect(canvasSlug('v1.16')).toBe('v1.16')
+  })
+
+  it('folds spaces and case into a slug', () => {
+    expect(canvasSlug('  Home Redesign v2 ')).toBe('home-redesign-v2')
+  })
+
+  it('has nothing to make of a name with no ASCII in it', () => {
+    expect(canvasSlug('新画布')).toBe('')
+  })
+
+  it('never slugs to a path', () => {
+    expect(canvasSlug('..')).toBe('')
+    expect(canvasSlug('../evil')).toBe('evil')
+  })
+})
+
+/** The added line taken back out, so a test can say the rest of the file never moved. */
+const without = (source: string, line: string) =>
+  source
+    .split('\n')
+    .filter((l) => l !== line)
+    .join('\n')
+
+describe('withCanvasName', () => {
+  it('replaces the name a layout already carries', () => {
+    const before = `{\n  "name": "v1.16",\n  "cover": "home"\n}\n`
+    expect(withCanvasName(before, 'v1.17')).toBe(
+      `{\n  "name": "v1.17",\n  "cover": "home"\n}\n`,
+    )
+  })
+
+  it('adds one to a layout that never named itself', () => {
+    const after = withCanvasName(PLAIN, 'Main Tabs')
+    expect(JSON.parse(after)).toEqual({ ...JSON.parse(PLAIN), name: 'Main Tabs' })
+    expect(without(after, '  "name": "Main Tabs",')).toBe(PLAIN)
+  })
+
+  it('does not mistake a row label for the page name', () => {
+    const before = `{\n  "rows": [\n    { "title": "T", "files": [{ "file": "a", "name": "no" }] }\n  ]\n}\n`
+    const after = withCanvasName(before, 'Page')
+    expect(after).toContain('"name": "no"')
+    expect(JSON.parse(after).name).toBe('Page')
+  })
+
+  it('leaves a hand-formatted layout otherwise byte-identical', () => {
+    const after = withCanvasName(LAYOUT, 'Cloned')
+    expect(JSON.parse(after)).toEqual({ ...JSON.parse(LAYOUT), name: 'Cloned' })
+    expect(without(after, '  "name": "Cloned",')).toBe(LAYOUT)
+  })
+})

--- a/canvas/src/boardStatusEdit.test.ts
+++ b/canvas/src/boardStatusEdit.test.ts
@@ -146,6 +146,11 @@ describe('withCanvasName', () => {
     expect(JSON.parse(after).name).toBe('Page')
   })
 
+  it('writes a name that looks like a replacement pattern as itself', () => {
+    const after = withCanvasName(PLAIN, 'A $& B')
+    expect(JSON.parse(after).name).toBe('A $& B')
+  })
+
   it('leaves a hand-formatted layout otherwise byte-identical', () => {
     const after = withCanvasName(LAYOUT, 'Cloned')
     expect(JSON.parse(after)).toEqual({ ...JSON.parse(LAYOUT), name: 'Cloned' })

--- a/canvas/src/boardStatusEdit.ts
+++ b/canvas/src/boardStatusEdit.ts
@@ -1,7 +1,7 @@
 /**
  * The writes the canvas makes back into a project: a board's `status`, set from the badge on the
  * inspector's stage, and a cloned folder's name. They live here rather than in vite.config.ts so
- * they can be tested as what they are — pure string edits — without standing a dev server up
+ * they can be tested as what they are, pure string edits, without standing a dev server up
  * around them.
  */
 
@@ -11,24 +11,23 @@ export const SAFE_NAME = /^[\w.-]+$/;
 /** The vocabulary the endpoint accepts, mirroring `CanvasBoardStatus`. */
 export const BOARD_STATUSES = ["exploring", "outdated", "live"];
 
-
 /**
  * layout.json with one board's `status` set, edited as text.
  *
- * As text, and never through JSON.parse + JSON.stringify: these files are hand-formatted — one
- * board per line, rows ordered to read like a walkthrough — and a round-trip through the parser
+ * As text, and never through JSON.parse + JSON.stringify: these files are hand-formatted, one
+ * board per line and rows ordered to read like a walkthrough, and a round-trip through the parser
  * would reformat every line of a file that belongs to whoever installed the plugin.
  *
  * A board appears in a row's `files` either as a bare `"name"`, which has to grow into an object
  * to carry anything, or as an object already holding `"file": "name"`. Entries never nest, so
  * `[^{}]*` is enough to find the one that names this board. Returns null when the layout does
- * not mention the board at all — one discovered on disk that no row ever listed.
+ * not mention the board at all, one discovered on disk that no row ever listed.
  */
 export function withBoardStatus(source: string, file: string, status: string) {
   const name = file.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   const STATUS = /"status"\s*:\s*"[^"]*"/;
-  // What a board that says nothing already is. Setting one to this writes no `status` at all —
-  // the shorthand the folder is written in, and what undoing a change has to get back to.
+  // What a board that says nothing already is. Setting one to this writes no `status` at all,
+  // which is the shorthand the folder is written in, and what undoing a change has to get back to.
   let folderDefault = "live";
   try {
     folderDefault = JSON.parse(source).status ?? "live";
@@ -61,7 +60,7 @@ export function withBoardStatus(source: string, file: string, status: string) {
   }
 
   // A bare string entry. It only ever appears inside an array, so it is preceded by `[` or `,`
-  // and followed by `,` or `]` — which is what keeps this off `"cover": "name"` and off a
+  // and followed by `,` or `]`, which is what keeps this off `"cover": "name"` and off a
   // `"label"` that happens to read the same.
   const bare = new RegExp(`([[,]\\s*)"${name}"(\\s*[,\\]])`);
   const found = bare.exec(source);
@@ -75,7 +74,6 @@ export function withBoardStatus(source: string, file: string, status: string) {
     source.slice(found.index + found[0].length)
   );
 }
-
 
 /**
  * The folder name a typed canvas name becomes. ASCII only: a slug is also the `?canvas=`
@@ -117,8 +115,13 @@ export function withCanvasName(source: string, name: string) {
       while (++i < source.length && source[i] !== '"') if (source[i] === "\\") i++;
     }
   }
-  // A layout that named nothing — the page was going by its humanized slug. Write the key at the
-  // front, where a layout that has one puts it.
+  // A layout that named nothing, so the page was going by its humanized slug. Write the key at
+  // the front, where a layout that has one puts it.
   const empty = /^\s*\{\s*\}\s*$/.test(source);
-  return source.replace("{", empty ? `{\n  "name": ${value}\n` : `{\n  "name": ${value},`);
+  const at = source.indexOf("{");
+  if (at < 0) return source;
+  // Spliced rather than `replace`: a replacement string reads `$&` and friends as patterns, and
+  // a canvas can be named anything.
+  const key = empty ? `\n  "name": ${value}\n` : `\n  "name": ${value},`;
+  return source.slice(0, at + 1) + key + source.slice(at + 1);
 }

--- a/canvas/src/boardStatusEdit.ts
+++ b/canvas/src/boardStatusEdit.ts
@@ -1,0 +1,124 @@
+/**
+ * The writes the canvas makes back into a project: a board's `status`, set from the badge on the
+ * inspector's stage, and a cloned folder's name. They live here rather than in vite.config.ts so
+ * they can be tested as what they are — pure string edits — without standing a dev server up
+ * around them.
+ */
+
+/** A slug or file name that is safe to join into a path: no separators, no dots of its own. */
+export const SAFE_NAME = /^[\w.-]+$/;
+
+/** The vocabulary the endpoint accepts, mirroring `CanvasBoardStatus`. */
+export const BOARD_STATUSES = ["exploring", "outdated", "live"];
+
+
+/**
+ * layout.json with one board's `status` set, edited as text.
+ *
+ * As text, and never through JSON.parse + JSON.stringify: these files are hand-formatted — one
+ * board per line, rows ordered to read like a walkthrough — and a round-trip through the parser
+ * would reformat every line of a file that belongs to whoever installed the plugin.
+ *
+ * A board appears in a row's `files` either as a bare `"name"`, which has to grow into an object
+ * to carry anything, or as an object already holding `"file": "name"`. Entries never nest, so
+ * `[^{}]*` is enough to find the one that names this board. Returns null when the layout does
+ * not mention the board at all — one discovered on disk that no row ever listed.
+ */
+export function withBoardStatus(source: string, file: string, status: string) {
+  const name = file.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const STATUS = /"status"\s*:\s*"[^"]*"/;
+  // What a board that says nothing already is. Setting one to this writes no `status` at all —
+  // the shorthand the folder is written in, and what undoing a change has to get back to.
+  let folderDefault = "live";
+  try {
+    folderDefault = JSON.parse(source).status ?? "live";
+  } catch {
+    // Unparseable layout: fall through and write the override anyway.
+  }
+
+  const object = new RegExp(`\\{[^{}]*"file"\\s*:\\s*"${name}"[^{}]*\\}`);
+  const match = object.exec(source);
+  if (match) {
+    const entry = match[0];
+    const splice = (replacement: string) =>
+      source.slice(0, match.index) + replacement + source.slice(match.index + entry.length);
+    if (status === folderDefault) {
+      if (!STATUS.test(entry)) return source;
+      // Back to what the folder says: take the override out rather than spell out what the line
+      // above already said. An entry left holding nothing but its `file` goes back to being the
+      // bare name it was before anyone clicked.
+      const without = entry
+        .replace(/\s*,\s*"status"\s*:\s*"[^"]*"/, "")
+        .replace(/"status"\s*:\s*"[^"]*"\s*,\s*/, "");
+      const bare = new RegExp(`^\\{\\s*"file"\\s*:\\s*"${name}"\\s*\\}$`);
+      return splice(bare.test(without) ? `"${file}"` : without);
+    }
+    return splice(
+      STATUS.test(entry)
+        ? entry.replace(STATUS, `"status": "${status}"`)
+        : entry.replace(/\s*\}$/, `, "status": "${status}" }`),
+    );
+  }
+
+  // A bare string entry. It only ever appears inside an array, so it is preceded by `[` or `,`
+  // and followed by `,` or `]` — which is what keeps this off `"cover": "name"` and off a
+  // `"label"` that happens to read the same.
+  const bare = new RegExp(`([[,]\\s*)"${name}"(\\s*[,\\]])`);
+  const found = bare.exec(source);
+  if (!found) return null;
+  // Already what it is being set to: leave the shorthand alone rather than expanding it into an
+  // object that says what the folder already said.
+  if (status === folderDefault) return source;
+  return (
+    source.slice(0, found.index) +
+    `${found[1]}{ "file": "${file}", "status": "${status}" }${found[2]}` +
+    source.slice(found.index + found[0].length)
+  );
+}
+
+
+/**
+ * The folder name a typed canvas name becomes. ASCII only: a slug is also the `?canvas=`
+ * parameter and the name SAFE_NAME guards, so a name with nothing ASCII in it slugs to the empty
+ * string and the caller has to ask for another. Leading and trailing dots go with it, which is
+ * what keeps a name of ".." from becoming a path.
+ */
+export const canvasSlug = (name: string) =>
+  name
+    .trim()
+    .toLowerCase()
+    .replace(/[^\w.-]+/g, "-")
+    .replace(/^[-.]+|[-.]+$/g, "");
+
+/**
+ * layout.json with the page's `name` set, edited as text for the same reason withBoardStatus is:
+ * a clone starts as a copy of a hand-formatted file, and only the key that names it should read
+ * differently afterwards.
+ *
+ * The scan is for the `name` sitting directly inside the outermost object, not for the first one
+ * the file happens to contain: rows carry `title`, `label` and `url` strings of their own, and a
+ * blind replace could land in one of those instead.
+ */
+export function withCanvasName(source: string, name: string) {
+  const value = JSON.stringify(name);
+  const KEY = /^"name"\s*:\s*"(?:[^"\\]|\\.)*"/;
+  for (let i = 0, depth = 0; i < source.length; i++) {
+    const char = source[i];
+    if (char === "{" || char === "[") depth++;
+    else if (char === "}" || char === "]") depth--;
+    else if (char === '"') {
+      const match = depth === 1 ? KEY.exec(source.slice(i)) : null;
+      if (match) {
+        return (
+          source.slice(0, i) + `"name": ${value}` + source.slice(i + match[0].length)
+        );
+      }
+      // Past the string, so its contents are never mistaken for structure or for the key.
+      while (++i < source.length && source[i] !== '"') if (source[i] === "\\") i++;
+    }
+  }
+  // A layout that named nothing — the page was going by its humanized slug. Write the key at the
+  // front, where a layout that has one puts it.
+  const empty = /^\s*\{\s*\}\s*$/.test(source);
+  return source.replace("{", empty ? `{\n  "name": ${value}\n` : `{\n  "name": ${value},`);
+}

--- a/canvas/src/canvasChrome.tsx
+++ b/canvas/src/canvasChrome.tsx
@@ -13,7 +13,7 @@ import {
   useEditor,
   useValue,
 } from "tldraw";
-import { CanvasComments, CommentTool } from "@tldraw/commenting";
+import { CanvasComments, CommentTool, commentToolOverrides } from "@tldraw/commenting";
 import { CloneCanvasDialog } from "./CloneCanvasDialog";
 import { CommentUserDialog } from "./CommentUserDialog";
 import { linkedBoard, readCommentUser, resolveAuthor, type CommentUser } from "./canvasComments";
@@ -55,8 +55,12 @@ export const CanvasChromeContext = createContext({
  * mockup it is about. Every comment placed on a board — or in the margin beside one — is anchored
  * to that board's shape, which is what makes the note ride the mockup when a layout.json edit
  * moves it. The header shows that link, and follows it: clicking opens the board in the inspector.
+ *
+ * Only where there is a dev server to post to, which is what a plugin install runs: a comment
+ * reaches the repo through it, and a built canvas is static files on a host with no repo behind
+ * them. There the committed threads are read and drawn, and that is all.
  */
-export const canvasCommentTools = [
+export const canvasCommentTools = import.meta.env.DEV ? [
   CommentTool.configure({
     components: {
       ThreadActions: ({ thread }) => {
@@ -80,7 +84,10 @@ export const canvasCommentTools = [
       },
     },
   }),
-];
+] : [];
+
+/** The toolbar entry for that tool, so it is not offered where the tool is not registered. */
+export const canvasCommentOverrides = import.meta.env.DEV ? commentToolOverrides : {};
 
 export const canvasChromeComponents: TLComponents = {
   /**
@@ -154,7 +161,7 @@ export const canvasChromeComponents: TLComponents = {
         <DefaultActionsMenu {...props} />
         {/* Nothing to copy on the welcome page, which the app draws and no folder backs, or on
             a page someone added by hand. */}
-        {slug && slug !== WELCOME_PAGE_SLUG && (
+        {import.meta.env.DEV && slug && slug !== WELCOME_PAGE_SLUG && (
           <TldrawUiButton
             type="icon"
             title="Clone this canvas into a new one"
@@ -176,29 +183,31 @@ export const canvasChromeComponents: TLComponents = {
         </TldrawUiButton>
         {/* The only account there is: the GitHub handle posted comments are signed with, wearing
             that account's avatar once there is one. Sits here rather than behind the comment tool
-            so it can be corrected after the fact. */}
-        <TldrawUiButton
-          type="icon"
-          title={
-            chrome.commentUser
-              ? `Commenting as ${chrome.commentUser.name} — click to change`
-              : "Set the GitHub handle your comments are signed with"
-          }
-          onClick={() =>
-            addDialog({
-              id: COMMENT_USER_DIALOG,
-              component: (dialog) => (
-                <CommentUserDialog {...dialog} onSave={chrome.setCommentUser} />
-              ),
-            })
-          }
-        >
-          {chrome.commentUser ? (
-            <img className="canvas-me" src={chrome.commentUser.image} alt="" />
-          ) : (
-            <TldrawUiButtonIcon icon="comment" />
-          )}
-        </TldrawUiButton>
+            so it can be corrected after the fact — where there is anything to sign, that is. */}
+        {import.meta.env.DEV && (
+          <TldrawUiButton
+            type="icon"
+            title={
+              chrome.commentUser
+                ? `Commenting as ${chrome.commentUser.name} — click to change`
+                : "Set the GitHub handle your comments are signed with"
+            }
+            onClick={() =>
+              addDialog({
+                id: COMMENT_USER_DIALOG,
+                component: (dialog) => (
+                  <CommentUserDialog {...dialog} onSave={chrome.setCommentUser} />
+                ),
+              })
+            }
+          >
+            {chrome.commentUser ? (
+              <img className="canvas-me" src={chrome.commentUser.image} alt="" />
+            ) : (
+              <TldrawUiButtonIcon icon="comment" />
+            )}
+          </TldrawUiButton>
+        )}
       </>
     );
   },
@@ -260,7 +269,9 @@ export const canvasChromeComponents: TLComponents = {
 
     return (
       <CanvasComments
-        currentUserId={chrome.commentUser?.id ?? null}
+        // No identity, no composer, no reply, no edit: the toolkit's own read-only mode, and what
+        // a built canvas gets, where none of those could be saved anyway.
+        currentUserId={import.meta.env.DEV ? (chrome.commentUser?.id ?? null) : null}
         resolveAuthor={resolveAuthor}
       />
     );

--- a/canvas/src/canvasChrome.tsx
+++ b/canvas/src/canvasChrome.tsx
@@ -294,7 +294,7 @@ export const canvasChromeComponents: TLComponents = {
           createPortal(
             <TldrawUiButton
               type="icon"
-              title="Close (Esc)"
+              title="Close"
               className="canvas-composer-close"
               onClick={() => editor.setCurrentTool("select")}
             >

--- a/canvas/src/canvasChrome.tsx
+++ b/canvas/src/canvasChrome.tsx
@@ -1,22 +1,32 @@
-import { createContext, useContext, useEffect } from "react";
+import { createContext, useContext, useEffect, useState } from "react";
+import { createPortal } from "react-dom";
 import {
   DefaultActionsMenu,
-  DefaultStylePanel,
-  DefaultToolbar,
-  DefaultToolbarContent,
+  DefaultContextMenu,
+  DefaultContextMenuContent,
   TldrawUiButton,
   TldrawUiButtonIcon,
+  TldrawUiIcon,
   type Editor,
   type TLComponents,
   type TLUiAssetUrlOverrides,
+  TldrawUiMenuGroup,
+  TldrawUiMenuItem,
   useDialogs,
   useEditor,
+  useEditorPortalHost,
   useValue,
 } from "tldraw";
 import { CanvasComments, CommentTool, commentToolOverrides } from "@tldraw/commenting";
 import { CloneCanvasDialog } from "./CloneCanvasDialog";
 import { CommentUserDialog } from "./CommentUserDialog";
-import { linkedBoard, readCommentUser, resolveAuthor, type CommentUser } from "./canvasComments";
+import {
+  GITHUB_PATH,
+  linkedBoard,
+  readCommentUser,
+  resolveAuthor,
+  type CommentUser,
+} from "./canvasComments";
 import type { CanvasFileShape } from "./CanvasFileShapeUtil";
 import { WELCOME_PAGE_SLUG } from "./canvasUrl";
 
@@ -24,7 +34,7 @@ const REPO_URL = "https://github.com/ReScienceLab/super-prototyping";
 /** The app the snapaction-ios boards are cloned from: its own site, not the App Store listing. */
 const SNAPACTION_URL = "https://snapaction.ai/";
 
-/** One dialog, whether it was opened by the button or by picking the tool without a name. */
+/** One dialog, whether the comment tool raised it or the inspector's composer did. */
 const COMMENT_USER_DIALOG = "comment-user";
 
 /**
@@ -34,12 +44,7 @@ const COMMENT_USER_DIALOG = "comment-user";
  */
 export const ASK_COMMENT_USER = "sp:ask-comment-user";
 
-const GITHUB_PATH =
-  "M12 0c6.63 0 12 5.276 12 11.79-.001 5.067-3.29 9.567-8.175 11.187-.6.118-.825-.25-.825-.56 0-.398.015-1.665.015-3.242 0-1.105-.375-1.813-.81-2.181 2.67-.295 5.475-1.297 5.475-5.822 0-1.297-.465-2.344-1.23-3.169.12-.295.54-1.503-.12-3.125 0 0-1.005-.324-3.3 1.209a11.32 11.32 0 00-3-.398c-1.02 0-2.04.133-3 .398-2.295-1.518-3.3-1.209-3.3-1.209-.66 1.622-.24 2.83-.12 3.125-.765.825-1.23 1.887-1.23 3.169 0 4.51 2.79 5.527 5.46 5.822-.345.294-.66.81-.765 1.577-.69.31-2.415.81-3.495-.973-.225-.354-.9-1.223-1.845-1.209-1.005.015-.405.56.015.781.51.28 1.095 1.327 1.23 1.666.24.663 1.02 1.93 4.035 1.385 0 .988.015 1.916.015 2.196 0 .31-.225.664-.825.56C3.303 21.374-.003 16.867 0 11.791 0 5.276 5.37 0 12 0z";
-
 export const CanvasChromeContext = createContext({
-  stylesVisible: false,
-  toggleStyles: () => {},
   relayoutLibrary: () => {},
   /** The mounted editor, for the parts of the app that render outside `<Tldraw>`. */
   editor: null as Editor | null,
@@ -56,11 +61,11 @@ export const CanvasChromeContext = createContext({
  * to that board's shape, which is what makes the note ride the mockup when a layout.json edit
  * moves it. The header shows that link, and follows it: clicking opens the board in the inspector.
  *
- * Only where there is a dev server to post to, which is what a plugin install runs: a comment
- * reaches the repo through it, and a built canvas is static files on a host with no repo behind
- * them. There the committed threads are read and drawn, and that is all.
+ * Everywhere, built canvas included. Where the comment goes differs — a dev server writes it into
+ * the board's folder, a hosted canvas keeps it in the browser (canvasComments.ts) — but the tool
+ * and the thread are the same, so someone trying the hosted canvas sees what commenting is like.
  */
-export const canvasCommentTools = import.meta.env.DEV ? [
+export const canvasCommentTools = [
   CommentTool.configure({
     components: {
       ThreadActions: ({ thread }) => {
@@ -84,10 +89,10 @@ export const canvasCommentTools = import.meta.env.DEV ? [
       },
     },
   }),
-] : [];
+];
 
-/** The toolbar entry for that tool, so it is not offered where the tool is not registered. */
-export const canvasCommentOverrides = import.meta.env.DEV ? commentToolOverrides : {};
+/** The toolbar entry for that tool. */
+export const canvasCommentOverrides = commentToolOverrides;
 
 export const canvasChromeComponents: TLComponents = {
   /**
@@ -181,54 +186,45 @@ export const canvasChromeComponents: TLComponents = {
         >
           <TldrawUiButtonIcon icon="refresh-icon" />
         </TldrawUiButton>
-        {/* The only account there is: the GitHub handle posted comments are signed with, wearing
-            that account's avatar once there is one. Sits here rather than behind the comment tool
-            so it can be corrected after the fact — where there is anything to sign, that is. */}
-        {import.meta.env.DEV && (
-          <TldrawUiButton
-            type="icon"
-            title={
-              chrome.commentUser
-                ? `Commenting as ${chrome.commentUser.name} — click to change`
-                : "Set the GitHub handle your comments are signed with"
-            }
-            onClick={() =>
-              addDialog({
-                id: COMMENT_USER_DIALOG,
-                component: (dialog) => (
-                  <CommentUserDialog {...dialog} onSave={chrome.setCommentUser} />
-                ),
-              })
-            }
-          >
-            {chrome.commentUser ? (
-              <img className="canvas-me" src={chrome.commentUser.image} alt="" />
-            ) : (
-              <TldrawUiButtonIcon icon="comment" />
-            )}
-          </TldrawUiButton>
-        )}
       </>
     );
   },
-  Toolbar: (props) => {
+  /**
+   * The right button carries what the toolbar used to: commenting, and the relayout. The bottom
+   * toolbar is gone (Toolbar below) because a canvas of boards is read, not drawn on — but a
+   * comment is the one mark someone does want to make, and it should be under the cursor rather
+   * than in a bar at the other end of the screen.
+   */
+  ContextMenu: (props) => {
     const chrome = useContext(CanvasChromeContext);
+    const editor = useEditor();
 
     return (
-      <DefaultToolbar {...props}>
-        <TldrawUiButton
-          type="tool"
-          isActive={chrome.stylesVisible}
-          title={chrome.stylesVisible ? "Hide styles" : "Show styles"}
-          aria-pressed={chrome.stylesVisible}
-          onClick={chrome.toggleStyles}
-        >
-          <TldrawUiButtonIcon icon="styles-icon" />
-        </TldrawUiButton>
-        <DefaultToolbarContent />
-      </DefaultToolbar>
+      <DefaultContextMenu {...props}>
+        <TldrawUiMenuGroup id="canvas">
+          <TldrawUiMenuItem
+            id="comment"
+            label="Comment"
+            icon="comment"
+            kbd="c"
+            onSelect={() => {
+              editor.setCurrentTool("comment");
+            }}
+          />
+          <TldrawUiMenuItem
+            id="relayout"
+            label="Force refresh"
+            icon="refresh-icon"
+            onSelect={chrome.relayoutLibrary}
+          />
+        </TldrawUiMenuGroup>
+        <DefaultContextMenuContent />
+      </DefaultContextMenu>
     );
   },
+  /** No drawing tools: the boards are the content, and the tools that are not for drawing are in
+   *  the top bar and the right button. Keyboard shortcuts still reach the ones tldraw ships. */
+  Toolbar: null,
   /**
    * The comments layer: pins, thread popovers and the composer the comment tool opens. Everything
    * about where they are stored — the board folder, Git, the pin snapping onto the mockup beside
@@ -240,6 +236,22 @@ export const canvasChromeComponents: TLComponents = {
     const { addDialog } = useDialogs();
     const tool = useValue("tool", () => editor.getCurrentToolId(), [editor]);
     const setCommentUser = chrome.setCommentUser;
+    const host = useEditorPortalHost();
+    const [composer, setComposer] = useState<Element | null>(null);
+
+    // A dismiss for the placement composer, which the toolkit gives no slot on. Picking the
+    // comment tool by accident — a stray `c`, a right-click menu misread — leaves a bubble open
+    // whose only ways out are Escape and a click into empty canvas, neither of which is on screen.
+    // The composer is a direct child of the editor's portal host, so watching that one node's
+    // child list finds it, at a querySelector per popover.
+    useEffect(() => {
+      if (!host) return;
+      const find = () => setComposer(host.querySelector(".tlui-cmt-canvas-composer"));
+      find();
+      const observer = new MutationObserver(find);
+      observer.observe(host, { childList: true });
+      return () => observer.disconnect();
+    }, [host]);
 
     // An anonymous viewer gets no composer, so picking the comment tool without a name would do
     // nothing at all. Ask for one instead, and drop back to select if they would rather not.
@@ -268,23 +280,36 @@ export const canvasChromeComponents: TLComponents = {
     }, [addDialog, setCommentUser]);
 
     return (
-      <CanvasComments
-        // No identity, no composer, no reply, no edit: the toolkit's own read-only mode, and what
-        // a built canvas gets, where none of those could be saved anyway.
-        currentUserId={import.meta.env.DEV ? (chrome.commentUser?.id ?? null) : null}
-        resolveAuthor={resolveAuthor}
-      />
+      <>
+        <CanvasComments
+          // Null until a handle is typed: the toolkit's own read-only mode, which is what an
+          // anonymous viewer gets until the dialog above has an answer.
+          currentUserId={chrome.commentUser?.id ?? null}
+          resolveAuthor={resolveAuthor}
+        />
+        {/* Out of the tool, not just out of the bubble — Escape closes only the bubble and leaves
+            the next click placing another one, which is not what an accidental comment wants. The
+            draft is kept either way, so a real comment interrupted here is there next time. */}
+        {composer &&
+          createPortal(
+            <TldrawUiButton
+              type="icon"
+              title="Close (Esc)"
+              className="canvas-composer-close"
+              onClick={() => editor.setCurrentTool("select")}
+            >
+              <TldrawUiIcon icon="cross-2" label="Close" small />
+            </TldrawUiButton>,
+            composer,
+          )}
+      </>
     );
   },
-  StylePanel: (props) => {
-    const chrome = useContext(CanvasChromeContext);
-    return chrome.stylesVisible ? <DefaultStylePanel {...props} /> : null;
-  },
+  StylePanel: null,
 };
 
 export const canvasChromeAssetUrls: TLUiAssetUrlOverrides = {
   icons: {
-    "styles-icon": "/styles.svg",
     "clone-icon": "/clone.svg",
     "refresh-icon": "/refresh.svg",
   },

--- a/canvas/src/canvasChrome.tsx
+++ b/canvas/src/canvasChrome.tsx
@@ -39,7 +39,7 @@ const COMMENT_USER_DIALOG = "comment-user";
 
 /**
  * Ask for the commenter's identity from outside the tldraw UI context. `useDialogs` is only
- * available under `<Tldraw>`, and the inspector panel is a sibling of it — so the panel raises
+ * available under `<Tldraw>`, and the inspector panel is a sibling of it, so the panel raises
  * this and the comments layer, which is inside, opens the one dialog there is.
  */
 export const ASK_COMMENT_USER = "sp:ask-comment-user";
@@ -57,12 +57,12 @@ export const CanvasChromeContext = createContext({
 
 /**
  * The comment tool, plus the one thing this canvas adds to a thread: the link it carries to the
- * mockup it is about. Every comment placed on a board — or in the margin beside one — is anchored
- * to that board's shape, which is what makes the note ride the mockup when a layout.json edit
+ * mockup it is about. Every comment placed on a board, or in the margin beside one, is anchored
+ * to that board's shape, which is what moves the note with the mockup when a layout.json edit
  * moves it. The header shows that link, and follows it: clicking opens the board in the inspector.
  *
- * Everywhere, built canvas included. Where the comment goes differs — a dev server writes it into
- * the board's folder, a hosted canvas keeps it in the browser (canvasComments.ts) — but the tool
+ * Everywhere, built canvas included. Where the comment goes differs, a dev server writes it into
+ * the board's folder and a hosted canvas keeps it in the browser (canvasComments.ts), but the tool
  * and the thread are the same, so someone trying the hosted canvas sees what commenting is like.
  */
 export const canvasCommentTools = [
@@ -80,7 +80,7 @@ export const canvasCommentTools = [
         return (
           <TldrawUiButton
             type="icon"
-            title={`Linked to ${board.props.name} — open it`}
+            title={`Linked to ${board.props.name}. Click to open it`}
             onClick={() => chrome.inspectBoard(board)}
           >
             <TldrawUiButtonIcon icon="link" />
@@ -191,7 +191,7 @@ export const canvasChromeComponents: TLComponents = {
   },
   /**
    * The right button carries what the toolbar used to: commenting, and the relayout. The bottom
-   * toolbar is gone (Toolbar below) because a canvas of boards is read, not drawn on — but a
+   * toolbar is gone (Toolbar below) because a canvas of boards is read, not drawn on, but a
    * comment is the one mark someone does want to make, and it should be under the cursor rather
    * than in a bar at the other end of the screen.
    */
@@ -226,9 +226,9 @@ export const canvasChromeComponents: TLComponents = {
    *  the top bar and the right button. Keyboard shortcuts still reach the ones tldraw ships. */
   Toolbar: null,
   /**
-   * The comments layer: pins, thread popovers and the composer the comment tool opens. Everything
-   * about where they are stored — the board folder, Git, the pin snapping onto the mockup beside
-   * it — is canvasComments.ts; this is only the surface.
+   * The comments layer: pins, thread popovers and the composer the comment tool opens. Where they
+   * are stored, in the board folder and in Git, and how a pin snaps onto the mockup beside it, is
+   * all canvasComments.ts; this is only the UI.
    */
   InFrontOfTheCanvas: () => {
     const chrome = useContext(CanvasChromeContext);
@@ -240,7 +240,7 @@ export const canvasChromeComponents: TLComponents = {
     const [composer, setComposer] = useState<Element | null>(null);
 
     // A dismiss for the placement composer, which the toolkit gives no slot on. Picking the
-    // comment tool by accident — a stray `c`, a right-click menu misread — leaves a bubble open
+    // comment tool by accident, a stray `c` or a right-click menu misread, leaves a bubble open
     // whose only ways out are Escape and a click into empty canvas, neither of which is on screen.
     // The composer is a direct child of the editor's portal host, so watching that one node's
     // child list finds it, at a querySelector per popover.
@@ -260,8 +260,8 @@ export const canvasChromeComponents: TLComponents = {
       addDialog({
         id: COMMENT_USER_DIALOG,
         component: (dialog) => <CommentUserDialog {...dialog} onSave={chrome.setCommentUser} />,
-        // Only when they closed it without giving a name — saving one should leave them in the
-        // tool they just picked. Read back rather than trusting the value this effect captured.
+        // Only when they closed it without giving a name, since saving one should leave them in
+        // the tool they just picked. Read back rather than trusting the value this effect captured.
         onClose: () => {
           if (!readCommentUser()) editor.setCurrentTool("select");
         },
@@ -287,8 +287,8 @@ export const canvasChromeComponents: TLComponents = {
           currentUserId={chrome.commentUser?.id ?? null}
           resolveAuthor={resolveAuthor}
         />
-        {/* Out of the tool, not just out of the bubble — Escape closes only the bubble and leaves
-            the next click placing another one, which is not what an accidental comment wants. The
+        {/* Out of the tool as well as the bubble. Escape closes only the bubble and leaves the
+            next click placing another one, which is not what an accidental comment wants. The
             draft is kept either way, so a real comment interrupted here is there next time. */}
         {composer &&
           createPortal(

--- a/canvas/src/canvasChrome.tsx
+++ b/canvas/src/canvasChrome.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext } from "react";
+import { createContext, useContext, useEffect } from "react";
 import {
   DefaultActionsMenu,
   DefaultStylePanel,
@@ -6,13 +6,33 @@ import {
   DefaultToolbarContent,
   TldrawUiButton,
   TldrawUiButtonIcon,
+  type Editor,
   type TLComponents,
   type TLUiAssetUrlOverrides,
+  useDialogs,
+  useEditor,
+  useValue,
 } from "tldraw";
+import { CanvasComments, CommentTool } from "@tldraw/commenting";
+import { CloneCanvasDialog } from "./CloneCanvasDialog";
+import { CommentUserDialog } from "./CommentUserDialog";
+import { linkedBoard, readCommentUser, resolveAuthor, type CommentUser } from "./canvasComments";
+import type { CanvasFileShape } from "./CanvasFileShapeUtil";
+import { WELCOME_PAGE_SLUG } from "./canvasUrl";
 
 const REPO_URL = "https://github.com/ReScienceLab/super-prototyping";
 /** The app the snapaction-ios boards are cloned from: its own site, not the App Store listing. */
 const SNAPACTION_URL = "https://snapaction.ai/";
+
+/** One dialog, whether it was opened by the button or by picking the tool without a name. */
+const COMMENT_USER_DIALOG = "comment-user";
+
+/**
+ * Ask for the commenter's identity from outside the tldraw UI context. `useDialogs` is only
+ * available under `<Tldraw>`, and the inspector panel is a sibling of it — so the panel raises
+ * this and the comments layer, which is inside, opens the one dialog there is.
+ */
+export const ASK_COMMENT_USER = "sp:ask-comment-user";
 
 const GITHUB_PATH =
   "M12 0c6.63 0 12 5.276 12 11.79-.001 5.067-3.29 9.567-8.175 11.187-.6.118-.825-.25-.825-.56 0-.398.015-1.665.015-3.242 0-1.105-.375-1.813-.81-2.181 2.67-.295 5.475-1.297 5.475-5.822 0-1.297-.465-2.344-1.23-3.169.12-.295.54-1.503-.12-3.125 0 0-1.005-.324-3.3 1.209a11.32 11.32 0 00-3-.398c-1.02 0-2.04.133-3 .398-2.295-1.518-3.3-1.209-3.3-1.209-.66 1.622-.24 2.83-.12 3.125-.765.825-1.23 1.887-1.23 3.169 0 4.51 2.79 5.527 5.46 5.822-.345.294-.66.81-.765 1.577-.69.31-2.415.81-3.495-.973-.225-.354-.9-1.223-1.845-1.209-1.005.015-.405.56.015.781.51.28 1.095 1.327 1.23 1.666.24.663 1.02 1.93 4.035 1.385 0 .988.015 1.916.015 2.196 0 .31-.225.664-.825.56C3.303 21.374-.003 16.867 0 11.791 0 5.276 5.37 0 12 0z";
@@ -21,7 +41,46 @@ export const CanvasChromeContext = createContext({
   stylesVisible: false,
   toggleStyles: () => {},
   relayoutLibrary: () => {},
+  /** The mounted editor, for the parts of the app that render outside `<Tldraw>`. */
+  editor: null as Editor | null,
+  /** Who this browser comments as, or null until they have typed a name. */
+  commentUser: null as CommentUser | null,
+  setCommentUser: (_user: CommentUser) => {},
+  /** Open a board in the inspector, for the parts of the canvas that link to one. */
+  inspectBoard: (_board: CanvasFileShape) => {},
 });
+
+/**
+ * The comment tool, plus the one thing this canvas adds to a thread: the link it carries to the
+ * mockup it is about. Every comment placed on a board — or in the margin beside one — is anchored
+ * to that board's shape, which is what makes the note ride the mockup when a layout.json edit
+ * moves it. The header shows that link, and follows it: clicking opens the board in the inspector.
+ */
+export const canvasCommentTools = [
+  CommentTool.configure({
+    components: {
+      ThreadActions: ({ thread }) => {
+        const chrome = useContext(CanvasChromeContext);
+        const editor = useEditor();
+        const board = useValue("linked board", () => linkedBoard(editor, thread.anchor), [
+          editor,
+          thread.anchor,
+        ]);
+        // A note dropped out in open canvas is linked to nothing, and says so by showing nothing.
+        if (!board) return null;
+        return (
+          <TldrawUiButton
+            type="icon"
+            title={`Linked to ${board.props.name} — open it`}
+            onClick={() => chrome.inspectBoard(board)}
+          >
+            <TldrawUiButtonIcon icon="link" />
+          </TldrawUiButton>
+        );
+      },
+    },
+  }),
+];
 
 export const canvasChromeComponents: TLComponents = {
   /**
@@ -78,19 +137,67 @@ export const canvasChromeComponents: TLComponents = {
       </a>
     </div>
   ),
-  /** Force-relayout sits with the other document-level actions in the top bar, not with the drawing tools. */
+  /** Clone and force-relayout are document-level actions, so they sit in the top bar with the
+   * rest of them rather than with the drawing tools. */
   ActionsMenu: (props) => {
     const chrome = useContext(CanvasChromeContext);
+    const editor = useEditor();
+    const { addDialog } = useDialogs();
+    const slug = useValue(
+      "canvas slug",
+      () => editor.getCurrentPage().meta.canvasSlug as string | undefined,
+      [editor],
+    );
 
     return (
       <>
         <DefaultActionsMenu {...props} />
+        {/* Nothing to copy on the welcome page, which the app draws and no folder backs, or on
+            a page someone added by hand. */}
+        {slug && slug !== WELCOME_PAGE_SLUG && (
+          <TldrawUiButton
+            type="icon"
+            title="Clone this canvas into a new one"
+            onClick={() =>
+              addDialog({
+                component: (dialog) => <CloneCanvasDialog {...dialog} slug={slug} />,
+              })
+            }
+          >
+            <TldrawUiButtonIcon icon="clone-icon" />
+          </TldrawUiButton>
+        )}
         <TldrawUiButton
           type="icon"
           title="Force refresh canvas library (fixes overlapping frames after a layout.json edit)"
           onClick={chrome.relayoutLibrary}
         >
           <TldrawUiButtonIcon icon="refresh-icon" />
+        </TldrawUiButton>
+        {/* The only account there is: the GitHub handle posted comments are signed with, wearing
+            that account's avatar once there is one. Sits here rather than behind the comment tool
+            so it can be corrected after the fact. */}
+        <TldrawUiButton
+          type="icon"
+          title={
+            chrome.commentUser
+              ? `Commenting as ${chrome.commentUser.name} — click to change`
+              : "Set the GitHub handle your comments are signed with"
+          }
+          onClick={() =>
+            addDialog({
+              id: COMMENT_USER_DIALOG,
+              component: (dialog) => (
+                <CommentUserDialog {...dialog} onSave={chrome.setCommentUser} />
+              ),
+            })
+          }
+        >
+          {chrome.commentUser ? (
+            <img className="canvas-me" src={chrome.commentUser.image} alt="" />
+          ) : (
+            <TldrawUiButtonIcon icon="comment" />
+          )}
         </TldrawUiButton>
       </>
     );
@@ -113,6 +220,51 @@ export const canvasChromeComponents: TLComponents = {
       </DefaultToolbar>
     );
   },
+  /**
+   * The comments layer: pins, thread popovers and the composer the comment tool opens. Everything
+   * about where they are stored — the board folder, Git, the pin snapping onto the mockup beside
+   * it — is canvasComments.ts; this is only the surface.
+   */
+  InFrontOfTheCanvas: () => {
+    const chrome = useContext(CanvasChromeContext);
+    const editor = useEditor();
+    const { addDialog } = useDialogs();
+    const tool = useValue("tool", () => editor.getCurrentToolId(), [editor]);
+    const setCommentUser = chrome.setCommentUser;
+
+    // An anonymous viewer gets no composer, so picking the comment tool without a name would do
+    // nothing at all. Ask for one instead, and drop back to select if they would rather not.
+    useEffect(() => {
+      if (tool !== "comment" || chrome.commentUser) return;
+      addDialog({
+        id: COMMENT_USER_DIALOG,
+        component: (dialog) => <CommentUserDialog {...dialog} onSave={chrome.setCommentUser} />,
+        // Only when they closed it without giving a name — saving one should leave them in the
+        // tool they just picked. Read back rather than trusting the value this effect captured.
+        onClose: () => {
+          if (!readCommentUser()) editor.setCurrentTool("select");
+        },
+      });
+    }, [tool, chrome, addDialog, editor]);
+
+    // The same dialog for the inspector panel's composer, which cannot open one itself.
+    useEffect(() => {
+      const ask = () =>
+        addDialog({
+          id: COMMENT_USER_DIALOG,
+          component: (dialog) => <CommentUserDialog {...dialog} onSave={setCommentUser} />,
+        });
+      window.addEventListener(ASK_COMMENT_USER, ask);
+      return () => window.removeEventListener(ASK_COMMENT_USER, ask);
+    }, [addDialog, setCommentUser]);
+
+    return (
+      <CanvasComments
+        currentUserId={chrome.commentUser?.id ?? null}
+        resolveAuthor={resolveAuthor}
+      />
+    );
+  },
   StylePanel: (props) => {
     const chrome = useContext(CanvasChromeContext);
     return chrome.stylesVisible ? <DefaultStylePanel {...props} /> : null;
@@ -122,6 +274,7 @@ export const canvasChromeComponents: TLComponents = {
 export const canvasChromeAssetUrls: TLUiAssetUrlOverrides = {
   icons: {
     "styles-icon": "/styles.svg",
+    "clone-icon": "/clone.svg",
     "refresh-icon": "/refresh.svg",
   },
 };

--- a/canvas/src/canvasComments.test.ts
+++ b/canvas/src/canvasComments.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'vitest'
+import { toRichText } from 'tldraw'
+import type {
+  TLComment,
+  TLCommentId,
+  TLCommentReaction,
+  TLCommentReactionId,
+  TLCommentThread,
+  TLCommentThreadId,
+  TLPageId,
+} from 'tldraw'
+import { commentsFileFor, distanceToBox, githubLogin, writeCommentUser } from './canvasComments'
+
+// The page id is exactly what must not survive into the file: it is minted per browser, and the
+// folder the file sits in is what identifies the page instead.
+const pageId = 'page:whatever' as TLPageId
+const ADA = 'user:ada-lovelace'
+const ada = { id: ADA, name: 'Ada-Lovelace', image: 'https://github.com/Ada-Lovelace.png?size=80' }
+
+const thread = (id: string, isDeleted = false): TLCommentThread => ({
+  id: `comment-thread:${id}` as TLCommentThreadId,
+  typeName: 'comment-thread',
+  pageId,
+  anchor: { type: 'point', x: 10, y: 20 },
+  createdBy: ADA,
+  createdAt: 0,
+  resolved: null,
+  isDeleted,
+  meta: {},
+})
+
+const comment = (id: string, threadId: string, isDeleted = false): TLComment => ({
+  id: `comment:${id}` as TLCommentId,
+  typeName: 'comment',
+  threadId: `comment-thread:${threadId}` as TLCommentThreadId,
+  pageId,
+  authorId: ADA,
+  createdAt: 0,
+  editedAt: null,
+  body: toRichText('nice'),
+  isDeleted,
+  meta: {},
+})
+
+const reaction = (id: string, commentId: string, userId: string): TLCommentReaction => ({
+  id: `comment-reaction:${id}` as TLCommentReactionId,
+  typeName: 'comment-reaction',
+  commentId: `comment:${commentId}` as TLCommentId,
+  threadId: 'comment-thread:a' as TLCommentThreadId,
+  pageId,
+  userId,
+  emoji: '👍',
+  createdAt: 0,
+  meta: {},
+})
+
+describe('distanceToBox', () => {
+  const box = { x: 0, y: 0, w: 100, h: 200 }
+
+  it('is zero inside the box and the gap outside it', () => {
+    expect(distanceToBox({ x: 50, y: 100 }, box)).toBe(0)
+    expect(distanceToBox({ x: 130, y: 100 }, box)).toBe(30)
+    expect(distanceToBox({ x: -10, y: 100 }, box)).toBe(10)
+    // Off a corner in both directions, so neither axis alone is the answer.
+    expect(distanceToBox({ x: 103, y: 204 }, box)).toBe(5)
+  })
+})
+
+describe('commentsFileFor', () => {
+  writeCommentUser(ada)
+
+  // b is deleted, so it takes its comment with it; r2 reacts to a comment that went with it.
+  const records = [
+    reaction('r1', 'a1', ADA),
+    comment('a1', 'a'),
+    thread('b', true),
+    thread('a'),
+    comment('b1', 'b'),
+    reaction('r2', 'b1', ADA),
+    comment('a2', 'a', true),
+  ]
+
+  it('drops soft-deletes and everything orphaned by them', () => {
+    expect(commentsFileFor(records).records.map((r) => r.id)).toEqual([
+      'comment-reaction:r1',
+      'comment-thread:a',
+      'comment:a1',
+    ])
+  })
+
+  it('strips the page id and sorts, so the file diffs line by line', () => {
+    const file = commentsFileFor(records)
+    expect(file.records.every((r) => !('pageId' in r))).toBe(true)
+    expect(file.records.map((r) => r.id)).toEqual([...file.records.map((r) => r.id)].sort())
+  })
+
+  it('carries the names of the authors it kept, and only those', () => {
+    // Someone this browser has never heard of resolves to their id at read time instead.
+    const withStranger = [...records, reaction('r3', 'a1', 'user:stranger')]
+    expect(commentsFileFor(withStranger).authors).toEqual({
+      [ADA]: { name: ada.name, image: ada.image },
+    })
+  })
+})
+
+describe('githubLogin', () => {
+  it('takes a handle however it was pasted', () => {
+    expect(githubLogin('  Ada-Lovelace ')).toBe('Ada-Lovelace')
+    expect(githubLogin('@ada')).toBe('ada')
+    expect(githubLogin('https://github.com/ada/some-repo')).toBe('ada')
+  })
+
+  it('is null for anything GitHub would not accept as a username', () => {
+    expect(githubLogin('')).toBeNull()
+    expect(githubLogin('Ada Lovelace')).toBeNull()
+    expect(githubLogin('-ada')).toBeNull()
+    expect(githubLogin('ada--lovelace')).toBeNull()
+    expect(githubLogin('a'.repeat(40))).toBeNull()
+  })
+})

--- a/canvas/src/canvasComments.ts
+++ b/canvas/src/canvasComments.ts
@@ -1,0 +1,361 @@
+import {
+  putCommentRecords,
+  shapeAnchorAt,
+  type CommentAuthor,
+  type TLCommentRecord,
+} from "@tldraw/commenting";
+import type { Editor, TLCommentAnchor, TLPageId, TLRecord, TLShapeId } from "tldraw";
+import { rawComments } from "virtual:canvases";
+import { CANVAS_FILE_SHAPE_TYPE, type CanvasFileShape } from "./CanvasFileShapeUtil";
+
+// Comments live in the board folder, as `<slug>/comments.json`, and go into Git with the boards.
+// That is the whole design decision: this canvas serves one repo, has no login and no sync
+// server, and a note on a mockup is only worth keeping next to the mockup it is about. So the
+// file is the source of truth and the tldraw store is a working copy of it — loaded over
+// whatever IndexedDB had, written back on every change.
+//
+// Two things the records cannot carry into the file. Page ids are minted per browser (App.tsx
+// asks tldraw to create the page, tldraw hands out the id), so the folder slug plays that role
+// and the page id is re-attached on load. Author ids are made up here rather than issued by
+// anything, so each file also carries the names of the people in it — that is what turns an id
+// back into a name in someone else's checkout.
+
+/** A board folder's comments.json. `records` carry no `pageId`: the folder is the page. */
+export interface CommentsFile {
+  /** Author id -> display info, for every author appearing in `records`. */
+  authors: Record<string, CommentAuthor>;
+  records: FileCommentRecord[];
+}
+
+type FileCommentRecord = Omit<TLCommentRecord, "pageId">;
+
+/** Who this browser posts as. No login: a GitHub handle typed once, kept in localStorage. */
+export interface CommentUser {
+  id: string;
+  name: string;
+  image: string;
+}
+
+const USER_KEY = "super-prototyping-comment-user";
+
+const COMMENT_TYPES = new Set(["comment-thread", "comment", "comment-reaction"]);
+
+const isComment = (record: { typeName: string }) => COMMENT_TYPES.has(record.typeName);
+
+/**
+ * Every comment record in the store. The comment types are registered records rather than part
+ * of `TLRecord`, so they cross into the typed world here and nowhere else.
+ */
+const allComments = (editor: Editor) =>
+  (editor.store.allRecords() as unknown as TLCommentRecord[]).filter(isComment);
+
+/**
+ * Every author named by any board's comments.json, plus this browser's own. Not reactive: it is
+ * read while a comment renders, and the only entry that changes during a session is the local
+ * user's own name, which re-renders the layer through the identity state in App.tsx anyway.
+ */
+const authors = new Map<string, CommentAuthor>();
+for (const file of Object.values(rawComments)) {
+  for (const [id, author] of Object.entries<CommentAuthor>(file.authors ?? {}))
+    authors.set(id, author);
+}
+
+/**
+ * Name an author id, for `CanvasComments`. Every id is a GitHub login, so one from a board this
+ * canvas has not loaded still resolves to a name and an avatar rather than to nothing.
+ */
+export function resolveAuthor(id: string): CommentAuthor {
+  return authors.get(id) ?? githubUser(id.replace(/^user:/, ""));
+}
+
+/**
+ * The login in whatever was typed: a handle, an `@handle`, or a pasted profile URL. Null when it
+ * is not a GitHub username — GitHub's own rule, alphanumerics and single inner hyphens, 39 max.
+ */
+export function githubLogin(input: string): string | null {
+  const login = input
+    .trim()
+    .replace(/^https?:\/\/(www\.)?github\.com\//i, "")
+    .replace(/^@/, "")
+    .replace(/\/.*$/, "");
+  return /^[a-z\d](?:[a-z\d]|-(?=[a-z\d])){0,38}$/i.test(login) ? login : null;
+}
+
+/**
+ * The identity a login gives, avatar included. There is no account here and no directory, so the
+ * handle is both the id and the display name — the one thing everyone reviewing this repo already
+ * has, and the one that means the same in a pull request. The avatar needs no API: github.com
+ * redirects `<login>.png` to it, which is also a URL worth reading in the committed JSON.
+ */
+function githubUser(login: string): CommentUser {
+  return {
+    id: `user:${login.toLowerCase()}`,
+    name: login,
+    image: `https://github.com/${login}.png?size=80`,
+  };
+}
+
+/**
+ * Who a typed handle is, or null if GitHub will not serve an avatar for it — which catches the
+ * typo before it is committed and confirms the one thing this needs in the same request.
+ * `api.github.com` answers the same question, but it rate-limits an unauthenticated caller hard
+ * enough to 403 every check away, and a 403 is not a "no such user".
+ */
+export async function resolveGithubUser(input: string): Promise<CommentUser | null> {
+  const login = githubLogin(input);
+  if (!login) return null;
+  const user = githubUser(login);
+  return await new Promise((resolve) => {
+    const img = new Image();
+    img.onload = () => resolve(user);
+    img.onerror = () => resolve(null);
+    img.src = user.image;
+  });
+}
+
+export function readCommentUser(): CommentUser | null {
+  try {
+    const raw = localStorage.getItem(USER_KEY);
+    const user = raw ? (JSON.parse(raw) as CommentUser) : null;
+    // Both, so a name-only identity stored before avatars asks for the GitHub handle once.
+    return user?.name && user.image ? user : null;
+  } catch {
+    return null;
+  }
+}
+
+export function writeCommentUser(user: CommentUser) {
+  authors.set(user.id, { name: user.name, image: user.image });
+  try {
+    localStorage.setItem(USER_KEY, JSON.stringify(user));
+  } catch {
+    // A browser refusing storage still gets to comment; it just asks for the handle again later.
+  }
+}
+
+/** Distance from a page point to a box, zero anywhere inside it. */
+export function distanceToBox(
+  point: { x: number; y: number },
+  box: { x: number; y: number; w: number; h: number },
+) {
+  const dx = Math.max(box.x - point.x, 0, point.x - (box.x + box.w));
+  const dy = Math.max(box.y - point.y, 0, point.y - (box.y + box.h));
+  return Math.hypot(dx, dy);
+}
+
+/**
+ * How far outside a board a comment still belongs to it, in page units — one column gap
+ * (LIBRARY_GAP in App.tsx), so a note dropped in the margin beside a mockup attaches to it while
+ * one dropped out in open canvas stays where it was put. Nearest board wins, so the gap between
+ * two boards splits down the middle rather than being ambiguous.
+ */
+const NEARBY = 80;
+
+/**
+ * The board a comment placed at `point` is about, or undefined out in open canvas. Inside a board
+ * the comment tool has already resolved this itself; this is only for the ones that landed beside
+ * one.
+ */
+export function nearestBoard(editor: Editor, pageId: TLPageId, point: { x: number; y: number }) {
+  let best: { id: TLShapeId; distance: number } | undefined;
+  for (const id of editor.getPageShapeIds(pageId)) {
+    const shape = editor.getShape(id);
+    if (shape?.type !== CANVAS_FILE_SHAPE_TYPE) continue;
+    const bounds = editor.getShapePageBounds(shape);
+    if (!bounds) continue;
+    const distance = distanceToBox(point, bounds);
+    if (distance <= NEARBY && (!best || distance < best.distance)) {
+      best = { id: shape.id, distance };
+    }
+  }
+  return best?.id;
+}
+
+/**
+ * Re-anchor a freshly placed thread onto the board beside it. A shape anchor is a normalized
+ * offset within the board's own bounds, unclamped both when it is recorded and when it is drawn,
+ * so a pin in the margin keeps exactly the spot it was dropped on *and* rides the board when a
+ * layout.json edit reflows the page. That is the point of doing this at all: the boards move, and
+ * the notes about them should move with them.
+ */
+function anchorToNearbyBoard(editor: Editor, records: { typeName: string }[]) {
+  const updates: TLCommentRecord[] = [];
+  for (const record of records) {
+    if (record.typeName !== "comment-thread") continue;
+    const thread = record as unknown as Extract<TLCommentRecord, { typeName: "comment-thread" }>;
+    const anchor = thread.anchor;
+    // Anything but a bare point was resolved deliberately — by the tool's own hit-test, or by
+    // someone dragging the pin — and is left alone.
+    if (anchor.type !== "point") continue;
+    const shapeId = nearestBoard(editor, thread.pageId, anchor);
+    if (!shapeId) continue;
+    updates.push({ ...thread, anchor: shapeAnchorAt(editor, shapeId, anchor, true) });
+  }
+  if (updates.length) putCommentRecords(editor, updates);
+}
+
+/**
+ * The board a thread is linked to, or undefined for one left out in open canvas. The shape anchor
+ * *is* the link — the comment tool records one for a comment placed on a mockup, and the function
+ * above writes one for a comment placed beside it — so this only reads it back, for the surfaces
+ * that show which mockup a note is about.
+ */
+export function linkedBoard(editor: Editor, anchor: TLCommentAnchor): CanvasFileShape | undefined {
+  if (anchor.type !== "shape") return undefined;
+  const shape = editor.getShape(anchor.shapeId);
+  return shape?.type === CANVAS_FILE_SHAPE_TYPE ? (shape as CanvasFileShape) : undefined;
+}
+
+/** The records of one board, as they go into Git: no page id, no tombstones, sorted by id. */
+export function commentsFileFor(records: TLCommentRecord[]): CommentsFile {
+  // Soft-deletes are left for a sync server to prune, and there is no server — so a delete drops
+  // the record from the file here, and the next load takes it out of the store.
+  const threads = new Set(
+    records.filter((r) => r.typeName === "comment-thread" && !r.isDeleted).map((r) => r.id),
+  );
+  const comments = new Set(
+    records
+      .filter((r) => r.typeName === "comment" && !r.isDeleted && threads.has(r.threadId))
+      .map((r) => r.id),
+  );
+  const kept = records.filter((record) => {
+    if (record.typeName === "comment-thread") return threads.has(record.id);
+    if (record.typeName === "comment") return comments.has(record.id);
+    return comments.has(record.commentId);
+  });
+
+  const named: Record<string, CommentAuthor> = {};
+  const name = (id: string) => {
+    const author = authors.get(id);
+    if (author) named[id] = author;
+  };
+  for (const record of kept) {
+    if (record.typeName === "comment-thread") name(record.createdBy);
+    else if (record.typeName === "comment") name(record.authorId);
+    else name(record.userId);
+  }
+
+  return {
+    authors: named,
+    records: kept
+      .map(({ pageId: _pageId, ...rest }) => rest as FileCommentRecord)
+      .sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0)),
+  };
+}
+
+/** Slug -> page id for every page a board folder backs. */
+function boardPages(editor: Editor) {
+  const bySlug = new Map<string, TLPageId>();
+  for (const page of editor.getPages()) {
+    const slug = page.meta.canvasSlug as string | undefined;
+    if (slug) bySlug.set(slug, page.id);
+  }
+  return bySlug;
+}
+
+/**
+ * Load the folders' comments over whatever this browser had, wire the store back to them, and
+ * attach new pins to the board beside them.
+ *
+ * The file wins on load, unconditionally: comment records are document records, so IndexedDB
+ * persisted them alongside the shapes, and without this a thread someone deleted in Git would
+ * come back on every machine that had already seen it. Returns a disposer, like the other
+ * installers in App.tsx.
+ */
+export function installCanvasComments(editor: Editor) {
+  const pageIds = boardPages(editor);
+
+  const wanted: TLCommentRecord[] = [];
+  for (const [slug, file] of Object.entries(rawComments)) {
+    const pageId = pageIds.get(slug);
+    // A folder the canvas is not showing keeps its comments in its file, untouched, rather than
+    // having them deleted by a canvas that cannot see them.
+    if (!pageId) continue;
+    for (const record of file.records ?? []) {
+      wanted.push({ ...record, pageId } as unknown as TLCommentRecord);
+    }
+  }
+  const wantedIds = new Set(wanted.map((record) => record.id));
+  const managed = new Set(pageIds.values());
+  const stale = allComments(editor)
+    .filter((record) => !wantedIds.has(record.id) && managed.has(record.pageId))
+    .map((record) => record.id);
+
+  // As a remote change: this is not the user's own edit, it does not belong on their undo stack,
+  // and the listener below ignores it — so loading the file does not write it straight back.
+  editor.store.mergeRemoteChanges(() => {
+    if (stale.length) editor.store.remove(stale as unknown as TLRecord["id"][]);
+    if (wanted.length) editor.store.put(wanted as unknown as TLRecord[]);
+  });
+
+  const bodies = () => {
+    const slugs = new Map<TLPageId, string>();
+    // Every board gets an entry, empty ones included: a board whose last comment was deleted
+    // still has to be written, or its file would keep the comments that were just removed.
+    const out = new Map<string, TLCommentRecord[]>();
+    for (const [slug, pageId] of pageIds) {
+      slugs.set(pageId, slug);
+      out.set(slug, []);
+    }
+    for (const record of allComments(editor)) {
+      const slug = slugs.get(record.pageId);
+      if (slug) out.get(slug)!.push(record);
+    }
+    return new Map(
+      [...out].map(([slug, records]) => {
+        const file = commentsFileFor(records);
+        return [slug, file.records.length ? JSON.stringify(file) : ""];
+      }),
+    );
+  };
+
+  // What is on disk already, so the first real edit only writes the board it touched.
+  const written = bodies();
+
+  let pending: ReturnType<typeof setTimeout> | undefined;
+  const flush = () => {
+    pending = undefined;
+    for (const [slug, body] of bodies()) {
+      if (written.get(slug) === body) continue;
+      written.set(slug, body);
+      void fetch("/__sp/comments", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ slug, file: body ? JSON.parse(body) : null }),
+      });
+    }
+  };
+
+  const dispose = editor.store.listen(
+    ({ changes }) => {
+      // Placed, not only created: a pin dragged onto a board arrives here as an update, and as a
+      // bare point just like a new comment does — the comment tool's own hit-test looks straight
+      // through the boards, which are locked shapes. Same rule for both, so the same call.
+      const placed = [
+        ...Object.values(changes.added),
+        ...Object.values(changes.updated).map(([, next]) => next),
+      ].filter(isComment);
+      // In a microtask, not here: this runs inside the store's own change notification, and the
+      // re-anchor is another write.
+      if (placed.length) queueMicrotask(() => anchorToNearbyBoard(editor, placed));
+      const touched = placed.length > 0 || Object.values(changes.removed).some(isComment);
+      if (!touched) return;
+      // Debounced: posting a comment is several records in one batch, and an edit is one write
+      // per keystroke. Half a second is well under the time it takes to notice a change.
+      clearTimeout(pending);
+      pending = setTimeout(flush, 500);
+    },
+    { source: "user", scope: "document" },
+  );
+
+  // The same rule, over what the files already hold: a note written before its board existed —
+  // or from a tab predating this — is linked on the next load rather than left pinned to a page
+  // coordinate the next layout.json edit would strand it at. Threads already anchored to a shape,
+  // and ones dropped out in open canvas, are left exactly as they are.
+  anchorToNearbyBoard(editor, wanted);
+
+  return () => {
+    dispose();
+    clearTimeout(pending);
+  };
+}

--- a/canvas/src/canvasComments.ts
+++ b/canvas/src/canvasComments.ts
@@ -29,6 +29,31 @@ export interface CommentsFile {
 
 type FileCommentRecord = Omit<TLCommentRecord, "pageId">;
 
+/**
+ * Where a changed board's comments go. Against a dev server — what a plugin install runs — into
+ * the board's folder as comments.json, so a review travels with the boards in Git. A built canvas
+ * is static files with no repo behind them, so there they stay in this browser: the hosted canvas
+ * gives commenting to try, not a place a review lands.
+ */
+const LOCAL_KEY = "super-prototyping-comments";
+
+/** The boards this browser has commented on, whole files, keyed by slug. Empty on a dev server. */
+const localFiles: Record<string, CommentsFile> = (() => {
+  if (import.meta.env.DEV) return {};
+  try {
+    return JSON.parse(localStorage.getItem(LOCAL_KEY) ?? "{}") as Record<string, CommentsFile>;
+  } catch {
+    return {};
+  }
+})();
+
+/**
+ * What this canvas shows: the committed files, with this browser's own written over them board by
+ * board. A board only appears in `localFiles` once someone here has changed it, so every other
+ * board keeps following the repo.
+ */
+const commentFiles: Record<string, CommentsFile> = { ...rawComments, ...localFiles };
+
 /** Who this browser posts as. No login: a GitHub handle typed once, kept in localStorage. */
 export interface CommentUser {
   id: string;
@@ -55,7 +80,7 @@ const allComments = (editor: Editor) =>
  * user's own name, which re-renders the layer through the identity state in App.tsx anyway.
  */
 const authors = new Map<string, CommentAuthor>();
-for (const file of Object.values(rawComments)) {
+for (const file of Object.values(commentFiles)) {
   for (const [id, author] of Object.entries<CommentAuthor>(file.authors ?? {}))
     authors.set(id, author);
 }
@@ -67,6 +92,10 @@ for (const file of Object.values(rawComments)) {
 export function resolveAuthor(id: string): CommentAuthor {
   return authors.get(id) ?? githubUser(id.replace(/^user:/, ""));
 }
+
+/** GitHub's mark, drawn wherever this canvas asks for or shows a GitHub handle. */
+export const GITHUB_PATH =
+  "M12 0c6.63 0 12 5.276 12 11.79-.001 5.067-3.29 9.567-8.175 11.187-.6.118-.825-.25-.825-.56 0-.398.015-1.665.015-3.242 0-1.105-.375-1.813-.81-2.181 2.67-.295 5.475-1.297 5.475-5.822 0-1.297-.465-2.344-1.23-3.169.12-.295.54-1.503-.12-3.125 0 0-1.005-.324-3.3 1.209a11.32 11.32 0 00-3-.398c-1.02 0-2.04.133-3 .398-2.295-1.518-3.3-1.209-3.3-1.209-.66 1.622-.24 2.83-.12 3.125-.765.825-1.23 1.887-1.23 3.169 0 4.51 2.79 5.527 5.46 5.822-.345.294-.66.81-.765 1.577-.69.31-2.415.81-3.495-.973-.225-.354-.9-1.223-1.845-1.209-1.005.015-.405.56.015.781.51.28 1.095 1.327 1.23 1.666.24.663 1.02 1.93 4.035 1.385 0 .988.015 1.916.015 2.196 0 .31-.225.664-.825.56C3.303 21.374-.003 16.867 0 11.791 0 5.276 5.37 0 12 0z";
 
 /**
  * The login in whatever was typed: a handle, an `@handle`, or a pasted profile URL. Null when it
@@ -172,6 +201,37 @@ export function nearestBoard(editor: Editor, pageId: TLPageId, point: { x: numbe
 }
 
 /**
+ * What a click would do, while the comment tool is up: the board the note would attach to gets
+ * tldraw's own hint outline, and the bubble cursor fills in (index.css keys off the attribute).
+ * Out in open canvas both go quiet, which is the honest answer — the note would stay a point.
+ *
+ * On `event` rather than a pointer handler because the tool clears the hint on every move: its
+ * hit-test looks straight through the boards, which are locked, so it finds nothing where
+ * `nearestBoard` finds something. The editor emits `event` after the state chart has run, which
+ * is the one place the answer sticks.
+ */
+function installCommentTargetHint(editor: Editor) {
+  const container = editor.getContainer();
+  const update = () => {
+    if (editor.getCurrentToolId() !== "comment") return;
+    // ponytail: every board on the page, per pointer move. A page holds tens of them, so the
+    // scan costs less than the cache that would keep it correct.
+    const id = nearestBoard(
+      editor,
+      editor.getCurrentPageId(),
+      editor.inputs.getCurrentPagePoint(),
+    );
+    editor.setHintingShapes(id ? [id] : []);
+    container.toggleAttribute("data-comment-target", !!id);
+  };
+  editor.on("event", update);
+  return () => {
+    editor.off("event", update);
+    container.removeAttribute("data-comment-target");
+  };
+}
+
+/**
  * Re-anchor a freshly placed thread onto the board beside it. A shape anchor is a normalized
  * offset within the board's own bounds, unclamped both when it is recorded and when it is drawn,
  * so a pin in the margin keeps exactly the spot it was dropped on *and* rides the board when a
@@ -266,7 +326,7 @@ export function installCanvasComments(editor: Editor) {
   const pageIds = boardPages(editor);
 
   const wanted: TLCommentRecord[] = [];
-  for (const [slug, file] of Object.entries(rawComments)) {
+  for (const [slug, file] of Object.entries(commentFiles)) {
     const pageId = pageIds.get(slug);
     // A folder the canvas is not showing keeps its comments in its file, untouched, rather than
     // having them deleted by a canvas that cannot see them.
@@ -318,18 +378,28 @@ export function installCanvasComments(editor: Editor) {
     for (const [slug, body] of bodies()) {
       if (written.get(slug) === body) continue;
       written.set(slug, body);
-      void fetch("/__sp/comments", {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({ slug, file: body ? JSON.parse(body) : null }),
-      });
+      const file = body ? (JSON.parse(body) as CommentsFile) : null;
+      if (import.meta.env.DEV) {
+        void fetch("/__sp/comments", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ slug, file }),
+        });
+        continue;
+      }
+      // An emptied board is kept as an empty file rather than dropped: dropping it would let the
+      // committed comments back in on the next load, which is not what deleting them meant.
+      localFiles[slug] = file ?? { authors: {}, records: [] };
+      try {
+        localStorage.setItem(LOCAL_KEY, JSON.stringify(localFiles));
+      } catch {
+        // Storage full or refused. The comment stays on screen for this session and is lost on
+        // reload — the same deal every other thing this canvas keeps in the browser gets.
+      }
     }
   };
 
-  // Only against a dev server, which is what a plugin install runs: the POST above is the only
-  // way a comment reaches the repo, and a built canvas is static files with nothing behind them.
-  // So there the folders' comments load, and the store is never written back.
-  const dispose = !import.meta.env.DEV ? () => {} : editor.store.listen(
+  const dispose = editor.store.listen(
     ({ changes }) => {
       // Placed, not only created: a pin dragged onto a board arrives here as an update, and as a
       // bare point just like a new comment does — the comment tool's own hit-test looks straight
@@ -357,8 +427,11 @@ export function installCanvasComments(editor: Editor) {
   // and ones dropped out in open canvas, are left exactly as they are.
   anchorToNearbyBoard(editor, wanted);
 
+  const disposeHint = installCommentTargetHint(editor);
+
   return () => {
     dispose();
+    disposeHint();
     clearTimeout(pending);
   };
 }

--- a/canvas/src/canvasComments.ts
+++ b/canvas/src/canvasComments.ts
@@ -326,7 +326,10 @@ export function installCanvasComments(editor: Editor) {
     }
   };
 
-  const dispose = editor.store.listen(
+  // Only against a dev server, which is what a plugin install runs: the POST above is the only
+  // way a comment reaches the repo, and a built canvas is static files with nothing behind them.
+  // So there the folders' comments load, and the store is never written back.
+  const dispose = !import.meta.env.DEV ? () => {} : editor.store.listen(
     ({ changes }) => {
       // Placed, not only created: a pin dragged onto a board arrives here as an update, and as a
       // bare point just like a new comment does — the comment tool's own hit-test looks straight

--- a/canvas/src/canvasComments.ts
+++ b/canvas/src/canvasComments.ts
@@ -213,7 +213,12 @@ export function nearestBoard(editor: Editor, pageId: TLPageId, point: { x: numbe
 function installCommentTargetHint(editor: Editor) {
   const container = editor.getContainer();
   const update = () => {
-    if (editor.getCurrentToolId() !== "comment") return;
+    // Not a bare return: a tool change emits nothing, so this is the only pass that gets to drop
+    // the attribute the last hover set — otherwise the filled cursor shows again on the next entry.
+    if (editor.getCurrentToolId() !== "comment") {
+      container.removeAttribute("data-comment-target");
+      return;
+    }
     // ponytail: every board on the page, per pointer move. A page holds tens of them, so the
     // scan costs less than the cache that would keep it correct.
     const id = nearestBoard(
@@ -369,6 +374,16 @@ export function installCanvasComments(editor: Editor) {
     );
   };
 
+  // The same rule, over what the files already hold: a note written before its board existed —
+  // or from a tab predating this — is linked on the next load rather than left pinned to a page
+  // coordinate the next layout.json edit would strand it at. Threads already anchored to a shape,
+  // and ones dropped out in open canvas, are left exactly as they are.
+  //
+  // Before the baseline below, and before the listener: this is derived from the file every load,
+  // not an edit to it. Taking it as an edit would have a hosted visitor who touched nothing write
+  // the board into their browser, and every later deploy of that board would then be invisible.
+  anchorToNearbyBoard(editor, wanted);
+
   // What is on disk already, so the first real edit only writes the board it touched.
   const written = bodies();
 
@@ -420,12 +435,6 @@ export function installCanvasComments(editor: Editor) {
     },
     { source: "user", scope: "document" },
   );
-
-  // The same rule, over what the files already hold: a note written before its board existed —
-  // or from a tab predating this — is linked on the next load rather than left pinned to a page
-  // coordinate the next layout.json edit would strand it at. Threads already anchored to a shape,
-  // and ones dropped out in open canvas, are left exactly as they are.
-  anchorToNearbyBoard(editor, wanted);
 
   const disposeHint = installCommentTargetHint(editor);
 

--- a/canvas/src/canvasComments.ts
+++ b/canvas/src/canvasComments.ts
@@ -11,13 +11,13 @@ import { CANVAS_FILE_SHAPE_TYPE, type CanvasFileShape } from "./CanvasFileShapeU
 // Comments live in the board folder, as `<slug>/comments.json`, and go into Git with the boards.
 // That is the whole design decision: this canvas serves one repo, has no login and no sync
 // server, and a note on a mockup is only worth keeping next to the mockup it is about. So the
-// file is the source of truth and the tldraw store is a working copy of it — loaded over
-// whatever IndexedDB had, written back on every change.
+// file is the source of truth and the tldraw store is a working copy of it, loaded over
+// whatever IndexedDB had and written back on every change.
 //
 // Two things the records cannot carry into the file. Page ids are minted per browser (App.tsx
 // asks tldraw to create the page, tldraw hands out the id), so the folder slug plays that role
 // and the page id is re-attached on load. Author ids are made up here rather than issued by
-// anything, so each file also carries the names of the people in it — that is what turns an id
+// anything, so each file also carries the names of the people in it. That is what turns an id
 // back into a name in someone else's checkout.
 
 /** A board folder's comments.json. `records` carry no `pageId`: the folder is the page. */
@@ -30,10 +30,10 @@ export interface CommentsFile {
 type FileCommentRecord = Omit<TLCommentRecord, "pageId">;
 
 /**
- * Where a changed board's comments go. Against a dev server — what a plugin install runs — into
- * the board's folder as comments.json, so a review travels with the boards in Git. A built canvas
- * is static files with no repo behind them, so there they stay in this browser: the hosted canvas
- * gives commenting to try, not a place a review lands.
+ * Where a changed board's comments go. Against a dev server, which is what a plugin install runs,
+ * into the board's folder as comments.json, so a review travels with the boards in Git. A built
+ * canvas is static files with no repo behind them, so there they stay in this browser: the hosted
+ * canvas gives commenting to try, not a place a review lands.
  */
 const LOCAL_KEY = "super-prototyping-comments";
 
@@ -65,7 +65,8 @@ const USER_KEY = "super-prototyping-comment-user";
 
 const COMMENT_TYPES = new Set(["comment-thread", "comment", "comment-reaction"]);
 
-const isComment = (record: { typeName: string }) => COMMENT_TYPES.has(record.typeName);
+const isComment = (record: { typeName: string }): record is TLCommentRecord =>
+  COMMENT_TYPES.has(record.typeName);
 
 /**
  * Every comment record in the store. The comment types are registered records rather than part
@@ -99,7 +100,7 @@ export const GITHUB_PATH =
 
 /**
  * The login in whatever was typed: a handle, an `@handle`, or a pasted profile URL. Null when it
- * is not a GitHub username — GitHub's own rule, alphanumerics and single inner hyphens, 39 max.
+ * is not a GitHub username by GitHub's own rule, alphanumerics and single inner hyphens, 39 max.
  */
 export function githubLogin(input: string): string | null {
   const login = input
@@ -112,9 +113,9 @@ export function githubLogin(input: string): string | null {
 
 /**
  * The identity a login gives, avatar included. There is no account here and no directory, so the
- * handle is both the id and the display name — the one thing everyone reviewing this repo already
- * has, and the one that means the same in a pull request. The avatar needs no API: github.com
- * redirects `<login>.png` to it, which is also a URL worth reading in the committed JSON.
+ * handle is both the id and the display name. It is the one thing everyone reviewing this repo
+ * already has, and the one that means the same in a pull request. The avatar needs no API:
+ * github.com redirects `<login>.png` to it, which is also a URL worth reading in the committed JSON.
  */
 function githubUser(login: string): CommentUser {
   return {
@@ -125,10 +126,10 @@ function githubUser(login: string): CommentUser {
 }
 
 /**
- * Who a typed handle is, or null if GitHub will not serve an avatar for it — which catches the
+ * Who a typed handle is, or null if GitHub will not serve an avatar for it, which catches the
  * typo before it is committed and confirms the one thing this needs in the same request.
- * `api.github.com` answers the same question, but it rate-limits an unauthenticated caller hard
- * enough to 403 every check away, and a 403 is not a "no such user".
+ * `api.github.com` answers the same question, but it rate-limits an unauthenticated caller so
+ * hard that checks come back 403, and a 403 is not a "no such user".
  */
 export async function resolveGithubUser(input: string): Promise<CommentUser | null> {
   const login = githubLogin(input);
@@ -158,7 +159,7 @@ export function writeCommentUser(user: CommentUser) {
   try {
     localStorage.setItem(USER_KEY, JSON.stringify(user));
   } catch {
-    // A browser refusing storage still gets to comment; it just asks for the handle again later.
+    // A browser refusing storage still gets to comment; it asks for the handle again later.
   }
 }
 
@@ -173,7 +174,7 @@ export function distanceToBox(
 }
 
 /**
- * How far outside a board a comment still belongs to it, in page units — one column gap
+ * How far outside a board a comment still belongs to it, in page units: one column gap
  * (LIBRARY_GAP in App.tsx), so a note dropped in the margin beside a mockup attaches to it while
  * one dropped out in open canvas stays where it was put. Nearest board wins, so the gap between
  * two boards splits down the middle rather than being ambiguous.
@@ -203,7 +204,7 @@ export function nearestBoard(editor: Editor, pageId: TLPageId, point: { x: numbe
 /**
  * What a click would do, while the comment tool is up: the board the note would attach to gets
  * tldraw's own hint outline, and the bubble cursor fills in (index.css keys off the attribute).
- * Out in open canvas both go quiet, which is the honest answer — the note would stay a point.
+ * Out in open canvas neither shows, because the note would stay a point.
  *
  * On `event` rather than a pointer handler because the tool clears the hint on every move: its
  * hit-test looks straight through the boards, which are locked, so it finds nothing where
@@ -214,7 +215,7 @@ function installCommentTargetHint(editor: Editor) {
   const container = editor.getContainer();
   const update = () => {
     // Not a bare return: a tool change emits nothing, so this is the only pass that gets to drop
-    // the attribute the last hover set — otherwise the filled cursor shows again on the next entry.
+    // the attribute the last hover set. Otherwise the filled cursor shows again on the next entry.
     if (editor.getCurrentToolId() !== "comment") {
       container.removeAttribute("data-comment-target");
       return;
@@ -239,7 +240,7 @@ function installCommentTargetHint(editor: Editor) {
 /**
  * Re-anchor a freshly placed thread onto the board beside it. A shape anchor is a normalized
  * offset within the board's own bounds, unclamped both when it is recorded and when it is drawn,
- * so a pin in the margin keeps exactly the spot it was dropped on *and* rides the board when a
+ * so a pin in the margin keeps the spot it was dropped on *and* moves with the board when a
  * layout.json edit reflows the page. That is the point of doing this at all: the boards move, and
  * the notes about them should move with them.
  */
@@ -249,8 +250,8 @@ function anchorToNearbyBoard(editor: Editor, records: { typeName: string }[]) {
     if (record.typeName !== "comment-thread") continue;
     const thread = record as unknown as Extract<TLCommentRecord, { typeName: "comment-thread" }>;
     const anchor = thread.anchor;
-    // Anything but a bare point was resolved deliberately — by the tool's own hit-test, or by
-    // someone dragging the pin — and is left alone.
+    // Anything but a bare point was resolved deliberately, by the tool's own hit-test or by
+    // someone dragging the pin, and is left alone.
     if (anchor.type !== "point") continue;
     const shapeId = nearestBoard(editor, thread.pageId, anchor);
     if (!shapeId) continue;
@@ -261,9 +262,9 @@ function anchorToNearbyBoard(editor: Editor, records: { typeName: string }[]) {
 
 /**
  * The board a thread is linked to, or undefined for one left out in open canvas. The shape anchor
- * *is* the link — the comment tool records one for a comment placed on a mockup, and the function
- * above writes one for a comment placed beside it — so this only reads it back, for the surfaces
- * that show which mockup a note is about.
+ * *is* the link: the comment tool records one for a comment placed on a mockup, and the function
+ * above writes one for a comment placed beside it. So this only reads it back, for the parts of
+ * the UI that show which mockup a note is about.
  */
 export function linkedBoard(editor: Editor, anchor: TLCommentAnchor): CanvasFileShape | undefined {
   if (anchor.type !== "shape") return undefined;
@@ -273,7 +274,7 @@ export function linkedBoard(editor: Editor, anchor: TLCommentAnchor): CanvasFile
 
 /** The records of one board, as they go into Git: no page id, no tombstones, sorted by id. */
 export function commentsFileFor(records: TLCommentRecord[]): CommentsFile {
-  // Soft-deletes are left for a sync server to prune, and there is no server — so a delete drops
+  // Soft-deletes are left for a sync server to prune, and there is no server, so a delete drops
   // the record from the file here, and the next load takes it out of the store.
   const threads = new Set(
     records.filter((r) => r.typeName === "comment-thread" && !r.isDeleted).map((r) => r.id),
@@ -347,7 +348,7 @@ export function installCanvasComments(editor: Editor) {
     .map((record) => record.id);
 
   // As a remote change: this is not the user's own edit, it does not belong on their undo stack,
-  // and the listener below ignores it — so loading the file does not write it straight back.
+  // and the listener below ignores it, so loading the file does not write it straight back.
   editor.store.mergeRemoteChanges(() => {
     if (stale.length) editor.store.remove(stale as unknown as TLRecord["id"][]);
     if (wanted.length) editor.store.put(wanted as unknown as TLRecord[]);
@@ -374,8 +375,8 @@ export function installCanvasComments(editor: Editor) {
     );
   };
 
-  // The same rule, over what the files already hold: a note written before its board existed —
-  // or from a tab predating this — is linked on the next load rather than left pinned to a page
+  // The same rule, over what the files already hold: a note written before its board existed, or
+  // from a tab predating this, is linked on the next load rather than left pinned to a page
   // coordinate the next layout.json edit would strand it at. Threads already anchored to a shape,
   // and ones dropped out in open canvas, are left exactly as they are.
   //
@@ -409,7 +410,7 @@ export function installCanvasComments(editor: Editor) {
         localStorage.setItem(LOCAL_KEY, JSON.stringify(localFiles));
       } catch {
         // Storage full or refused. The comment stays on screen for this session and is lost on
-        // reload — the same deal every other thing this canvas keeps in the browser gets.
+        // reload, the same as everything else this canvas keeps in the browser.
       }
     }
   };
@@ -417,8 +418,8 @@ export function installCanvasComments(editor: Editor) {
   const dispose = editor.store.listen(
     ({ changes }) => {
       // Placed, not only created: a pin dragged onto a board arrives here as an update, and as a
-      // bare point just like a new comment does — the comment tool's own hit-test looks straight
-      // through the boards, which are locked shapes. Same rule for both, so the same call.
+      // bare point just like a new comment does, because the comment tool's own hit-test looks
+      // straight through the boards, which are locked shapes. Same rule for both, so the same call.
       const placed = [
         ...Object.values(changes.added),
         ...Object.values(changes.updated).map(([, next]) => next),

--- a/canvas/src/canvasLibrary.ts
+++ b/canvas/src/canvasLibrary.ts
@@ -26,14 +26,49 @@ export interface CanvasLibraryFile {
 }
 
 /**
+ * How far along a board is. `live` is the default — it matches the version being shipped —
+ * and it is the one status that draws no tab on the canvas: most boards on a finished page
+ * are live, and a tab on every one of them would say nothing while costing 134px of every
+ * row. The other two draw a coloured tab above the board.
+ *
+ * It is a tldraw shape the layout places, not markup in the board, so a board keeps no record
+ * of its own status and survives being regenerated when that status changes.
+ */
+export type CanvasBoardStatus = "exploring" | "outdated" | "live";
+
+/** The default: what a board is when neither its entry nor its folder says otherwise. */
+export const DEFAULT_BOARD_STATUS: CanvasBoardStatus = "live";
+
+/** Title Case for the badge and the menu, per Geist's own Badge copy rule. */
+export const BOARD_STATUS_LABEL: Record<CanvasBoardStatus, string> = {
+  exploring: "Exploring",
+  outdated: "Outdated",
+  live: "Live",
+};
+
+/** In menu order: what you are exploring, what it replaced, what shipped. */
+export const BOARD_STATUSES = Object.keys(
+  BOARD_STATUS_LABEL,
+) as CanvasBoardStatus[];
+
+/**
  * A row's file, either by name alone (uses that file's humanized title) or with a label
  * override. `w`/`h` override the 478 x 980 artboard for a board that is not phone-shaped,
  * a landscape banner say; a row is laid out at its first file's size, so give every file
  * in the row the same one.
+ *
+ * `status` overrides the folder's own `status` for this one board, including back to
+ * `live` to drop a tab the folder would otherwise give it.
  */
 export type CanvasLayoutFileEntry =
   | string
-  | { file: string; label?: string; w?: number; h?: number };
+  | {
+      file: string;
+      label?: string;
+      w?: number;
+      h?: number;
+      status?: CanvasBoardStatus;
+    };
 
 /** A button under a row that opens an address in a new tab. */
 export interface CanvasLayoutLink {
@@ -80,6 +115,12 @@ export interface CanvasLayoutConfig {
    * board that is not a phone, e.g. a full-bleed sheet: `[0, 0, 478, 980]`.
    */
   coverBox?: [number, number, number, number];
+  /**
+   * The status every board in this folder has unless its own entry says otherwise: the
+   * useful default on a folder that is one round of exploration, where saying it 70 times
+   * would be 70 chances to leave one board saying something else.
+   */
+  status?: CanvasBoardStatus;
   rows: CanvasLayoutRow[];
 }
 
@@ -108,6 +149,72 @@ function parse(path: string): CanvasLibraryFile | null {
     fileName,
     title: humanize(fileName),
   };
+}
+
+/**
+ * A board's status: its own entry's in layout.json, else its folder's, else `live`. Read from
+ * the layout by file name the same way the artboard size override is, so the board itself
+ * carries no record of it.
+ */
+export function boardStatusForPath(path: string): CanvasBoardStatus {
+  const file = parse(path);
+  if (!file) return DEFAULT_BOARD_STATUS;
+  const layout = readCanvasLayout(file.pageSlug);
+  let status = layout?.status;
+  for (const row of layout?.rows ?? []) {
+    for (const entry of row.files) {
+      if (typeof entry === "string" || entry.file !== file.fileName) continue;
+      if (entry.status) status = entry.status;
+    }
+  }
+  return status ?? DEFAULT_BOARD_STATUS;
+}
+
+/**
+ * The status a tab is drawn for, or undefined for the ones that draw none. `live` is the
+ * default and the majority, so it stays silent on the canvas and speaks only in the inspector,
+ * where there is one board on screen and the badge is also the control that changes it.
+ */
+export function boardTabStatusForPath(path: string) {
+  const status = boardStatusForPath(path);
+  return status === DEFAULT_BOARD_STATUS ? undefined : status;
+}
+
+/**
+ * Writes a board's status into its folder's layout.json, through the dev server (vite.config.ts).
+ * The server edits the one entry as text rather than reparsing the file, so hand formatting and
+ * key order survive; the write then lands in the module graph and reloads the page.
+ *
+ * Only the dev server can write. A built canvas is static files on a host with no repo behind
+ * them, which is why the badge is not a button there.
+ */
+export async function writeBoardStatus(path: string, status: CanvasBoardStatus) {
+  const file = parse(path);
+  if (!file) return false;
+  const response = await fetch("/__sp/board-status", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ slug: file.pageSlug, file: file.fileName, status }),
+  });
+  return response.ok;
+}
+
+/**
+ * Copies a canvas folder under a new name, through the dev server (vite.config.ts), and answers
+ * the slug it ended up with — the typed name is what the page is called, the slug is what the
+ * folder is called, and only the server knows the second one is free.
+ *
+ * Dev server only, like writeBoardStatus and for the same reason.
+ */
+export async function cloneCanvas(slug: string, name: string) {
+  const response = await fetch("/__sp/clone-canvas", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ slug, name }),
+  });
+  const body = await response.text();
+  if (!response.ok) throw new Error(body);
+  return JSON.parse(body).slug as string;
 }
 
 /** path -> raw HTML for every file fetched so far. Filled by loadCanvasFileHtml. */
@@ -168,11 +275,51 @@ export function useCanvasFileHtml(path: string): string | undefined {
 
 const LAYOUT_PATTERN = /canvases\/([^/]+)\/layout\.json$/;
 
+/**
+ * Window event fired once `layouts` holds an edit. The canvas lays itself out again on it
+ * (App.tsx) and the inspector re-reads the board's status (InspectorPanel.tsx) — between them,
+ * everything a layout.json change can move.
+ */
+export const LAYOUT_CHANGED = "sp:layout";
+
+/**
+ * The layouts. Starts as the generated module's own map and is replaced wholesale when that
+ * module re-executes, so a layout.json edit repaints the canvas instead of reloading the page.
+ * Callers read through readCanvasLayout rather than holding this, which is what lets it be
+ * swapped underneath them.
+ */
+let layouts: Record<string, CanvasLayoutConfig> = rawLayouts;
+
+if (import.meta.hot) {
+  // The status endpoint sends the layout.json it has just written, rather than leaving the page
+  // to hear about the write from the file watcher: the boards live outside the app's root, where
+  // the watcher misses changes, and a missed one meant the status only took effect on the next
+  // reload.
+  import.meta.hot.on(
+    "sp:board-status",
+    ({ slug, layout }: { slug: string; layout: CanvasLayoutConfig }) => {
+      const key = Object.keys(layouts).find((path) => LAYOUT_PATTERN.exec(path)?.[1] === slug);
+      if (!key) return;
+      layouts = { ...layouts, [key]: layout };
+      window.dispatchEvent(new Event(LAYOUT_CHANGED));
+    },
+  );
+
+  // The other way a layout.json changes is someone editing it. When the watcher does see that,
+  // virtual:canvases re-executes and hands its fresh layouts over here, because this module keeps
+  // the bindings of the *old* copy of it and would otherwise go on reading the layouts the page
+  // started with.
+  window.addEventListener("sp:canvases", (event) => {
+    layouts = (event as CustomEvent<Record<string, CanvasLayoutConfig>>).detail;
+    window.dispatchEvent(new Event(LAYOUT_CHANGED));
+  });
+}
+
 /** This board's layout.json, if it dropped one next to its HTML files. */
 export function readCanvasLayout(
   pageSlug: string,
 ): CanvasLayoutConfig | undefined {
-  for (const [path, config] of Object.entries(rawLayouts)) {
+  for (const [path, config] of Object.entries(layouts)) {
     if (LAYOUT_PATTERN.exec(path)?.[1] === pageSlug) return config;
   }
   return undefined;

--- a/canvas/src/canvasLibrary.ts
+++ b/canvas/src/canvasLibrary.ts
@@ -26,8 +26,8 @@ export interface CanvasLibraryFile {
 }
 
 /**
- * How far along a board is. `live` is the default — it matches the version being shipped —
- * and it is the one status that draws no tab on the canvas: most boards on a finished page
+ * How far along a board is. `live` is the default, the version being shipped, and it is the
+ * one status that draws no tab on the canvas: most boards on a finished page
  * are live, and a tab on every one of them would say nothing while costing 134px of every
  * row. The other two draw a coloured tab above the board.
  *
@@ -172,7 +172,7 @@ export function boardStatusForPath(path: string): CanvasBoardStatus {
 
 /**
  * The status a tab is drawn for, or undefined for the ones that draw none. `live` is the
- * default and the majority, so it stays silent on the canvas and speaks only in the inspector,
+ * default and the majority, so it draws nothing on the canvas and shows only in the inspector,
  * where there is one board on screen and the badge is also the control that changes it.
  */
 export function boardTabStatusForPath(path: string) {
@@ -183,7 +183,8 @@ export function boardTabStatusForPath(path: string) {
 /**
  * Writes a board's status into its folder's layout.json, through the dev server (vite.config.ts).
  * The server edits the one entry as text rather than reparsing the file, so hand formatting and
- * key order survive; the write then lands in the module graph and reloads the page.
+ * key order survive; it then sends the edited layout back over HMR (`sp:board-status`, below), and
+ * the canvas repaints without a reload.
  *
  * Only the dev server can write. A built canvas is static files on a host with no repo behind
  * them, which is why the badge is not a button there.
@@ -201,7 +202,7 @@ export async function writeBoardStatus(path: string, status: CanvasBoardStatus) 
 
 /**
  * Copies a canvas folder under a new name, through the dev server (vite.config.ts), and answers
- * the slug it ended up with — the typed name is what the page is called, the slug is what the
+ * the slug it ended up with. The typed name is what the page is called, the slug is what the
  * folder is called, and only the server knows the second one is free.
  *
  * Dev server only, like writeBoardStatus and for the same reason.
@@ -277,8 +278,8 @@ const LAYOUT_PATTERN = /canvases\/([^/]+)\/layout\.json$/;
 
 /**
  * Window event fired once `layouts` holds an edit. The canvas lays itself out again on it
- * (App.tsx) and the inspector re-reads the board's status (InspectorPanel.tsx) — between them,
- * everything a layout.json change can move.
+ * (App.tsx) and the inspector re-reads the board's status (InspectorPanel.tsx). Between them,
+ * that is everything a layout.json change can move.
  */
 export const LAYOUT_CHANGED = "sp:layout";
 

--- a/canvas/src/index.css
+++ b/canvas/src/index.css
@@ -5,6 +5,9 @@ body,
   height: 100%;
   margin: 0;
   overflow: hidden;
+  /* Nothing here scrolls, so any leftover horizontal overscroll is the browser's back gesture —
+     which is what a two-finger pan turns into anywhere tldraw does not get the wheel first. */
+  overscroll-behavior: none;
 }
 
 body {

--- a/canvas/src/index.css
+++ b/canvas/src/index.css
@@ -131,10 +131,43 @@ input.canvas-clone-name:focus {
   border-color: var(--tl-color-selected);
 }
 
+/* The comment cursor while a click here would attach the note to the mockup under it: the same
+   bubble tldraw ships, filled with the selection blue instead of white. The attribute is set by
+   installCommentTargetHint in canvasComments.ts, and the variable is otherwise only read while
+   the comment tool is up — so a stale attribute cannot show a cursor nobody asked for. */
+.tl-container[data-comment-target] {
+  --tl-cursor-comment:
+    url("data:image/svg+xml,<svg height='32' width='32' viewBox='0 0 32 32' xmlns='http://www.w3.org/2000/svg'><defs><filter id='shadow' y='-40%' x='-40%' width='180px' height='180%' color-interpolation-filters='sRGB'><feDropShadow dx='1' dy='1' stdDeviation='1.2' flood-opacity='.5'/></filter></defs><g filter='url(%23shadow)'><path d='M5 19.5 L5 11 A8 8 0 0 1 13 3 A8 8 0 0 1 21 11 A8 8 0 0 1 13 19 Z' fill='hsl(214, 84%, 56%)' stroke='white' stroke-width='1.5' stroke-linejoin='round'/></g></svg>")
+      5 19,
+    crosshair;
+}
+
+/* The handle field: the border sits on the input's row rather than the input, so the GitHub mark
+   tldraw lays out beside the text is inside it. */
+.canvas-gh-field .tlui-input__wrapper {
+  padding-left: var(--tl-space-4);
+  border: 1px solid var(--tl-color-low-border);
+  border-radius: var(--tl-radius-2);
+}
+
+.canvas-gh-field:focus-within .tlui-input__wrapper {
+  border-color: var(--tl-color-selected);
+}
+
+.canvas-gh-field svg {
+  flex-shrink: 0;
+  fill: var(--tl-color-text-3);
+}
+
 .canvas-clone-hint {
   font-size: 12px;
   line-height: 1.5;
   color: var(--tl-color-text-3);
+}
+
+/* The half of the sentence that decides whether someone types a name at all. */
+.canvas-clone-hint strong {
+  color: var(--tl-color-text-1);
 }
 
 /* The path is what the hint is for — cloning writes a folder into the project — so it is set
@@ -157,15 +190,6 @@ input.canvas-clone-name:focus {
 .canvas-clone-hint__error {
   margin-top: 4px;
   color: var(--tl-color-warning);
-}
-
-/* Who this browser comments as, in the top bar: their GitHub avatar, which is also the button
-   that changes the handle. Sized like the icons beside it. */
-.canvas-me {
-  width: 18px;
-  height: 18px;
-  border-radius: 50%;
-  background: var(--tl-color-muted-2);
 }
 
 /*
@@ -1365,4 +1389,25 @@ button.sp-status[aria-expanded="true"] .sp-status-chev {
   background: var(--sp-accent);
   font-weight: 500;
   cursor: pointer;
+}
+
+/* The dismiss on the placement composer (ComposerCloseButton in canvasChrome.tsx). A cross on the
+   bubble's top-right corner, outside the 300px field rather than crowding it. Two classes deep
+   because tldraw.css loads after this file and .tlui-button sizes its own buttons. */
+.tlui-cmt-canvas-composer .canvas-composer-close {
+  position: absolute;
+  top: -10px;
+  right: -10px;
+  width: 22px;
+  height: 22px;
+  min-width: 0;
+  min-height: 0;
+  padding: 0;
+  border-radius: 50%;
+  color: var(--tl-color-text-1);
+  background: var(--tl-color-panel);
+  box-shadow: var(--tl-shadow-2);
+}
+.tlui-cmt-canvas-composer .canvas-composer-close:hover {
+  background: var(--tl-color-muted-2);
 }

--- a/canvas/src/index.css
+++ b/canvas/src/index.css
@@ -5,7 +5,7 @@ body,
   height: 100%;
   margin: 0;
   overflow: hidden;
-  /* Nothing here scrolls, so any leftover horizontal overscroll is the browser's back gesture —
+  /* Nothing here scrolls, so any leftover horizontal overscroll is the browser's back gesture,
      which is what a two-finger pan turns into anywhere tldraw does not get the wheel first. */
   overscroll-behavior: none;
 }
@@ -119,7 +119,7 @@ button {
 }
 
 /*
- * The name field in the clone dialog (CloneCanvasDialog.tsx). tldraw's input is chromeless —
+ * The name field in the clone dialog (CloneCanvasDialog.tsx). tldraw's input is chromeless, since
  * everywhere it ships, the row or menu around it already draws the edge. A dialog body draws
  * none, so an unstyled field reads as a line of placeholder text rather than somewhere to type.
  */
@@ -137,7 +137,7 @@ input.canvas-clone-name:focus {
 /* The comment cursor while a click here would attach the note to the mockup under it: the same
    bubble tldraw ships, filled with the selection blue instead of white. The attribute is set by
    installCommentTargetHint in canvasComments.ts, and the variable is otherwise only read while
-   the comment tool is up — so a stale attribute cannot show a cursor nobody asked for. */
+   the comment tool is up, so a stale attribute cannot show a cursor nobody asked for. */
 .tl-container[data-comment-target] {
   --tl-cursor-comment:
     url("data:image/svg+xml,<svg height='32' width='32' viewBox='0 0 32 32' xmlns='http://www.w3.org/2000/svg'><defs><filter id='shadow' y='-40%' x='-40%' width='180px' height='180%' color-interpolation-filters='sRGB'><feDropShadow dx='1' dy='1' stdDeviation='1.2' flood-opacity='.5'/></filter></defs><g filter='url(%23shadow)'><path d='M5 19.5 L5 11 A8 8 0 0 1 13 3 A8 8 0 0 1 21 11 A8 8 0 0 1 13 19 Z' fill='hsl(214, 84%, 56%)' stroke='white' stroke-width='1.5' stroke-linejoin='round'/></g></svg>")
@@ -173,7 +173,7 @@ input.canvas-clone-name:focus {
   color: var(--tl-color-text-1);
 }
 
-/* The path is what the hint is for — cloning writes a folder into the project — so it is set
+/* The path is what the hint is for, since cloning writes a folder into the project, so it is set
    apart from the sentence introducing it rather than running on from it. */
 .canvas-clone-path {
   display: block;
@@ -279,7 +279,7 @@ input.canvas-clone-name:focus {
 /*
   Geist, at the published values of the steps this panel uses: 100-300 are component
   backgrounds, 400 a border, 700 a solid fill or a dot, 900-1000 text. They are spelled out
-  rather than imported because the canvas ships as a plugin — there is no design-system
+  rather than imported because the canvas ships as a plugin, and there is no design-system
   package on the other side of an install.
 */
 .sp-panel {
@@ -568,9 +568,9 @@ input.canvas-clone-name:focus {
 }
 
 /* Status. Top-left of the stage, and the badge is the control: click it for the menu. Geist's
-   subtle badge — tinted ground, a step-400 rule, step-900 text — because at 100% beside a single
-   board a solid fill out-shouts the board it labels. The tab out on the canvas is the same
-   status drawn solid, which is what a page read at 34% needs instead. */
+   subtle badge, tinted ground with a step-400 rule and step-900 text, because at 100% beside a
+   single board a solid fill competes with the board it labels. The tab out on the canvas is the
+   same status drawn solid, which is what a page read at 34% needs instead. */
 .sp-status-wrap {
   position: absolute;
   top: 10px;
@@ -661,7 +661,7 @@ button.sp-status:focus-visible {
 }
 
 /* Blue, not green: green is Geist's health colour, and this is not a check that passed. Blue is
-   what Vercel marks the deployment that is actually serving. */
+   what Vercel marks the deployment that is serving. */
 .sp-status--live {
   --bg: var(--ds-blue-100);
   --bg-2: var(--ds-blue-200);
@@ -1394,9 +1394,10 @@ button.sp-status[aria-expanded="true"] .sp-status-chev {
   cursor: pointer;
 }
 
-/* The dismiss on the placement composer (ComposerCloseButton in canvasChrome.tsx). A cross on the
-   bubble's top-right corner, outside the 300px field rather than crowding it. Two classes deep
-   because tldraw.css loads after this file and .tlui-button sizes its own buttons. */
+/* The dismiss on the placement composer, which InFrontOfTheCanvas in canvasChrome.tsx portals
+   into it. A cross on the bubble's top-right corner, outside the 300px field rather than
+   crowding it. Two classes deep because tldraw.css loads after this file and .tlui-button sizes
+   its own buttons. */
 .tlui-cmt-canvas-composer .canvas-composer-close {
   position: absolute;
   top: -10px;

--- a/canvas/src/index.css
+++ b/canvas/src/index.css
@@ -116,6 +116,59 @@ button {
 }
 
 /*
+ * The name field in the clone dialog (CloneCanvasDialog.tsx). tldraw's input is chromeless —
+ * everywhere it ships, the row or menu around it already draws the edge. A dialog body draws
+ * none, so an unstyled field reads as a line of placeholder text rather than somewhere to type.
+ */
+/* Tag-qualified so it outranks .tlui-input, which zeroes the border and the left padding. */
+input.canvas-clone-name {
+  padding-left: var(--tl-space-4);
+  border: 1px solid var(--tl-color-low-border);
+  border-radius: var(--tl-radius-2);
+}
+
+input.canvas-clone-name:focus {
+  border-color: var(--tl-color-selected);
+}
+
+.canvas-clone-hint {
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--tl-color-text-3);
+}
+
+/* The path is what the hint is for — cloning writes a folder into the project — so it is set
+   apart from the sentence introducing it rather than running on from it. */
+.canvas-clone-path {
+  display: block;
+  margin-top: 4px;
+  padding: 5px 7px;
+  border-radius: var(--tl-radius-1);
+  background: var(--tl-color-muted-2);
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  /* An absolute path is longer than the dialog is wide, and it is only useful unabbreviated. */
+  overflow-wrap: anywhere;
+}
+
+.canvas-clone-path b {
+  color: var(--tl-color-text-1);
+}
+
+.canvas-clone-hint__error {
+  margin-top: 4px;
+  color: var(--tl-color-warning);
+}
+
+/* Who this browser comments as, in the top bar: their GitHub avatar, which is also the button
+   that changes the handle. Sized like the icons beside it. */
+.canvas-me {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: var(--tl-color-muted-2);
+}
+
+/*
  * The no-boards notice (EmptyLibraryNotice in App.tsx). It names the directory the canvas
  * resolved, because an empty grid and a canvas pointed at the wrong folder look identical.
  * pointer-events stay off the panel so it can never sit between a cursor and the toolbar; only
@@ -196,22 +249,53 @@ button {
   min-width: 0;
 }
 
+/*
+  Geist, at the published values of the steps this panel uses: 100-300 are component
+  backgrounds, 400 a border, 700 a solid fill or a dot, 900-1000 text. They are spelled out
+  rather than imported because the canvas ships as a plugin — there is no design-system
+  package on the other side of an install.
+*/
 .sp-panel {
-  --sp-line: #e6e6e6;
-  --sp-text: #1e1e1e;
-  --sp-text-2: #7a7a7a;
-  --sp-field: #f5f5f5;
-  --sp-hover: #f5f5f5;
-  --sp-sel: #e5f4ff;
-  --sp-accent: #0d99ff;
-  --sp-mono: ui-monospace, "SF Mono", Menlo, monospace;
+  --ds-gray-100: #f2f2f2;
+  --ds-gray-200: #ebebeb;
+  --ds-gray-300: #e6e6e6;
+  --ds-gray-400: #ebebeb;
+  --ds-gray-700: #8f8f8f;
+  --ds-gray-900: #4d4d4d;
+  --ds-gray-1000: #171717;
+  --ds-blue-100: #f0f7ff;
+  --ds-blue-200: #ebf5ff;
+  --ds-blue-300: #e0f0ff;
+  --ds-blue-400: #cce6ff;
+  --ds-blue-700: #0072f5;
+  --ds-blue-900: #0068d6;
+  --ds-amber-100: #fff6e6;
+  --ds-amber-200: #fff4d6;
+  --ds-amber-300: #fef0cd;
+  --ds-amber-400: #ffdd8f;
+  --ds-amber-700: #ffb224;
+  --ds-amber-900: #a35200;
+  --ds-shadow-menu:
+    0 0 0 1px #00000014, 0 1px 1px #00000005, 0 4px 8px -4px #0000000a,
+    0 16px 24px -8px #0000000f;
+  --ds-focus-ring: 0 0 0 2px #ffffff, 0 0 0 4px var(--ds-blue-700);
+
+  --sp-line: var(--ds-gray-400);
+  --sp-text: var(--ds-gray-1000);
+  --sp-text-2: var(--ds-gray-700);
+  --sp-field: #fafafa;
+  --sp-hover: var(--ds-gray-100);
+  --sp-sel: var(--ds-blue-100);
+  --sp-accent: var(--ds-blue-700);
+  --sp-mono: "Geist Mono", ui-monospace, "SF Mono", Menlo, monospace;
   display: flex;
   flex: 0 0 auto;
   height: 100%;
   border-left: 1px solid var(--sp-line);
   background: #ffffff;
   color: var(--sp-text);
-  font: 400 11px/16px Inter, ui-sans-serif, system-ui, -apple-system, sans-serif;
+  font: 400 12px/16px Geist, Inter, ui-sans-serif, system-ui, -apple-system, sans-serif;
+  letter-spacing: -0.01em;
   font-variant-numeric: tabular-nums;
   -webkit-font-smoothing: antialiased;
   user-select: none;
@@ -227,11 +311,19 @@ button {
   text-align: left;
 }
 
-/* Preview */
+/* Preview: the board, and the comments on it underneath */
+.sp-preview {
+  flex: 1 1 auto;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+}
+
 .sp-stage {
   position: relative;
   flex: 1 1 auto;
   min-width: 0;
+  min-height: 0;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -303,8 +395,45 @@ button {
 }
 
 .sp-board {
+  position: relative;
   flex: 0 0 auto;
   transform-origin: center;
+}
+
+/* Pins. The wrapper is a zero-size point at the anchor's fraction of the board, so the pin needs
+   no arithmetic to be placed; the pin then counter-scales off that point, which is why it is a
+   second element and why its origin is the corner it hangs from. */
+.sp-pin-at {
+  position: absolute;
+  width: 0;
+  height: 0;
+}
+
+.sp-panel .sp-pin {
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  min-width: 22px;
+  height: 22px;
+  padding: 0 6px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 11px 11px 11px 2px;
+  transform-origin: 0 100%;
+  color: #ffffff;
+  background: var(--sp-accent);
+  box-shadow: 0 1px 4px #00000040;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.sp-panel .sp-pin--done {
+  background: var(--ds-gray-700);
+}
+
+.sp-panel .sp-pin.on {
+  box-shadow: 0 0 0 2px #ffffff, 0 1px 4px #00000040;
 }
 
 .sp-zoom {
@@ -317,17 +446,18 @@ button {
 
 .sp-collapse {
   position: absolute;
-  top: 8px;
-  right: 8px;
-  width: 24px;
-  height: 24px;
+  top: 10px;
+  right: 10px;
+  width: 26px;
+  height: 26px;
   display: flex;
   align-items: center;
   justify-content: center;
-  border-radius: 4px;
+  border-radius: 6px;
   color: var(--sp-text-2);
   background: #ffffff;
   box-shadow: 0 0 0 1px var(--sp-line);
+  cursor: pointer;
 }
 
 .sp-collapse:hover {
@@ -403,10 +533,183 @@ button {
 }
 
 .sp-head-name {
-  font-weight: 600;
+  font-size: 13px;
+  font-weight: 500;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+/* Status. Top-left of the stage, and the badge is the control: click it for the menu. Geist's
+   subtle badge — tinted ground, a step-400 rule, step-900 text — because at 100% beside a single
+   board a solid fill out-shouts the board it labels. The tab out on the canvas is the same
+   status drawn solid, which is what a page read at 34% needs instead. */
+.sp-status-wrap {
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  z-index: 2;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+/* Next to the badge, for ten seconds after a click. Neutral rather than coloured: it is not a
+   fourth status, and it has to read the same whichever of the three it sits beside. */
+.sp-status-undo {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  height: 26px;
+  padding: 0 10px;
+  border: 1px solid var(--ds-gray-400);
+  border-radius: 9999px;
+  background: #fff;
+  color: var(--ds-gray-1000);
+  font: inherit;
+  font-weight: 500;
+  cursor: pointer;
+  box-shadow: 0 0 0 1px #ffffffa8;
+  transition: background 0.12s ease;
+}
+
+.sp-status-undo:hover {
+  background: var(--ds-gray-100);
+}
+
+.sp-status-undo:focus-visible {
+  outline: none;
+  box-shadow: var(--ds-focus-ring);
+}
+
+.sp-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 26px;
+  padding: 0 8px 0 10px;
+  border: 1px solid var(--bd);
+  border-radius: 9999px;
+  background: var(--bg);
+  color: var(--fg);
+  font-weight: 500;
+  /* Against a board that may be any colour at all, not a drop shadow. */
+  box-shadow: 0 0 0 1px #ffffffa8;
+  transition: background 0.12s ease;
+}
+
+button.sp-status {
+  cursor: pointer;
+}
+
+button.sp-status:hover {
+  background: var(--bg-2);
+}
+
+button.sp-status[aria-expanded="true"] {
+  background: var(--bg-3);
+}
+
+button.sp-status:focus-visible {
+  outline: none;
+  box-shadow: var(--ds-focus-ring);
+}
+
+.sp-status--exploring {
+  --bg: var(--ds-amber-100);
+  --bg-2: var(--ds-amber-200);
+  --bg-3: var(--ds-amber-300);
+  --bd: var(--ds-amber-400);
+  --fg: var(--ds-amber-900);
+  --dot: var(--ds-amber-700);
+}
+
+.sp-status--outdated {
+  --bg: var(--ds-gray-100);
+  --bg-2: var(--ds-gray-200);
+  --bg-3: var(--ds-gray-300);
+  --bd: var(--ds-gray-400);
+  --fg: var(--ds-gray-900);
+  --dot: var(--ds-gray-700);
+}
+
+/* Blue, not green: green is Geist's health colour, and this is not a check that passed. Blue is
+   what Vercel marks the deployment that is actually serving. */
+.sp-status--live {
+  --bg: var(--ds-blue-100);
+  --bg-2: var(--ds-blue-200);
+  --bg-3: var(--ds-blue-300);
+  --bd: var(--ds-blue-400);
+  --fg: var(--ds-blue-900);
+  --dot: var(--ds-blue-700);
+}
+
+.sp-status-dot {
+  flex: none;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--dot);
+}
+
+.sp-status-chev {
+  flex: none;
+  opacity: 0.6;
+  transition: transform 0.15s ease;
+}
+
+button.sp-status[aria-expanded="true"] .sp-status-chev {
+  transform: rotate(180deg);
+}
+
+.sp-menu {
+  position: absolute;
+  top: 32px;
+  left: 0;
+  width: 196px;
+  padding: 6px;
+  border-radius: 12px;
+  background: #ffffff;
+  box-shadow: var(--ds-shadow-menu);
+}
+
+.sp-menu-row {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  width: 100%;
+  height: 32px;
+  padding: 0 8px;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.sp-menu-row:hover {
+  background: var(--sp-hover);
+}
+
+.sp-menu-ck {
+  flex: none;
+  margin-left: auto;
+  color: var(--sp-text-2);
+}
+
+/* Says which file the click is about to edit, because it edits a file in the user's repo. */
+.sp-menu-foot {
+  margin: 6px -6px 0;
+  padding: 7px 14px 1px;
+  border-top: 1px solid var(--sp-line);
+  color: var(--sp-text-2);
+}
+
+.sp-menu-foot code {
+  font-family: var(--sp-mono);
+}
+
+.sp-status-err {
+  display: block;
+  margin-top: 6px;
+  color: #cb2a2f;
 }
 
 .sp-head-dim {
@@ -421,8 +724,9 @@ button {
   display: flex;
   align-items: center;
   justify-content: center;
-  border-radius: 5px;
+  border-radius: 6px;
   color: var(--sp-text-2);
+  cursor: pointer;
 }
 
 .sp-head-x:hover {
@@ -440,15 +744,22 @@ button {
 }
 
 .sp-tabs button {
-  height: 32px;
-  padding: 0 8px;
+  height: 24px;
+  padding: 0 10px;
+  border-radius: 6px;
   color: var(--sp-text-2);
   font-weight: 500;
+  cursor: pointer;
+}
+
+.sp-tabs button:hover {
+  background: var(--sp-hover);
+  color: var(--sp-text);
 }
 
 .sp-tabs button.on {
+  background: var(--sp-hover);
   color: var(--sp-text);
-  font-weight: 600;
 }
 
 .sp-tab {
@@ -551,6 +862,11 @@ button {
 
 .sp-layer.on {
   background: var(--sp-sel);
+  color: var(--ds-blue-900);
+}
+
+.sp-layer.on svg {
+  color: inherit;
 }
 
 .sp-layer-n {
@@ -582,12 +898,13 @@ button {
 }
 
 .sp-field {
-  height: 24px;
+  height: 28px;
   display: flex;
   align-items: center;
   gap: 8px;
   padding: 0 8px;
-  border-radius: 5px;
+  border: 1px solid var(--sp-line);
+  border-radius: 6px;
   background: var(--sp-field);
 }
 
@@ -881,4 +1198,171 @@ button {
 
 .sp-token-note code {
   font-family: var(--sp-mono);
+}
+
+/* Comments, under the preview */
+.sp-notes {
+  flex: 0 0 auto;
+  max-height: 45%;
+  display: flex;
+  flex-direction: column;
+  background: #ffffff;
+  border-top: 1px solid var(--sp-line);
+}
+
+.sp-notes-list {
+  flex: 0 1 auto;
+  min-height: 0;
+  overflow: auto;
+}
+
+.sp-note {
+  padding: 2px 12px 8px;
+  border-bottom: 1px solid var(--sp-line);
+}
+
+.sp-note--done {
+  color: var(--sp-text-2);
+}
+
+.sp-panel .sp-note-head {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  height: 24px;
+  cursor: pointer;
+}
+
+.sp-note-n {
+  flex: none;
+  width: 16px;
+  height: 16px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 8px;
+  color: #ffffff;
+  background: var(--sp-accent);
+  font-size: 10px;
+  font-weight: 600;
+}
+
+/* A thread anchored beside the board rather than on it: numbered like the rest, but there is no
+   pin out on the preview for that number to match. */
+.sp-note-n--off {
+  color: var(--sp-text-2);
+  background: var(--ds-gray-300);
+}
+
+.sp-note-av {
+  flex: none;
+  width: 16px;
+  height: 16px;
+  border-radius: 8px;
+  background: var(--ds-gray-300);
+}
+
+.sp-note-who {
+  font-weight: 500;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.sp-note-when {
+  flex: none;
+  color: var(--sp-text-2);
+}
+
+.sp-note-count {
+  margin-left: auto;
+  flex: none;
+  color: var(--sp-text-2);
+  font-family: var(--sp-mono);
+}
+
+.sp-note-body {
+  margin: 0;
+  padding-left: 22px;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  user-select: text;
+}
+
+.sp-note-body--clamp {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  overflow: hidden;
+}
+
+.sp-note-reply {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  padding-top: 6px;
+}
+
+.sp-note-reply .sp-note-body,
+.sp-note-reply .sp-note-actions,
+.sp-note-reply .sp-note-new {
+  flex-basis: 100%;
+  padding-left: 0;
+}
+
+.sp-note-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+  padding: 6px 0 0;
+}
+
+.sp-note-actions button {
+  color: var(--sp-text-2);
+  cursor: pointer;
+}
+
+.sp-note-actions button:hover:enabled {
+  color: var(--sp-accent);
+}
+
+.sp-note-new {
+  flex: none;
+  display: flex;
+  align-items: flex-start;
+  gap: 6px;
+  padding: 8px 12px;
+  border-top: 1px solid var(--sp-line);
+}
+
+.sp-note-new textarea {
+  flex: 1;
+  min-width: 0;
+  max-height: 88px;
+  padding: 4px 6px;
+  border: 1px solid var(--sp-line);
+  border-radius: 6px;
+  background: var(--sp-field);
+  color: inherit;
+  font: inherit;
+  resize: none;
+  field-sizing: content;
+  user-select: text;
+}
+
+.sp-note-new textarea:focus {
+  outline: none;
+  border-color: var(--sp-accent);
+}
+
+.sp-panel .sp-note-send {
+  flex: none;
+  padding: 4px 8px;
+  border-radius: 6px;
+  color: #ffffff;
+  background: var(--sp-accent);
+  font-weight: 500;
+  cursor: pointer;
 }

--- a/canvas/src/inspectorAgent.ts
+++ b/canvas/src/inspectorAgent.ts
@@ -314,9 +314,9 @@ function addAsset(i,uri,via,el){var c=uri.indexOf(','),payload=uri.slice(c+1),k=
 
 /* An inline <svg> is an asset too, keyed by its geometry rather than its bytes: the generators'
    icon() writes class, style and preserveAspectRatio into the root tag on the way in, so the
-   board's markup is never the file's. The copy handed out stands alone — the colours the cascade
-   supplied (currentColor, var(), a fill from a stylesheet) are written in, and xmlns is added
-   where a literal icon had none — so an <img> in the parent draws it and Figma accepts it. */
+   board's markup is never the file's. The copy handed out is self-contained: the colours the
+   cascade supplied (currentColor, var(), a fill from a stylesheet) are written in, and xmlns is
+   added where a literal icon had none, so an <img> in the parent draws it and Figma accepts it. */
 function addSvg(i,el){
   if(!el.querySelector('path,rect,circle,ellipse,line,polygon,polyline,text,image,use'))return;
   var c=el.cloneNode(true),cs=getComputedStyle(el),inner=c.querySelectorAll('[data-sp]'),n;
@@ -345,7 +345,7 @@ function addSvg(i,el){
 /* No board writes a title on its icons, so with no file to name one the name is a guess from
    context: the accessible name if there is one; else a class, when it is a word (logo, aiface)
    and not a generator's abbreviation (i, mk); else a caption, which is the one short leaf of text
-   beside the icon within two ancestors — the span under a tab icon, the label in a chip. A clock,
+   beside the icon within two ancestors, the span under a tab icon or the label in a chip. A clock,
    a keyboard row, a whole composer or a screen of text is not a caption: the icon stays nameless.
    ponytail: two ancestors and one leaf sibling is the ceiling; a <title> in the svg beats it. */
 function svgLabel(el){var t=el.querySelector('title'),c=(el.getAttribute('class')||'').split(/\s+/)[0],p=el.parentElement,d,k,n,s,one;
@@ -426,7 +426,7 @@ document.addEventListener('mouseleave',function(){lastHover=null;hover(null);par
 
 /**
  * The whole tag, as spliced into a board. Exported for the tests and the Playwright sweeps. The
- * signature function rides along as its own source: it has no outer references, so the text is
+ * signature function goes in as its own source: it has no outer references, so the text is
  * the same function whether the bundle was minified or not.
  */
 export const AGENT =

--- a/canvas/src/inspectorModel.test.ts
+++ b/canvas/src/inspectorModel.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, it } from "vitest";
+import type { TLCommentAnchor, TLShapeId } from "tldraw";
 import type { SpAsset, SpNode, SpToken } from "./inspectorAgent";
 import type { AssetRow } from "./inspectorModel";
 import {
   assetForNode,
   assetRows,
+  boardPin,
+  newBoardPin,
   fitScale,
   initialLayersH,
   layersBounds,
@@ -285,5 +288,39 @@ describe("assetForNode", () => {
   it("takes the first row when one layer draws two images, as the layer name does", () => {
     const both = [{ key: "bg", uses: [2] }, { key: "fg", uses: [2] }] as unknown as AssetRow[];
     expect(assetForNode(both, 2)?.key).toBe("bg");
+  });
+});
+
+describe("boardPin", () => {
+  const shapeId = "shape:board" as TLShapeId;
+  const at = (x: number, y: number, id = shapeId): TLCommentAnchor => ({
+    type: "shape",
+    shapeId: id,
+    x,
+    y,
+    isPrecise: true,
+  });
+
+  it("is null for a thread anchored to another board, or to no board at all", () => {
+    expect(boardPin(at(0.5, 0.5, "shape:other" as TLShapeId), shapeId)).toBeNull();
+    expect(boardPin({ type: "point", x: 10, y: 20 }, shapeId)).toBeNull();
+  });
+
+  it("keeps a thread dropped beside the board, and says it is not on it", () => {
+    expect(boardPin(at(0.25, 0.75), shapeId)).toEqual({ x: 0.25, y: 0.75, inside: true });
+    expect(boardPin(at(-0.1, 0.5), shapeId)).toEqual({ x: -0.1, y: 0.5, inside: false });
+    expect(boardPin(at(0.5, 1.4), shapeId)).toEqual({ x: 0.5, y: 1.4, inside: false });
+  });
+});
+
+describe("newBoardPin", () => {
+  const board = { w: 400, h: 1000 };
+
+  it("pins to the middle of the board when nothing is selected", () => {
+    expect(newBoardPin(null, board)).toEqual({ x: 0.5, y: 0.5 });
+  });
+
+  it("pins to the middle of the selected layer", () => {
+    expect(newBoardPin({ x: 100, y: 200, w: 200, h: 100 }, board)).toEqual({ x: 0.5, y: 0.25 });
   });
 });

--- a/canvas/src/inspectorModel.ts
+++ b/canvas/src/inspectorModel.ts
@@ -2,7 +2,8 @@
  * What the inspector panel derives from an agent report before drawing it. Pure functions, so
  * the joins and fallbacks are testable without a frame.
  */
-import type { SpAsset, SpGroup, SpNode, SpToken, SpTokenKind } from "./inspectorAgent";
+import type { TLCommentAnchor, TLShapeId } from "tldraw";
+import type { SpAsset, SpBox, SpGroup, SpNode, SpToken, SpTokenKind } from "./inspectorAgent";
 
 /**
  * Where an asset's name came from, so a fallback is never passed off as a file name: `alt` is an
@@ -193,7 +194,7 @@ export const assetForNode = (rows: AssetRow[], node: number | null): AssetRow | 
 
 /** Starting sizes. Every one of them is a drag away from something else. */
 export const PANEL_W = 736;
-export const RAIL_W = 280;
+export const RAIL_W = 300;
 
 /**
  * How tall the layers list opens: a share of the window rather than a constant, because the
@@ -258,3 +259,30 @@ export const fitScale = (stage: { w: number; h: number }, board: { w: number; h:
   const pad = 32;
   return Math.max(0.05, Math.min(1, (stage.w - pad) / board.w, (stage.h - pad) / board.h));
 };
+
+/**
+ * Where a comment thread points on a board, when it is that board's thread at all. Normalized
+ * (0–1) within the artboard, and left unclamped: a pin dropped in the margin beside the mockup
+ * belongs to it — that is what anchors it to the board through a layout.json reflow — but the
+ * preview only draws the ones that land on the board itself.
+ */
+export interface BoardPin {
+  x: number;
+  y: number;
+  inside: boolean;
+}
+
+export function boardPin(anchor: TLCommentAnchor, shapeId: TLShapeId): BoardPin | null {
+  if (anchor.type !== "shape" || anchor.shapeId !== shapeId) return null;
+  const inside = anchor.x >= 0 && anchor.x <= 1 && anchor.y >= 0 && anchor.y <= 1;
+  return { x: anchor.x, y: anchor.y, inside };
+}
+
+/**
+ * Where a comment written in the panel is pinned: on the middle of the selected layer, so a note
+ * about one button lands on that button, and on the middle of the board when nothing is selected.
+ */
+export function newBoardPin(box: SpBox | null | undefined, board: { w: number; h: number }) {
+  if (!box) return { x: 0.5, y: 0.5 };
+  return { x: (box.x + box.w / 2) / board.w, y: (box.y + box.h / 2) / board.h };
+}

--- a/canvas/src/inspectorModel.ts
+++ b/canvas/src/inspectorModel.ts
@@ -11,6 +11,10 @@ import type { SpAsset, SpBox, SpGroup, SpNode, SpToken, SpTokenKind } from "./in
  */
 export type AssetNameSource = "file" | "alt" | "label" | "none";
 
+/** Class names, skipping the falsy ones. Here rather than in either panel file: both draw with
+ *  it, and a component module cannot export it without costing fast refresh. */
+export const cx = (...parts: (string | false | null | undefined)[]) => parts.filter(Boolean).join(" ");
+
 export interface AssetRow {
   key: string;
   name: string;
@@ -262,8 +266,8 @@ export const fitScale = (stage: { w: number; h: number }, board: { w: number; h:
 
 /**
  * Where a comment thread points on a board, when it is that board's thread at all. Normalized
- * (0–1) within the artboard, and left unclamped: a pin dropped in the margin beside the mockup
- * belongs to it — that is what anchors it to the board through a layout.json reflow — but the
+ * (0 to 1) within the artboard, and left unclamped: a pin dropped in the margin beside the mockup
+ * belongs to it, which is what anchors it to the board through a layout.json reflow, but the
  * preview only draws the ones that land on the board itself.
  */
 export interface BoardPin {

--- a/canvas/src/svgSignature.test.ts
+++ b/canvas/src/svgSignature.test.ts
@@ -40,7 +40,7 @@ describe("svgSignature", () => {
     expect(svgSignature(u.replace("#a", "#b"))).not.toBe(svgSignature(u));
   });
 
-  it("rides in the agent as its own source, so the frame keys a vector as the index does", () => {
+  it("is in the agent as its own source, so the frame keys a vector as the index does", () => {
     expect(AGENT).toContain("<script>var svgSignature=function");
     expect(AGENT).toContain("svg:'+fnv(svgSignature(");
   });

--- a/canvas/src/tldraw-local-store.d.ts
+++ b/canvas/src/tldraw-local-store.d.ts
@@ -1,0 +1,19 @@
+import type { TLStoreOptions, TLStoreWithStatus } from "tldraw";
+
+/**
+ * `useLocalStore` is the hook `<Tldraw persistenceKey>` uses internally to build its store and
+ * keep it in IndexedDB. It is exported at runtime from `@tldraw/editor`, and so from `tldraw`,
+ * which re-exports that package wholesale — but it is marked "Excluded from this release type",
+ * so it ships without a declaration. Hence this one.
+ *
+ * App.tsx needs it because the comment record types have to be registered on the store
+ * (`records: commentSchemaRecords`) and `<Tldraw>` takes no `records` prop: it destructures a
+ * fixed list of options on its way to building the store. Calling the hook directly keeps the
+ * IndexedDB persistence exactly as it was — the alternative, `createTLStore` plus hand-rolled
+ * snapshot saving, would reimplement it.
+ */
+declare module "tldraw" {
+  export function useLocalStore(
+    options: TLStoreOptions & { persistenceKey?: string; sessionId?: string },
+  ): TLStoreWithStatus;
+}

--- a/canvas/src/tldraw-local-store.d.ts
+++ b/canvas/src/tldraw-local-store.d.ts
@@ -3,13 +3,13 @@ import type { TLStoreOptions, TLStoreWithStatus } from "tldraw";
 /**
  * `useLocalStore` is the hook `<Tldraw persistenceKey>` uses internally to build its store and
  * keep it in IndexedDB. It is exported at runtime from `@tldraw/editor`, and so from `tldraw`,
- * which re-exports that package wholesale — but it is marked "Excluded from this release type",
+ * which re-exports that package wholesale, but it is marked "Excluded from this release type",
  * so it ships without a declaration. Hence this one.
  *
  * App.tsx needs it because the comment record types have to be registered on the store
  * (`records: commentSchemaRecords`) and `<Tldraw>` takes no `records` prop: it destructures a
  * fixed list of options on its way to building the store. Calling the hook directly keeps the
- * IndexedDB persistence exactly as it was — the alternative, `createTLStore` plus hand-rolled
+ * IndexedDB persistence exactly as it was. The alternative, `createTLStore` plus hand-rolled
  * snapshot saving, would reimplement it.
  */
 declare module "tldraw" {

--- a/canvas/src/virtual-canvases.d.ts
+++ b/canvas/src/virtual-canvases.d.ts
@@ -15,6 +15,7 @@
  * every shape in an existing document.
  */
 declare module "virtual:canvases" {
+  import type { CommentsFile } from "./canvasComments";
   import type { CanvasLayoutConfig } from "./canvasLibrary";
 
   /** Board HTML, one lazy chunk per file, fetched when a shape first shows it. */
@@ -38,6 +39,14 @@ declare module "virtual:canvases" {
    * the dev server's own environment.
    */
   export const canvasesDir: string;
+
+  /**
+   * Each folder's comments.json, keyed by slug — the canvas's own comments, which live with the
+   * boards in Git rather than in a sync server. Inlined rather than imported, so writing one back
+   * (canvasComments.ts posts to `/__sp/comments`) does not reload the page through the module
+   * graph while its composer is still open. Missing for a folder nobody has commented on.
+   */
+  export const rawComments: Record<string, CommentsFile>;
 
   /**
    * Suffix that keeps two projects' documents apart, `":<hash>"` or `""`. Every canvas runs on

--- a/canvas/src/virtual-canvases.d.ts
+++ b/canvas/src/virtual-canvases.d.ts
@@ -41,7 +41,7 @@ declare module "virtual:canvases" {
   export const canvasesDir: string;
 
   /**
-   * Each folder's comments.json, keyed by slug — the canvas's own comments, which live with the
+   * Each folder's comments.json, keyed by slug: the canvas's own comments, which live with the
    * boards in Git rather than in a sync server. Inlined rather than imported, so writing one back
    * (canvasComments.ts posts to `/__sp/comments`) does not reload the page through the module
    * graph while its composer is still open. Missing for a folder nobody has commented on.

--- a/canvas/vite.config.ts
+++ b/canvas/vite.config.ts
@@ -247,7 +247,6 @@ function scan(dir: string): Board[] {
  * `import.meta.glob` is itself only a Vite codegen macro, so generating the same three maps by
  * hand costs nothing downstream and buys a directory that can be chosen at run time.
  */
-
 function canvasesSource(): Plugin {
   let isBuild = false;
 
@@ -336,7 +335,7 @@ function canvasesSource(): Plugin {
         // away the tldraw document, the open panel and the viewport, to change one word.
         //
         // Self-accepting stops that walk. This module is re-executed with the new JSON while the
-        // page stays up, and announces its fresh layouts — importers hold the *old* module's
+        // page stays up, and announces its fresh layouts. Importers hold the *old* module's
         // bindings, so the new data has to be handed over rather than read. canvasLibrary.ts
         // listens, and is the only reader. Fires on first execution too, before anything is
         // listening, which is the same no-op as any event with no handler.
@@ -422,8 +421,8 @@ function canvasesSource(): Plugin {
         server.ws.send({ type: "full-reload" });
       };
 
-      // Canvas comments, written back into the board folder so they travel with it in Git —
-      // this is a repo-local review tool, not a synced document, and a comment on a mockup is
+      // Canvas comments, written back into the board folder so they travel with it in Git.
+      // This is a repo-local review tool, not a synced document, and a comment on a mockup is
       // only worth anything next to the mockup it is about. Dev server only, like the two
       // endpoints around it.
       server.middlewares.use("/__sp/comments", (req, res, next) => {
@@ -466,8 +465,8 @@ function canvasesSource(): Plugin {
       });
 
       // Cloning a canvas, from the button in the top bar: the folder copied whole under the name
-      // the dialog asked for. Dev server only, like the status write and for the same reason —
-      // a built canvas is static files with no folder behind them.
+      // the dialog asked for. Dev server only, like the status write and for the same reason. A
+      // built canvas is static files with no folder behind them.
       server.middlewares.use("/__sp/clone-canvas", (req, res, next) => {
         if (req.method !== "POST") return next();
         let body = "";

--- a/canvas/vite.config.ts
+++ b/canvas/vite.config.ts
@@ -541,11 +541,6 @@ function canvasesSource(): Plugin {
 
 export default defineConfig({
   plugins: [react(), repoRootMeta(), canvasesSource()],
-  // The tldraw license key is set in the host's build environment, under whichever of the two
-  // obvious names it was given there. A license key is meant to ship in the client bundle — it is
-  // checked against the domain serving it — so widening the prefix leaks nothing a visitor could
-  // not already read.
-  envPrefix: ["VITE_", "TLDRAW_"],
   server: {
     // The boards sit outside this app's root — one level up by default, anywhere at all when
     // PROTOTYPING_CANVASES_DIR points elsewhere. They load on demand rather than being pulled

--- a/canvas/vite.config.ts
+++ b/canvas/vite.config.ts
@@ -541,6 +541,11 @@ function canvasesSource(): Plugin {
 
 export default defineConfig({
   plugins: [react(), repoRootMeta(), canvasesSource()],
+  // The tldraw license key is set in the host's build environment, under whichever of the two
+  // obvious names it was given there. A license key is meant to ship in the client bundle — it is
+  // checked against the domain serving it — so widening the prefix leaks nothing a visitor could
+  // not already read.
+  envPrefix: ["VITE_", "TLDRAW_"],
   server: {
     // The boards sit outside this app's root — one level up by default, anywhere at all when
     // PROTOTYPING_CANVASES_DIR points elsewhere. They load on demand rather than being pulled

--- a/canvas/vite.config.ts
+++ b/canvas/vite.config.ts
@@ -5,6 +5,14 @@ import react from "@vitejs/plugin-react";
 import { defineConfig, type Plugin } from "vite";
 import { svgSignature } from "./src/svgSignature.ts";
 
+import {
+  BOARD_STATUSES,
+  SAFE_NAME,
+  canvasSlug,
+  withBoardStatus,
+  withCanvasName,
+} from "./src/boardStatusEdit.ts";
+
 /**
  * Repo root — vite.config.ts sits in canvas/, one level below it. It is published into the page
  * so a running server can be identified: a port that responds is not necessarily *this*
@@ -239,6 +247,7 @@ function scan(dir: string): Board[] {
  * `import.meta.glob` is itself only a Vite codegen macro, so generating the same three maps by
  * hand costs nothing downstream and buys a directory that can be chosen at run time.
  */
+
 function canvasesSource(): Plugin {
   let isBuild = false;
 
@@ -271,6 +280,7 @@ function canvasesSource(): Plugin {
       const layouts: string[] = [];
       const icons: string[] = [];
       const assets: string[] = [];
+      const comments: string[] = [];
 
       boards.forEach((board, i) => {
         const folder = path.join(canvasesDir, board.slug);
@@ -292,6 +302,19 @@ function canvasesSource(): Plugin {
         if (Object.keys(board.assets).length) {
           assets.push(`  ${jsString(board.slug)}: ${jsLiteral(board.assets)},`);
         }
+        // Inlined rather than imported: comments.json is written back by the endpoint below on
+        // every post, and an import would put it in the module graph, where each write would
+        // reload the page out from under the composer that caused it.
+        const commentsPath = path.join(folder, "comments.json");
+        if (fs.existsSync(commentsPath)) {
+          try {
+            const parsed = JSON.parse(fs.readFileSync(commentsPath, "utf8"));
+            comments.push(`  ${jsString(board.slug)}: ${jsLiteral(parsed)},`);
+          } catch (error) {
+            // A board whose comments file is corrupt still has to open, without its comments.
+            this.warn(`ignoring ${commentsPath}: ${error}`);
+          }
+        }
       });
 
       return [
@@ -306,10 +329,70 @@ function canvasesSource(): Plugin {
         `export const rawLayouts = {\n${layouts.join("\n")}\n};`,
         `export const rawIcons = {\n${icons.join("\n")}\n};`,
         `export const rawAssetNames = {\n${assets.join("\n")}\n};`,
+        `export const rawComments = {\n${comments.join("\n")}\n};`,
+        // The HMR boundary for every layout.json, which the inspector's status control writes on
+        // each click. A layout.json is a real import and accepts nothing itself, so without a
+        // boundary here Vite walks up to the entry and full-reloads: switching a status threw
+        // away the tldraw document, the open panel and the viewport, to change one word.
+        //
+        // Self-accepting stops that walk. This module is re-executed with the new JSON while the
+        // page stays up, and announces its fresh layouts — importers hold the *old* module's
+        // bindings, so the new data has to be handed over rather than read. canvasLibrary.ts
+        // listens, and is the only reader. Fires on first execution too, before anything is
+        // listening, which is the same no-op as any event with no handler.
+        `if (import.meta.hot) {`,
+        `  import.meta.hot.accept();`,
+        `  window.dispatchEvent(new CustomEvent("sp:canvases", { detail: rawLayouts }));`,
+        `}`,
       ].join("\n");
     },
 
     configureServer(server) {
+      // The inspector's status badge, writing back. Only the dev server can do this: a built
+      // canvas is static files on a host with no repo behind them, which is why the badge is
+      // not a button there.
+      server.middlewares.use("/__sp/board-status", (req, res, next) => {
+        if (req.method !== "POST") return next();
+        let body = "";
+        req.on("data", (chunk) => (body += chunk));
+        req.on("end", () => {
+          const send = (code: number, message: string) => {
+            res.statusCode = code;
+            res.end(message);
+          };
+          try {
+            const { slug, file, status } = JSON.parse(body || "{}");
+            // The two names land in a filesystem path, so they are checked before they are
+            // joined, not after: a `slug` of "../.." would otherwise write outside the boards.
+            if (!SAFE_NAME.test(slug ?? "") || !SAFE_NAME.test(file ?? "")) {
+              return send(400, "bad board name");
+            }
+            if (!BOARD_STATUSES.includes(status)) return send(400, "bad status");
+            const layoutPath = path.join(canvasesDir, slug, "layout.json");
+            const before = fs.readFileSync(layoutPath, "utf8");
+            const after = withBoardStatus(before, file, status);
+            if (after === null) return send(404, "board is not in layout.json");
+            if (after !== before) {
+              fs.writeFileSync(layoutPath, after);
+              // Hand the edited layout to the page directly instead of waiting for the file
+              // watcher to notice the write. The boards live outside the app's root, where the
+              // watcher misses changes, and a missed one meant the status only took effect on
+              // the next reload. canvasLibrary.ts listens.
+              server.hot.send("sp:board-status", { slug, layout: JSON.parse(after) });
+              // The same missed event leaves the transformed layout.json cached as it was when
+              // the server started, so drop it by hand or the *next* page load would serve the
+              // status back stale and undo what the click just did.
+              for (const mod of server.moduleGraph.getModulesByFile(layoutPath) ?? []) {
+                server.moduleGraph.invalidateModule(mod);
+              }
+            }
+            send(200, "ok");
+          } catch (error) {
+            send(500, String(error));
+          }
+        });
+      });
+
       // Editing a board already reloads, because the file is in the module graph once fetched.
       // Adding or deleting one changes the *set* of boards, which only this module knows, so it
       // has to be rebuilt and the page reloaded.
@@ -326,11 +409,112 @@ function canvasesSource(): Plugin {
         (/(\.html|layout\.json|icon\.png|assets\.json)$/.test(file) ||
           /\/assets(-dark)?\//.test(file));
 
-      const rebuild = () => {
+      // The generated index, dropped so the next request for it runs the scan again. Whoever
+      // asks for that request is the caller's business: the watcher reloads the open page,
+      // while the clone endpoint below leaves it to the navigation it answers with.
+      const invalidateIndex = () => {
         const mod = server.moduleGraph.getModuleById(RESOLVED_ID);
         if (mod) server.moduleGraph.invalidateModule(mod);
+      };
+
+      const rebuild = () => {
+        invalidateIndex();
         server.ws.send({ type: "full-reload" });
       };
+
+      // Canvas comments, written back into the board folder so they travel with it in Git —
+      // this is a repo-local review tool, not a synced document, and a comment on a mockup is
+      // only worth anything next to the mockup it is about. Dev server only, like the two
+      // endpoints around it.
+      server.middlewares.use("/__sp/comments", (req, res, next) => {
+        if (req.method !== "POST") return next();
+        let body = "";
+        req.on("data", (chunk) => (body += chunk));
+        req.on("end", () => {
+          const send = (code: number, message: string) => {
+            res.statusCode = code;
+            res.end(message);
+          };
+          try {
+            const { slug, file } = JSON.parse(body || "{}");
+            // The slug lands in a filesystem path, so it is checked before it is joined.
+            if (!SAFE_NAME.test(slug ?? "")) return send(400, "bad board name");
+            const folder = path.join(canvasesDir, slug);
+            if (!fs.statSync(folder, { throwIfNoEntry: false })?.isDirectory()) {
+              return send(404, `no canvas folder named ${slug}`);
+            }
+            const target = path.join(folder, "comments.json");
+            // The last comment on a board leaves no file behind: an empty one would be a diff
+            // in every folder anyone ever opened.
+            if (!file?.records?.length) {
+              fs.rmSync(target, { force: true });
+            } else {
+              // Machine-written every time, so unlike layout.json this may be re-serialised
+              // whole. Two spaces and a trailing newline to keep the Git diff line-by-line.
+              fs.writeFileSync(target, JSON.stringify(file, null, 2) + "\n");
+            }
+            // No reload broadcast: the page that posted already has these records in its store,
+            // and reloading would throw away the composer that is still open. Dropping the
+            // index is only so the *next* load reads the file back rather than the scan the
+            // server did at startup.
+            invalidateIndex();
+            send(200, "ok");
+          } catch (error) {
+            send(500, String(error));
+          }
+        });
+      });
+
+      // Cloning a canvas, from the button in the top bar: the folder copied whole under the name
+      // the dialog asked for. Dev server only, like the status write and for the same reason —
+      // a built canvas is static files with no folder behind them.
+      server.middlewares.use("/__sp/clone-canvas", (req, res, next) => {
+        if (req.method !== "POST") return next();
+        let body = "";
+        req.on("data", (chunk) => (body += chunk));
+        req.on("end", () => {
+          const send = (code: number, message: string) => {
+            res.statusCode = code;
+            res.end(message);
+          };
+          try {
+            const { slug, name } = JSON.parse(body || "{}");
+            const target = canvasSlug(name ?? "");
+            // Both names land in a filesystem path, so they are checked before they are joined.
+            if (!SAFE_NAME.test(slug ?? "") || !SAFE_NAME.test(target)) {
+              return send(400, "bad canvas name");
+            }
+            const from = path.join(canvasesDir, slug);
+            const to = path.join(canvasesDir, target);
+            // The welcome page is drawn by the app and has no folder, so this is also what
+            // stops it being cloned into one.
+            if (!fs.existsSync(from)) return send(404, `no canvas folder named ${slug}`);
+            if (fs.existsSync(to)) return send(409, `${target} already exists`);
+            // Everything, generator and assets included: a board folder is only worth cloning
+            // if the clone can be regenerated the same way the original could.
+            fs.cpSync(from, to, { recursive: true });
+            const layoutPath = path.join(to, "layout.json");
+            const before = fs.existsSync(layoutPath)
+              ? fs.readFileSync(layoutPath, "utf8")
+              : null;
+            fs.writeFileSync(
+              layoutPath,
+              // Nothing to preserve when the original had no layout at all, so the clone gets a
+              // fresh one that does nothing but carry the name.
+              before === null
+                ? JSON.stringify({ name }, null, 2) + "\n"
+                : withCanvasName(before, name),
+            );
+            // No reload broadcast: the page that asked is about to navigate to the clone, and a
+            // reload racing that navigation would land it back on the canvas it copied.
+            invalidateIndex();
+            res.setHeader("content-type", "application/json");
+            send(200, JSON.stringify({ slug: target }));
+          } catch (error) {
+            send(500, String(error));
+          }
+        });
+      });
 
       const onFile = (file: string) => {
         if (structural(file)) rebuild();

--- a/docs/2026-09-08-canvas-comments.md
+++ b/docs/2026-09-08-canvas-comments.md
@@ -9,23 +9,24 @@ committed with the boards, pinned to the board it names.
 - **The file is the source of truth, the tldraw store is a working copy.** Comment records are
   document records, so IndexedDB persisted them beside the shapes; without a rule the two would
   diverge and a thread deleted in Git would come back on every machine that had already seen it.
-  So the file wins on load, unconditionally, applied through `mergeRemoteChanges` — not the
+  So the file wins on load, unconditionally, applied through `mergeRemoteChanges`: not the
   user's own edit, not on their undo stack, and not written straight back by the listener.
 - **Two things a record cannot carry into a file.** Page ids are minted per browser, so the
   folder slug plays that role and the page id is stripped on write and re-attached on load. Author
   ids are made up here rather than issued by anything, so each file carries the names of the
-  people in it — that is what turns an id back into a name in someone else's checkout.
+  people in it. That is what turns an id back into a name in someone else's checkout.
 - **Soft-deletes are pruned on write.** They exist for a sync server to reconcile, and there is
   no server. A board whose last comment was deleted is still written, as an empty file, or the
   removed comments would load back in.
-- **A thread is anchored to the board shape, not to a point on the page**, so it rides a
-  `layout.json` reflow. The anchor is a normalized offset within the board's bounds, unclamped at
-  both ends, so a pin dropped in the margin keeps that spot *and* still moves with the board. The
-  comment tool's own hit-test looks straight through the boards, which are locked shapes, so it
-  never resolves one itself — `anchorToNearbyBoard` does it after the fact, for a new pin, for a
-  pin dragged onto a board, and once over the committed files on load. That last pass is derived
-  from the file, never written back: taking it as an edit would have a hosted visitor who touched
-  nothing write the board into their browser and go blind to every later deploy of it.
+- **A thread is anchored to the board shape, not to a point on the page.** That is what moves it
+  with a `layout.json` reflow. The anchor is a normalized offset within the board's bounds,
+  unclamped at both ends, so a pin dropped in the margin keeps that spot *and* still moves with
+  the board. The comment tool's own hit-test looks straight through the boards, which are locked
+  shapes, so it never resolves one itself; `anchorToNearbyBoard` does it after the fact, for a
+  new pin, for a pin dragged onto a board, and once over the committed files on load. That last
+  pass is derived from the file, never written back: taking it as an edit would have a hosted
+  visitor who touched nothing write the board into their browser and stop seeing every later
+  deploy of it.
 - **Identity is a GitHub handle, typed once, kept in localStorage.** There is no login and there
   is not going to be one. The handle rather than a free-typed name because it is what a pull
   request will call the same person, and because the avatar comes with it: `github.com/<login>.png`
@@ -40,8 +41,8 @@ the canvas should get to try the thing it is for, and a note in their own browse
 
 ## The license
 
-Commenting is a licensed tldraw feature. Without a key `CanvasComments` renders **nothing** in
-production — not the composer, not the committed threads either — so the hosted canvas would
+Commenting is a licensed tldraw feature. Without a key `CanvasComments` renders nothing in
+production, not the composer and not the committed threads either, so the hosted canvas would
 offer a comment tool that does nothing. `VITE_TLDRAW_LICENSE_KEY` is set on the `super-prototyping`
 Pages project, production and preview both, and Vite's default prefix inlines it; no widened
 `envPrefix` is needed and the one added first was removed.
@@ -50,7 +51,7 @@ Two things worth knowing before December:
 
 - **tldraw decides "development" from the runtime host**, not from the build. Loopback addresses,
   `.localhost` and any plain-`http:` origin get every feature unlicensed. A production build served
-  from `127.0.0.1` therefore proves nothing about the deployed site — that cost a wrong
+  from `127.0.0.1` therefore proves nothing about the deployed site; that cost a wrong
   verification here. Only the deploy can tell you.
 - **The current key is an evaluation license and expires 2026-12-12, with no grace period.** On
   that date the hosted canvas stops showing comments at all until the key is replaced.
@@ -66,5 +67,5 @@ Two things worth knowing before December:
 Dev server: a thread written on the canvas appears in the inspector and lands in the folder's
 `comments.json`; one written in the inspector appears on the canvas; deleting the last comment
 leaves an empty file rather than resurrecting the committed ones; a `layout.json` reflow carries
-the pins with the boards. Built canvas on a loopback host: the same, into localStorage — which is
+the pins with the boards. Built canvas on a loopback host: the same, into localStorage, which is
 also the test that could not have caught the license problem, and did not.

--- a/docs/2026-09-08-canvas-comments.md
+++ b/docs/2026-09-08-canvas-comments.md
@@ -1,0 +1,70 @@
+# A comment on a mockup belongs next to the mockup
+
+2026-09-08. A review of a board had nowhere to land but a chat window, where it came apart from
+the thing it was about within a day. Now it lands in the board's folder: `<slug>/comments.json`,
+committed with the boards, pinned to the board it names.
+
+## What changed
+
+- **The file is the source of truth, the tldraw store is a working copy.** Comment records are
+  document records, so IndexedDB persisted them beside the shapes; without a rule the two would
+  diverge and a thread deleted in Git would come back on every machine that had already seen it.
+  So the file wins on load, unconditionally, applied through `mergeRemoteChanges` — not the
+  user's own edit, not on their undo stack, and not written straight back by the listener.
+- **Two things a record cannot carry into a file.** Page ids are minted per browser, so the
+  folder slug plays that role and the page id is stripped on write and re-attached on load. Author
+  ids are made up here rather than issued by anything, so each file carries the names of the
+  people in it — that is what turns an id back into a name in someone else's checkout.
+- **Soft-deletes are pruned on write.** They exist for a sync server to reconcile, and there is
+  no server. A board whose last comment was deleted is still written, as an empty file, or the
+  removed comments would load back in.
+- **A thread is anchored to the board shape, not to a point on the page**, so it rides a
+  `layout.json` reflow. The anchor is a normalized offset within the board's bounds, unclamped at
+  both ends, so a pin dropped in the margin keeps that spot *and* still moves with the board. The
+  comment tool's own hit-test looks straight through the boards, which are locked shapes, so it
+  never resolves one itself — `anchorToNearbyBoard` does it after the fact, for a new pin, for a
+  pin dragged onto a board, and once over the committed files on load. That last pass is derived
+  from the file, never written back: taking it as an edit would have a hosted visitor who touched
+  nothing write the board into their browser and go blind to every later deploy of it.
+- **Identity is a GitHub handle, typed once, kept in localStorage.** There is no login and there
+  is not going to be one. The handle rather than a free-typed name because it is what a pull
+  request will call the same person, and because the avatar comes with it: `github.com/<login>.png`
+  serves it without a token, where `api.github.com` would spend the unauthenticated rate limit.
+
+## The hosted canvas
+
+The same tool, everywhere, with a different sink: a dev server writes the file through
+`/__sp/comments`, a built canvas keeps whole files per slug in localStorage over the committed
+ones. Commenting was hidden on the hosted site first (`86f2444`) and that lost: someone trying
+the canvas should get to try the thing it is for, and a note in their own browser costs nothing.
+
+## The license
+
+Commenting is a licensed tldraw feature. Without a key `CanvasComments` renders **nothing** in
+production — not the composer, not the committed threads either — so the hosted canvas would
+offer a comment tool that does nothing. `VITE_TLDRAW_LICENSE_KEY` is set on the `super-prototyping`
+Pages project, production and preview both, and Vite's default prefix inlines it; no widened
+`envPrefix` is needed and the one added first was removed.
+
+Two things worth knowing before December:
+
+- **tldraw decides "development" from the runtime host**, not from the build. Loopback addresses,
+  `.localhost` and any plain-`http:` origin get every feature unlicensed. A production build served
+  from `127.0.0.1` therefore proves nothing about the deployed site — that cost a wrong
+  verification here. Only the deploy can tell you.
+- **The current key is an evaluation license and expires 2026-12-12, with no grace period.** On
+  that date the hosted canvas stops showing comments at all until the key is replaced.
+
+## Not changed
+
+- Reading committed threads on a dev server needs no key: development is unlicensed by design.
+- Board status and clone stay dev-server-only. They edit the repo; commenting is the one thing
+  that was worth giving a reader without one.
+
+## Checked
+
+Dev server: a thread written on the canvas appears in the inspector and lands in the folder's
+`comments.json`; one written in the inspector appears on the canvas; deleting the last comment
+leaves an empty file rather than resurrecting the committed ones; a `layout.json` reflow carries
+the pins with the boards. Built canvas on a loopback host: the same, into localStorage — which is
+also the test that could not have caught the license problem, and did not.

--- a/docs/2026-09-08-vector-assets.md
+++ b/docs/2026-09-08-vector-assets.md
@@ -33,13 +33,13 @@ Measured over the 180 committed boards before deciding (`scratch/svg_census.py`)
   `toString()`, which is why it is written with no reference outside its own body. The index adds
   the key beside the byte key it already had for every `.svg` under `assets/`. An svg that draws
   nothing, the one filter-only definitions block on `chatgpt-ios/16-memory-sheet`, is no asset.
-- **The copy stands alone.** The agent strips what the generator and the agent itself injected,
+- **The copy is self-contained.** The agent strips what the generator and the agent itself injected,
   adds `xmlns` where a literal icon had none, writes the root's computed `fill` and `stroke` in
   where the markup left them to the cascade, and a child's where a stylesheet rule set it apart
   from its parent (apple-wallet's `.ds path`), and substitutes `currentColor` and every `var()` with
   the values the board resolved. That string is the preview, as an inert
   `<img src="data:image/svg+xml,…">` in the parent, never live DOM, which matters on a hosted
-  canvas where a board is a pull request away; and it is what **Copy SVG** puts on the
+  canvas, where any pull request can add a board; and it is what **Copy SVG** puts on the
   clipboard, for Figma or another `gen.py`.
 - **A name comes from the file, else from context, else nowhere.** No board writes a title on an
   icon. With no file the agent takes an `aria-label` or `<title>` if one ever appears, else a class

--- a/mockups/canvases/README.md
+++ b/mockups/canvases/README.md
@@ -76,6 +76,7 @@ laid out top to bottom:
 ```json
 {
   "name": "(example) Notion iOS",
+  "status": "exploring",
   "rows": [
     { "title": "Foundations", "files": ["00-design-tokens"] },
     { "title": "Screens", "numbered": true,
@@ -113,6 +114,19 @@ laid out top to bottom:
 - `{ "file", "label", "w", "h" }` overrides the 478 x 980 artboard for a board
   that is not phone-shaped, a landscape banner say. A row is laid out at its
   first file's size, so give every file in the row the same one.
+- `status` is how far along a board is: `exploring`, `outdated`, or `live`.
+  `live` is the default and draws nothing; the other two draw a coloured tab
+  above the board — amber for exploring, grey for outdated. Declare it once at
+  the top level for a folder that is one round of exploration, and per file
+  (`{ "file", "label", "status": "outdated" }`) for a board that differs,
+  including back to `"live"` to drop a tab the folder would otherwise give it.
+  The status control at the top left of the inspector writes this field, so a
+  board can be restatused by clicking it rather than by editing this file. It
+  is a tldraw shape the layout places, not markup in the board, so a board
+  keeps no record of its own status and does not need regenerating when that
+  status changes. A row reserves the tab's height for all of its boards as soon
+  as one of them carries a tab, which is what keeps item N of one row aligned
+  with item N of the next.
 - `"links": [{ "label", "url" }]` puts buttons under the row that open an
   address in a new tab. A board renders in `<iframe srcDoc sandbox="">`, where
   a link can navigate nothing, so anything clickable has to be a shape out

--- a/mockups/canvases/README.md
+++ b/mockups/canvases/README.md
@@ -28,8 +28,8 @@ A folder is an unzipped Sketch file: `layout.json` plays `document.json` and
 pre-encoded images the generator inlines; commit it too, it is the only
 copy of those images. The canvas's inspector names a board's images by
 content, from `assets/` first and `assets.json` second, and falls back to
-the image's `alt` when a generator re-encoded it. An inline `<svg>` is
-named the same way from `assets/icons/`, by its geometry rather than its
+the image's `alt` when a generator re-encoded it. It names an inline
+`<svg>` the same way from `assets/icons/`, by its geometry rather than its
 bytes, so keep each icon as a file there and inline it through a helper in
 `gen.py`. Everything a run makes on the way, grids, shots, montages,
 candidate boards, goes in `<slug>/scratch/`. The root `.gitignore` ignores
@@ -116,12 +116,12 @@ laid out top to bottom:
   first file's size, so give every file in the row the same one.
 - `status` is how far along a board is: `exploring`, `outdated`, or `live`.
   `live` is the default and draws nothing; the other two draw a coloured tab
-  above the board — amber for exploring, grey for outdated. Declare it once at
-  the top level for a folder that is one round of exploration, and per file
+  above the board, amber for exploring and grey for outdated. Declare it once
+  at the top level for a folder that is one round of exploration, and per file
   (`{ "file", "label", "status": "outdated" }`) for a board that differs,
   including back to `"live"` to drop a tab the folder would otherwise give it.
-  The status control at the top left of the inspector writes this field, so a
-  board can be restatused by clicking it rather than by editing this file. It
+  The status control at the top left of the inspector writes this field, so
+  clicking it changes a board's status without editing this file. It
   is a tldraw shape the layout places, not markup in the board, so a board
   keeps no record of its own status and does not need regenerating when that
   status changes. A row reserves the tab's height for all of its boards as soon

--- a/skills/prototype-canvas/references/layout.md
+++ b/skills/prototype-canvas/references/layout.md
@@ -91,7 +91,7 @@ out top to bottom:
   including back to `"live"` to drop a tab the folder would otherwise give it.
   The status control at the top left of the inspector writes this field, so a
   board can be restatused by clicking it rather than by editing this file.
-  Like the flow arrow it is a tldraw shape the layout places, not markup in the
+  It is a tldraw shape the layout places, not markup in the
   board, so a board keeps no record of its own status and does not need
   regenerating when that status changes. A row reserves the tab's height for all
   of its boards as soon as one of them carries a tab, which is what keeps item N

--- a/skills/prototype-canvas/references/layout.md
+++ b/skills/prototype-canvas/references/layout.md
@@ -28,7 +28,7 @@ where a folder has one, is a `name → data URI` map of pre-encoded images the
 generator inlines; commit it too, it is the only copy of those images. The
 canvas's inspector names a board's images by content, from `assets/` first
 and `assets.json` second, and falls back to the image's `alt` when a
-generator re-encoded it. An inline `<svg>` is named the same way from
+generator re-encoded it. It names an inline `<svg>` the same way from
 `assets/icons/`, by its geometry rather than its bytes, so keep each icon
 as a file there and inline it through a helper in `gen.py`.
 Everything a run makes on the way (grids, shots, montages, candidate boards)
@@ -85,12 +85,12 @@ out top to bottom:
   first file's size, so give every file in the row the same one.
 - `status` is how far along a board is: `exploring`, `outdated`, or `live`.
   `live` is the default and draws nothing; the other two draw a coloured tab
-  above the board — amber for exploring, grey for outdated. Declare it once at
-  the top level for a folder that is one round of exploration, and per file
+  above the board, amber for exploring and grey for outdated. Declare it once
+  at the top level for a folder that is one round of exploration, and per file
   (`{ "file", "label", "status": "outdated" }`) for a board that differs,
   including back to `"live"` to drop a tab the folder would otherwise give it.
-  The status control at the top left of the inspector writes this field, so a
-  board can be restatused by clicking it rather than by editing this file.
+  The status control at the top left of the inspector writes this field, so
+  clicking it changes a board's status without editing this file.
   It is a tldraw shape the layout places, not markup in the
   board, so a board keeps no record of its own status and does not need
   regenerating when that status changes. A row reserves the tab's height for all

--- a/skills/prototype-canvas/references/layout.md
+++ b/skills/prototype-canvas/references/layout.md
@@ -47,6 +47,7 @@ out top to bottom:
 ```json
 {
   "name": "Notion iOS",
+  "status": "exploring",
   "rows": [
     { "title": "Foundations", "files": ["00-design-tokens"] },
     { "title": "Screens", "numbered": true,
@@ -82,6 +83,19 @@ out top to bottom:
 - `{ "file", "label", "w", "h" }` overrides the 478 × 980 artboard for a board
   that is not phone-shaped, a landscape banner say. A row is laid out at its
   first file's size, so give every file in the row the same one.
+- `status` is how far along a board is: `exploring`, `outdated`, or `live`.
+  `live` is the default and draws nothing; the other two draw a coloured tab
+  above the board — amber for exploring, grey for outdated. Declare it once at
+  the top level for a folder that is one round of exploration, and per file
+  (`{ "file", "label", "status": "outdated" }`) for a board that differs,
+  including back to `"live"` to drop a tab the folder would otherwise give it.
+  The status control at the top left of the inspector writes this field, so a
+  board can be restatused by clicking it rather than by editing this file.
+  Like the flow arrow it is a tldraw shape the layout places, not markup in the
+  board, so a board keeps no record of its own status and does not need
+  regenerating when that status changes. A row reserves the tab's height for all
+  of its boards as soon as one of them carries a tab, which is what keeps item N
+  of one row aligned with item N of the next.
 - `"links": [{ "label", "url" }]` puts buttons under the row that open an
   address in a new tab. A board renders in `<iframe srcDoc sandbox="">`, where
   a link can navigate nothing, so anything clickable has to be a shape out


### PR DESCRIPTION
Three things that had been running only in an installed plugin cache, rebased onto main — and then gated so a built canvas does not offer what only a plugin install can do.

## Comments

On stock `@tldraw/commenting`. A thread is anchored to the **board shape** rather than to canvas coordinates, so a note rides its mockup when a `layout.json` edit reflows the page. A pin dropped — or dragged — beside a board links itself to it: the comment tool's own hit-test looks straight through the boards, which are locked shapes, so both the add and the update go through the same re-anchor.

Storage is `<slug>/comments.json` next to the boards, so notes go into Git with the mockups they are about. There is no login: identity is a GitHub handle typed once, which is also where the name and the avatar come from, and the file carries the authors it names so an id resolves to a person in someone else's checkout.

The inspector carries the same threads beside the preview — pinned on the board image, listed under it, editable and deletable there.

## Board status

`exploring` / `outdated` / `live` is a tldraw shape the layout places, so a board keeps no record of its own and never needs regenerating when its status changes. The control at the top of the inspector writes `layout.json`.

## Clone canvas

A dialog that says which folder the copy will land in, because it really does write into the reader's project.

## What a static build gets

All three write through the dev server, which is what a plugin install runs. On a static host they were still offered and failed silently — a posted comment even disappeared on the next load, because the reconciler treats "not in the file" as deleted. `import.meta.env.DEV` now gates the comment tool, the identity button, the clone button, the composer and the per-comment actions, the same rule the status control already used.

Reading is untouched: the folders' comments are baked into the build, so committed threads still load, still ride their boards, and are still listed and pinned — with no identity, which is the commenting toolkit's own read-only mode. `__sp/comments` and `__sp/clone-canvas` now drop out of the production bundle alongside `__sp/board-status`.

## Checks

`tsc -b --force`, `oxlint src/`, `vitest run` (9 files, 75 tests), `vite build`. Verified live against a dev server (everything present and working) and against `vite preview` of the production build with real boards (threads read-only, every write affordance gone, no errors).

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)