### PR TITLE
canvas: the status badge keeps its corner in a built canvas

### DIFF
--- a/canvas/src/InspectorPanel.tsx
+++ b/canvas/src/InspectorPanel.tsx
@@ -158,8 +158,15 @@ function BoardStatus({ path }: { path: string }) {
     </>
   );
 
+  // Away from the dev server there is no file to write a status back to, so the badge is only a
+  // label — but it keeps the wrapper, which is what holds it in the stage's top left. Without it
+  // the badge is a plain flex child of the stage and rides along beside the board, centred.
   if (!import.meta.env.DEV) {
-    return <span className={`sp-status sp-status--${status}`}>{badge}</span>;
+    return (
+      <div className="sp-status-wrap">
+        <span className={`sp-status sp-status--${status}`}>{badge}</span>
+      </div>
+    );
   }
 
   return (


### PR DESCRIPTION
On a deployed canvas the board status badge is not in the preview's top left — it floats beside the board, vertically centred:

`BoardStatus` returns early away from the dev server (nothing to write a status back to), and that branch returned the bare `<span class="sp-status">` without `.sp-status-wrap` — which is where `position: absolute; top: 10px; left: 10px` lives. Left static, the badge becomes a flex child of `.sp-stage` and gets placed by its `align-items: center` / `justify-content: center`. Dev never shows it, because dev renders the wrapper.

The read-only badge now keeps the wrapper; only the dev server renders the menu inside it.

Measured on a production build (`bun run build` + `vite preview`), duolingo-ios open in the inspector:

| | wrapper | badge offset from stage |
|---|---|---|
| before (deployed) | no | 393, 343 — outside a 362px-wide stage |
| after | yes | 10, 10 |

`lint` and `test` (76) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)