### PR TITLE
canvas: the rail's collapse handle moves onto its divider

### DIFF
--- a/canvas/src/InspectorPanel.tsx
+++ b/canvas/src/InspectorPanel.tsx
@@ -433,6 +433,20 @@ export function InspectorPanel({
   };
   const usedTokens = data ? data.tokens.filter((t) => t.usedBy.length).length : 0;
 
+  const railGrip: React.HTMLAttributes<HTMLDivElement> = railOpen
+    ? {
+        role: "separator",
+        "aria-orientation": "vertical",
+        "aria-label": "Resize details",
+        "aria-valuenow": rail,
+        "aria-valuemin": railBounds(panel)[0],
+        "aria-valuemax": railBounds(panel)[1],
+        tabIndex: 0,
+        onPointerDown: divider("x", setRail.from, setRail.apply),
+        onKeyDown: dividerKeys("x", setRail.from, setRail.apply),
+      }
+    : {};
+
   const jumpToToken = (token: string) => {
     setTab("tokens");
     setFocusToken(token);
@@ -489,23 +503,6 @@ export function InspectorPanel({
           </div>
           <BoardStatus path={path} />
           <span className="sp-zoom">{Math.round(scale * 100)}%</span>
-          {/*
-            Lives on the stage, not in the rail, so that collapsing the rail does not also hide the
-            only way back — Escape does not help here, because clicking the preview moves focus into
-            the frame and the agent forwards no keys.
-          */}
-          <button
-            type="button"
-            className="sp-collapse"
-            aria-expanded={railOpen}
-            title={railOpen ? "Hide details" : "Show details"}
-            aria-label={railOpen ? "Hide details" : "Show details"}
-            onClick={() => setRailOpen((v) => !v)}
-          >
-            <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.2">
-              <path d={railOpen ? "M7.5 2l4 4-4 4M4.5 2l-4 4 4 4" : "M2 2l4 4-4 4M7.5 2l4 4-4 4"} />
-            </svg>
-          </button>
         </div>
         {editor ? (
           <BoardComments
@@ -518,20 +515,38 @@ export function InspectorPanel({
         ) : null}
       </div>
 
-      {railOpen ? (
-        <div
-          className="sp-grip sp-grip--x"
-          role="separator"
-          aria-orientation="vertical"
-          aria-label="Resize details"
-          aria-valuenow={rail}
-          aria-valuemin={railBounds(panel)[0]}
-          aria-valuemax={railBounds(panel)[1]}
-          tabIndex={0}
-          onPointerDown={divider("x", setRail.from, setRail.apply)}
-          onKeyDown={dividerKeys("x", setRail.from, setRail.apply)}
-        />
-      ) : null}
+      {/*
+        The rail's divider carries the collapse handle: the seam is where the fold happens, and a
+        handle on it costs the preview nothing. The grip itself stays mounted when the rail is
+        shut — the handle is then the only way back, because Escape does not help here: clicking
+        the preview moves focus into the frame and the agent forwards no keys. Shut, it is only a
+        perch, so it drops the separator role and the drag with the pane they would resize.
+      */}
+      <div className={cx("sp-grip", "sp-grip--x", !railOpen && "sp-grip--shut")} {...railGrip}>
+        <button
+          type="button"
+          className="sp-collapse"
+          aria-expanded={railOpen}
+          title={railOpen ? "Hide details" : "Show details"}
+          aria-label={railOpen ? "Hide details" : "Show details"}
+          // Sitting on the divider, the press that opens the rail must not also start a drag.
+          onPointerDown={(e) => e.stopPropagation()}
+          onClick={() => setRailOpen((v) => !v)}
+        >
+          <svg
+            width="9"
+            height="9"
+            viewBox="0 0 12 12"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <path d={railOpen ? "M4 2l4 4-4 4" : "M8 2l-4 4 4 4"} />
+          </svg>
+        </button>
+      </div>
 
       <div className="sp-rail" style={{ width: rail, display: railOpen ? undefined : "none" }}>
         <header className="sp-head">

--- a/canvas/src/index.css
+++ b/canvas/src/index.css
@@ -471,12 +471,16 @@ input.canvas-clone-name:focus {
   pointer-events: none;
 }
 
+/* The rail's collapse handle, a lozenge straddling its divider. It was a 26px chip in the top
+   right of the preview, where it covered the board it was meant to help read. */
 .sp-collapse {
   position: absolute;
-  top: 10px;
-  right: 10px;
-  width: 26px;
-  height: 26px;
+  z-index: 1;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 12px;
+  height: 28px;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -489,6 +493,24 @@ input.canvas-clone-name:focus {
 
 .sp-collapse:hover {
   color: var(--sp-text);
+  background: var(--sp-hover);
+}
+
+/* Shut, the divider resizes nothing: no col-resize cursor, no accent line under the pointer. */
+.sp-grip--shut {
+  cursor: default;
+}
+
+.sp-grip--shut:hover::after {
+  background: transparent;
+}
+
+/* Its right edge then hangs 2px past the panel, and the panel is against the window's edge, so
+   a centred handle would lose half of itself off-screen. */
+.sp-grip--shut .sp-collapse {
+  left: auto;
+  right: 4px;
+  transform: translateY(-50%);
 }
 
 /* Dividers. The hit area is wider than the line, which is the whole reason for ::after. */


### PR DESCRIPTION
The inspector's collapse control was a 26px chip in the preview's top right — the corner of the board it exists to help read. It is now a 12×28 lozenge straddling the rail's own divider: the seam is where the fold happens, so the control costs the preview nothing.

- The divider stays mounted when the rail is shut, because the handle is then the only way back (Escape does not help: clicking the preview moves focus into the frame).
- Shut, it resizes nothing, so it drops the `separator` role, the drag and the `col-resize` cursor, and the handle tucks against the window's edge rather than losing half of itself off it.
- A press on the handle stops there instead of starting a drag on the divider under it.

Checked in the running canvas: click folds and unfolds the rail, dragging the divider still resizes it (301 → 391px), and a drag starting on the handle neither resizes nor toggles. `bun run build`, `lint` and `test` (76) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)