### PR TITLE
canvas: the dev server watches the boards itself

### DIFF
--- a/canvas/src/boardWatch.test.ts
+++ b/canvas/src/boardWatch.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest'
+import { boardChangeKind, boardSetSignature, boardSlug } from './boardWatch'
+
+const DIR = '/project/mockups/canvases'
+const kind = (file: string) => boardChangeKind(DIR, `${DIR}/${file}`)
+
+describe('boardChangeKind', () => {
+  it('names a board, its layout, its comments and its assets', () => {
+    expect(kind('spotify-ios/01-home.html')).toBe('board')
+    expect(kind('spotify-ios/layout.json')).toBe('layout')
+    expect(kind('spotify-ios/comments.json')).toBe('comments')
+    expect(kind('spotify-ios/assets.json')).toBe('assets')
+    expect(kind('spotify-ios/icon.png')).toBe('assets')
+    expect(kind('spotify-ios/assets/art/hero.png')).toBe('assets')
+    expect(kind('spotify-ios/assets-dark/icons/play.svg')).toBe('assets')
+  })
+
+  it('ignores everything a run leaves beside the boards', () => {
+    // The generator and its notes are not the boards it writes.
+    expect(kind('spotify-ios/gen.py')).toBeNull()
+    expect(kind('spotify-ios/README.md')).toBeNull()
+    expect(kind('spotify-ios/probes.json')).toBeNull()
+    // scratch/ is where a run puts its working files, at any depth, and reloading the canvas
+    // for one would interrupt the run that is writing it.
+    expect(kind('spotify-ios/scratch/draft.html')).toBeNull()
+    expect(kind('spotify-ios/scratch/shots/measure.png')).toBeNull()
+    // Third-party captures: never committed, never indexed, and a clone run writes hundreds.
+    // The folder they arrive in is as quiet as the files in it.
+    expect(kind('spotify-ios/assets/refs')).toBeNull()
+    expect(kind('spotify-ios/assets/refs/home@2x.png')).toBeNull()
+    // A folder that only starts with those four letters is an asset folder like any other.
+    expect(kind('spotify-ios/assets/refsheet/a.png')).toBe('assets')
+    // A board is one level deep, which is what the discovery scan reads.
+    expect(kind('loose.html')).toBeNull()
+  })
+
+  it('claims nothing outside the boards directory', () => {
+    expect(boardChangeKind(DIR, '/project/src/App.tsx')).toBeNull()
+    // A sibling whose name starts with the same characters is not inside it.
+    expect(boardChangeKind(DIR, '/project/mockups/canvases-old/demo/a.html')).toBeNull()
+  })
+
+  it('reads a Windows path the way it reads a POSIX one', () => {
+    const dir = 'C:\\project\\mockups\\canvases'
+    expect(boardChangeKind(dir, `${dir}\\demo\\a.html`)).toBe('board')
+    expect(boardSlug(dir, `${dir}\\demo\\layout.json`)).toBe('demo')
+  })
+})
+
+describe('boardSetSignature', () => {
+  /** A boards directory as a name -> entries map, standing in for readdirSync. */
+  const tree = (entries: Record<string, string[]>) => (dir: string) => entries[dir] ?? []
+
+  const BOARDS = {
+    [DIR]: ['spotify-ios', 'templates', '.DS_Store'],
+    [`${DIR}/spotify-ios`]: ['01-home.html', '02-search.html', 'layout.json', 'icon.png', 'gen.py'],
+    [`${DIR}/templates`]: ['01-blank.html', 'layout.json'],
+  }
+
+  it('moves when a board is added, removed or renamed', () => {
+    const before = boardSetSignature(DIR, tree(BOARDS))
+    const added = {
+      ...BOARDS,
+      [`${DIR}/spotify-ios`]: [...BOARDS[`${DIR}/spotify-ios`], '03-library.html'],
+    }
+    expect(boardSetSignature(DIR, tree(added))).not.toBe(before)
+
+    const renamed = { ...BOARDS, [`${DIR}/templates`]: ['01-start.html', 'layout.json'] }
+    expect(boardSetSignature(DIR, tree(renamed))).not.toBe(before)
+
+    const { [`${DIR}/templates`]: _gone, ...rest } = BOARDS
+    const removed = { ...rest, [DIR]: ['spotify-ios', '.DS_Store'] }
+    expect(boardSetSignature(DIR, tree(removed))).not.toBe(before)
+  })
+
+  it('does not move when a board, a comment or a working file changes', () => {
+    const before = boardSetSignature(DIR, tree(BOARDS))
+    // Editing a file does not change any listing, and a comment or a scratch file is not in the
+    // signature at all: neither is worth a reload.
+    const noisy = {
+      ...BOARDS,
+      [`${DIR}/spotify-ios`]: [...BOARDS[`${DIR}/spotify-ios`], 'comments.json', 'scratch'],
+    }
+    expect(boardSetSignature(DIR, tree(noisy))).toBe(before)
+  })
+
+  it('is stable whatever order the filesystem lists in', () => {
+    const shuffled = {
+      ...BOARDS,
+      [DIR]: ['templates', '.DS_Store', 'spotify-ios'],
+      [`${DIR}/spotify-ios`]: ['layout.json', 'gen.py', '02-search.html', 'icon.png', '01-home.html'],
+    }
+    expect(boardSetSignature(DIR, tree(shuffled))).toBe(boardSetSignature(DIR, tree(BOARDS)))
+  })
+
+  it('signs a folder it cannot read, and one with nothing in it, alike', () => {
+    // The server's `list` hands back nothing for a folder that is gone or unreadable, so a
+    // dangling symlink signs the same as an empty folder instead of taking the watcher down.
+    const empty = { ...BOARDS, [`${DIR}/templates`]: [] }
+    expect(boardSetSignature(DIR, tree(empty))).toContain('templates:')
+  })
+})

--- a/canvas/src/boardWatch.ts
+++ b/canvas/src/boardWatch.ts
@@ -1,0 +1,96 @@
+/**
+ * What a write under the boards directory means, and what the set of boards looks like right now.
+ *
+ * They live here rather than in vite.config.ts, like the write helpers in boardStatusEdit.ts, so
+ * they can be tested as what they are — a path classifier and a directory listing — without
+ * standing a dev server up around them.
+ *
+ * Paths arrive from `fs.watch`, which spells them the way the platform does. Everything below
+ * compares them with forward slashes, which is what the rest of the plugin already assumes.
+ */
+
+const slashes = (p: string) => p.replace(/\\/g, "/");
+
+/** The board files the discovery scan reads, one level deep: `<slug>/<name>`. */
+const BOARD_FILES = /^[^/]+\/[^/]+$/;
+
+/**
+ * What one changed path is to the canvas, or null for a path it has no opinion about — a
+ * generator, a README, anything under `scratch/`.
+ *
+ * - `board`: a board's HTML. Its transformed module holds the file as it was first read, so it
+ *   has to be dropped and the page reloaded.
+ * - `layout`: a board folder's layout.json. Read on every render, and handed to the page over
+ *   HMR rather than through a reload, which would throw the viewport away.
+ * - `assets`: an image or assets.json, whose bytes are hashed into the generated index.
+ * - `comments`: comments.json, which the page that wrote it already has.
+ *
+ * Only one level deep, because that is what `scan()` discovers: a `scratch/draft.html` is a
+ * working file, not a board, and reloading the canvas for it interrupts the run that wrote it.
+ */
+export function boardChangeKind(
+  canvasesDir: string,
+  file: string,
+): "board" | "layout" | "assets" | "comments" | null {
+  const dir = slashes(canvasesDir).replace(/\/$/, "");
+  const full = slashes(file);
+  if (!full.startsWith(dir + "/")) return null;
+  const rel = full.slice(dir.length + 1);
+
+  // An asset, at any depth under the folder that holds them. `refs/` is third-party captures,
+  // which are never committed and never indexed, and a clone run writes hundreds of them.
+  const asset = /^[^/]+\/assets(-dark)?\/(.+)$/.exec(rel);
+  if (asset) return /^refs(\/|$)/.test(asset[2]) ? null : "assets";
+
+  if (!BOARD_FILES.test(rel)) return null;
+  const name = rel.slice(rel.indexOf("/") + 1);
+  if (name.endsWith(".html")) return "board";
+  if (name === "layout.json") return "layout";
+  if (name === "comments.json") return "comments";
+  if (name === "assets.json" || name === "icon.png") return "assets";
+  return null;
+}
+
+/** The board folder a path is in, for a path `boardChangeKind` claimed. */
+export function boardSlug(canvasesDir: string, file: string): string {
+  const rel = slashes(file).slice(slashes(canvasesDir).replace(/\/$/, "").length + 1);
+  return rel.slice(0, rel.indexOf("/"));
+}
+
+/**
+ * The set of boards as one string: every folder, and the files in it that the scan would read.
+ *
+ * Compared against the last one after a batch of writes, this is what separates "a board was
+ * added, removed or renamed" — where the generated index is stale and the page has to be
+ * reloaded — from "a board was edited", where a reload would be a heavier answer than the change
+ * deserves. Contents are deliberately not in it: an edit does not move the set.
+ *
+ * comments.json is left out too. It changes on every comment posted, and the page that posted it
+ * is holding the composer that a reload would close.
+ *
+ * `list` is `fs.readdirSync` in the server and a fake in the tests. It returns nothing for a path
+ * it cannot read, so a dangling symlink or a folder pulled out from under the scan signs as
+ * empty rather than throwing out of the watcher.
+ */
+export function boardSetSignature(
+  canvasesDir: string,
+  list: (dir: string) => string[],
+): string {
+  return list(canvasesDir)
+    .filter((slug) => !slug.startsWith("."))
+    .sort()
+    .map((slug) => {
+      const files = list(`${canvasesDir}/${slug}`)
+        .filter(
+          (name) =>
+            !name.startsWith(".") &&
+            (name.endsWith(".html") ||
+              name === "layout.json" ||
+              name === "icon.png" ||
+              name === "assets.json"),
+        )
+        .sort();
+      return `${slug}:${files.join(",")}`;
+    })
+    .join("|");
+}

--- a/canvas/src/canvasLibrary.ts
+++ b/canvas/src/canvasLibrary.ts
@@ -293,9 +293,9 @@ let layouts: Record<string, CanvasLayoutConfig> = rawLayouts;
 
 if (import.meta.hot) {
   // The status endpoint sends the layout.json it has just written, rather than leaving the page
-  // to hear about the write from the file watcher: the boards live outside the app's root, where
-  // the watcher misses changes, and a missed one meant the status only took effect on the next
-  // reload.
+  // to hear about the write from the file watcher: the watcher answers a settled batch of writes
+  // and would have the badge lag the click it answers. The watcher sends this same message for a
+  // layout.json edited by hand, so a status set twice over lands twice, identically.
   import.meta.hot.on(
     "sp:board-status",
     ({ slug, layout }: { slug: string; layout: CanvasLayoutConfig }) => {
@@ -306,10 +306,11 @@ if (import.meta.hot) {
     },
   );
 
-  // The other way a layout.json changes is someone editing it. When the watcher does see that,
-  // virtual:canvases re-executes and hands its fresh layouts over here, because this module keeps
-  // the bindings of the *old* copy of it and would otherwise go on reading the layouts the page
-  // started with.
+  // And whenever virtual:canvases re-executes for any other reason, it hands its fresh layouts
+  // over here, because this module keeps the bindings of the *old* copy of it and would otherwise
+  // go on reading the layouts the page started with. That is Vite's own HMR update, which reaches
+  // a layout.json only where the boards happen to sit inside the app's root; the message above is
+  // what carries an edit in every other case.
   window.addEventListener("sp:canvases", (event) => {
     layouts = (event as CustomEvent<Record<string, CanvasLayoutConfig>>).detail;
     window.dispatchEvent(new Event(LAYOUT_CHANGED));

--- a/canvas/vite.config.ts
+++ b/canvas/vite.config.ts
@@ -12,6 +12,7 @@ import {
   withBoardStatus,
   withCanvasName,
 } from "./src/boardStatusEdit.ts";
+import { boardChangeKind, boardSetSignature, boardSlug } from "./src/boardWatch.ts";
 
 /**
  * Repo root — vite.config.ts sits in canvas/, one level below it. It is published into the page
@@ -373,14 +374,14 @@ function canvasesSource(): Plugin {
             if (after === null) return send(404, "board is not in layout.json");
             if (after !== before) {
               fs.writeFileSync(layoutPath, after);
-              // Hand the edited layout to the page directly instead of waiting for the file
-              // watcher to notice the write. The boards live outside the app's root, where the
-              // watcher misses changes, and a missed one meant the status only took effect on
-              // the next reload. canvasLibrary.ts listens.
+              // Hand the edited layout to the page directly rather than leaving it to hear about
+              // its own write from the watcher, which answers a batch and not a keystroke: a
+              // badge that lags a fifth of a second behind the click reads as a badge that did
+              // not take. canvasLibrary.ts listens.
               server.hot.send("sp:board-status", { slug, layout: JSON.parse(after) });
-              // The same missed event leaves the transformed layout.json cached as it was when
-              // the server started, so drop it by hand or the *next* page load would serve the
-              // status back stale and undo what the click just did.
+              // And drop the transformed layout.json by hand for the same reason, or the *next*
+              // page load, if it beats the watcher, would serve the status back stale and undo
+              // what the click just did.
               for (const mod of server.moduleGraph.getModulesByFile(layoutPath) ?? []) {
                 server.moduleGraph.invalidateModule(mod);
               }
@@ -392,21 +393,10 @@ function canvasesSource(): Plugin {
         });
       });
 
-      // Editing a board already reloads, because the file is in the module graph once fetched.
-      // Adding or deleting one changes the *set* of boards, which only this module knows, so it
-      // has to be rebuilt and the page reloaded.
-      //
-      // Create the folder first. Watching a path that does not exist registers nothing — chokidar
-      // does not watch a parent for its creation — and a brand new project is exactly the case
+      // The boards are watched at the bottom of this hook. Create the folder first: watching a
+      // path that does not exist registers nothing, and a brand new project is exactly the case
       // where the first board folder appears while the server is already up.
       fs.mkdirSync(canvasesDir, { recursive: true });
-      server.watcher.add(canvasesDir);
-
-      const inside = (p: string) => p.startsWith(canvasesDir + path.sep);
-      const structural = (file: string) =>
-        inside(file) &&
-        (/(\.html|layout\.json|icon\.png|assets\.json)$/.test(file) ||
-          /\/assets(-dark)?\//.test(file));
 
       // The generated index, dropped so the next request for it runs the scan again. Whoever
       // asks for that request is the caller's business: the watcher reloads the open page,
@@ -515,25 +505,143 @@ function canvasesSource(): Plugin {
         });
       });
 
-      const onFile = (file: string) => {
-        if (structural(file)) rebuild();
-      };
-      // A board folder appearing or vanishing changes the set even though no file event names a
-      // board file. Scoped to the boards directory: the watcher also sees `dist/` being written
-      // during a build, which is nothing to do with us.
-      const onDir = (dir: string) => {
-        if (inside(dir)) rebuild();
+      // Every module Vite transformed from this file, dropped, so the next request for it reads
+      // the file again. The same call the status endpoint above makes, and it is effective for a
+      // board exactly as it is for a layout.json.
+      const invalidateFile = (file: string) => {
+        for (const mod of server.moduleGraph.getModulesByFile(file) ?? []) {
+          server.moduleGraph.invalidateModule(mod);
+        }
       };
 
-      server.watcher.on("add", onFile);
-      server.watcher.on("unlink", onFile);
-      // An asset edited in place keeps its name and changes its hash, so the index is stale
-      // until the module is rebuilt. Board HTML edits already reload through the module graph.
-      server.watcher.on("change", (file) => {
-        if (inside(file) && /\/assets(-dark)?\/|assets\.json$/.test(file)) rebuild();
-      });
-      server.watcher.on("addDir", onDir);
-      server.watcher.on("unlinkDir", onDir);
+      const list = (dir: string) => {
+        try {
+          return fs.readdirSync(dir);
+        } catch {
+          return []; // unreadable or gone: it signs as empty rather than throwing out of a watch
+        }
+      };
+      let signature = boardSetSignature(canvasesDir, list);
+
+      /**
+       * One settled batch of writes, answered once.
+       *
+       * The set of boards first, because a board added, removed or renamed makes the generated
+       * index wrong about which boards exist, and a reload is the only thing that fixes that.
+       * Otherwise the batch is read file by file, and a board is reloaded while a layout is
+       * handed over live — the distinction the canvas has always drawn, now drawn for a write
+       * from anywhere rather than only for one the endpoints made themselves.
+       */
+      const settle = (files: string[]) => {
+        const now = boardSetSignature(canvasesDir, list);
+        if (now !== signature) {
+          signature = now;
+          rebuild();
+          return;
+        }
+        let dropIndex = false;
+        let reload = false;
+        const layouts = new Set<string>();
+        for (const file of files) {
+          switch (boardChangeKind(canvasesDir, file)) {
+            case "board":
+              // A reload rather than an HMR update: the page keeps every board it has fetched in
+              // a Map (canvasLibrary.ts), and re-executing the generated module hands over fresh
+              // layouts, never fresh HTML. The tldraw document is in IndexedDB and survives the
+              // reload; the viewport is what it costs, which is why only a board edit spends it.
+              invalidateFile(file);
+              reload = true;
+              break;
+            case "assets":
+              // An image edited in place keeps its name and changes its hash, so the index that
+              // names a board's images by content is stale until it is generated again.
+              invalidateFile(file);
+              dropIndex = true;
+              reload = true;
+              break;
+            case "layout":
+              invalidateFile(file);
+              layouts.add(file);
+              break;
+            case "comments":
+              // No reload: comments.json is written by the endpoint above on every post, and the
+              // page that posted already holds the record. Dropping the index is only so the
+              // *next* load reads the file rather than the scan the server did at startup.
+              dropIndex = true;
+              break;
+          }
+        }
+        for (const file of layouts) {
+          // The same message the status endpoint sends, for the same reason: a layout.json is
+          // read on every render, and a reload to change one word would throw away the tldraw
+          // viewport and the open panel. canvasLibrary.ts listens.
+          try {
+            const layout = JSON.parse(fs.readFileSync(file, "utf8"));
+            server.hot.send("sp:board-status", { slug: boardSlug(canvasesDir, file), layout });
+          } catch {
+            // Half-written or malformed: the next write brings a whole one, and the page keeps
+            // the layout it has until then.
+          }
+        }
+        if (dropIndex) invalidateIndex();
+        if (reload) server.ws.send({ type: "full-reload" });
+      };
+
+      // A generator writes a folder of boards over a second or two, and a save can arrive as
+      // more than one event. Batched on the trailing edge, so a run answers with one reload
+      // once it is done rather than one per file while it is still writing.
+      const queued = new Set<string>();
+      let batch: ReturnType<typeof setTimeout> | undefined;
+      const queue = (file: string) => {
+        queued.add(file);
+        clearTimeout(batch);
+        batch = setTimeout(() => {
+          const files = [...queued];
+          queued.clear();
+          try {
+            settle(files);
+          } catch (error) {
+            server.config.logger.error(`[canvases] ${error}`);
+          }
+        }, 120);
+        // Never a reason to hold the process open: a pending reload for a server on its way down
+        // has nobody left to send it to.
+        batch.unref?.();
+      };
+
+      // The boards are watched here, directly, rather than through `server.watcher`.
+      //
+      // `server.watcher` watches the app's root, and the boards are always outside it — one level
+      // up for this checkout, anywhere at all under PROTOTYPING_CANVASES_DIR. `.add()` for a path
+      // outside the root is accepted and can then register nothing at all (issue #52), silently:
+      // no event ever arrives, the transformed module for a board stays as it was read at
+      // startup, and the server serves that board for the rest of its life however often the file
+      // is rewritten. That is unrecoverable from the browser, because the ETag never changes
+      // either, and it is the one failure a design tool must not have.
+      //
+      // Recursive fs.watch is supported on macOS and Windows, and on Linux since Node 20. Older
+      // Linux throws ERR_FEATURE_UNAVAILABLE_ON_PLATFORM, and there `server.watcher` is still
+      // better than nothing: it watches inotify-style, and the boards are usually in the same
+      // tree as the app.
+      try {
+        const watcher = fs.watch(canvasesDir, { recursive: true }, (_event, name) => {
+          if (name) queue(path.resolve(canvasesDir, name.toString()));
+        });
+        watcher.on("error", (error) => {
+          server.config.logger.error(`[canvases] watch of ${canvasesDir} failed: ${error}`);
+        });
+        watcher.unref();
+        server.httpServer?.once("close", () => watcher.close());
+      } catch (error) {
+        server.config.logger.warn(
+          `[canvases] recursive watch of ${canvasesDir} is unavailable (${error}); ` +
+            `falling back to Vite's watcher, which may miss boards outside the app's root`,
+        );
+        server.watcher.add(canvasesDir);
+        for (const event of ["add", "unlink", "change", "addDir", "unlinkDir"] as const) {
+          server.watcher.on(event, queue);
+        }
+      }
     },
   };
 }

--- a/docs/2026-09-09-boards-watched-directly.md
+++ b/docs/2026-09-09-boards-watched-directly.md
@@ -1,0 +1,61 @@
+# The canvas watches the boards itself
+
+2026-09-09. Issue #52: with `PROTOTYPING_CANVASES_DIR` pointing at a project, a board rewritten
+on disk never reached the browser. The dev server now watches the boards directory with its own
+recursive `fs.watch` instead of asking Vite's watcher to, and answers a settled batch of writes
+per kind of file.
+
+## What was wrong
+
+Two things, one for each half of the report.
+
+- `server.watcher.add(canvasesDir)` was the only registration for a directory that is *always*
+  outside the app's root — one level up for this checkout, anywhere at all for an installed
+  plugin. Adding a path outside the root is accepted silently and, on the reporter's machine,
+  registered nothing: no event ever arrived, so the transformed `?raw` module for a board kept
+  the HTML read at startup, ETag and all, and no reload in the browser could get past it. The
+  cure was restarting the server on every board write.
+- Even where the watcher does fire, a board edit did not reach the page. The comment said
+  "editing a board already reloads, because the file is in the module graph once fetched", but
+  `virtual:canvases` is self-accepting — deliberately, so a `layout.json` edit does not cost the
+  viewport — so the update stopped there, and the page keeps every board it has fetched in
+  `canvasFileHtml`. What the module hands over on re-execution is layouts, never HTML.
+
+Worth recording: the issue's repro did not reproduce on the machine that fixed it (vite 8.2.2,
+Node 26.3.1, macOS 15.7, boards under `/tmp`, run both as `npx vite` and as `bun run dev`).
+There, `.add()` did register and the edit did invalidate the module. So the first half is
+environment-dependent — which is the argument for not depending on it — and the second half was
+reproducible everywhere.
+
+## What changed
+
+- One recursive `fs.watch` on the boards directory, in `configureServer`. Supported on macOS and
+  Windows, and on Linux since Node 20; where it throws, the old `server.watcher.add` wiring is
+  the fallback, feeding the same queue.
+- Events are batched on the trailing edge, 120ms, so a generator writing twenty boards answers
+  with one reload once it has finished rather than one per file while it is still writing.
+- A batch is answered by what changed, in `boardWatch.ts`:
+  - the **set** of boards first — folders and the files the scan reads, as one signature string.
+    Moved means a board was added, removed or renamed, the generated index is wrong about which
+    boards exist, and the page reloads.
+  - a **board** edited: its module is dropped and the page reloads. That is the only way its
+    HTML gets back in, and the tldraw document is in IndexedDB, so a reload costs the viewport
+    and nothing else.
+  - a **layout.json** edited: parsed and sent over `sp:board-status`, the message the status
+    endpoint already sends, so a hand edit lands live exactly as a badge click does.
+  - an **asset** or `assets.json`: the index is regenerated, because it names a board's images by
+    the hash of their bytes.
+  - **comments.json**: the index is dropped and nothing else. The page that wrote it holds the
+    composer a reload would close.
+  - anything else — a generator, a README, `scratch/` at any depth, `assets/refs/` — is ignored.
+    Previously a `scratch/draft.html` was a board file to the watcher and reloaded the canvas
+    out from under the run that wrote it.
+
+## Checked
+
+Against the dev server on `/tmp/cv`, reading the HMR socket directly: a board edit sends
+`full-reload` and the module serves the new HTML; a board folder added or deleted sends
+`full-reload` and the index follows; the first board in an empty project appears without a
+restart; a hand-edited `layout.json` sends `sp:board-status` and no reload; posting a status or
+a comment sends no reload; an asset edited in place reloads; writes under `scratch/` and
+`assets/refs/` send nothing at all.

--- a/skills/new-ui-mock/SKILL.md
+++ b/skills/new-ui-mock/SKILL.md
@@ -128,7 +128,7 @@ and numbers, then pastes it back.
 
 1. Echo what you read each annotation as, before touching anything.
 2. Change the generator, not the artboard.
-3. Re-run the generator; HMR reloads the shape in place.
+3. Re-run the generator; the canvas reloads onto the new board.
 4. Verify that region visually before claiming it is done.
 
 Answer every annotation, including the ones you disagree with. Say so in a

--- a/skills/prototype-canvas/SKILL.md
+++ b/skills/prototype-canvas/SKILL.md
@@ -55,9 +55,10 @@ pointed at the wrong one look identical otherwise.
 
 **A folder created after boot appears on its own.** The dev server watches the
 boards directory and rebuilds its index when a board folder or file is added
-or removed. Content edits reload through HMR as always. If a `?canvas=<slug>`
-link still matches no page, the folder has no `.html` file in it yet — an
-empty folder is not a board.
+or removed. Rewriting a board reloads the page onto the new version, so a
+generator can be re-run with the canvas open. If a `?canvas=<slug>` link still
+matches no page, the folder has no `.html` file in it yet — an empty folder is
+not a board.
 
 The styles panel is hidden by default; toggle it from the toolbar. Always-snap
 is on by default. The setting is per browser, so turning it off in tldraw's
@@ -77,7 +78,7 @@ reordering a row entry leaves the old shape at its old position, overlapping
 the new one. Force-refresh deletes every `canvas-file` /
 `canvas-row-heading` / `canvas-file-label` shape on all pages and rebuilds
 them from the current files. Content-only edits to a placed file do **not**
-need it; Vite HMR updates that iframe's `srcDoc` live.
+need it: the dev server reloads the canvas onto the rewritten board.
 
 ## Drive the canvas
 
@@ -114,7 +115,7 @@ tools or any image annotator.
    it as ("box 2: tighten the card gap") before touching anything.
 2. Read the surrounding UI and the HTML source before editing.
 3. Make the smallest source change that satisfies it.
-4. Let HMR reload, then verify the same region visually.
+4. Let the canvas reload, then verify the same region visually.
 
 Do not build an annotation-to-agent protocol. The screenshot is the bridge.
 


### PR DESCRIPTION
Closes #52.

## What the issue is, and what I could confirm

Two separate failures, one for each half of the report.

**The watcher.** `server.watcher.add(canvasesDir)` was the only registration for a directory that is *always* outside the app's root — one level up for this checkout, anywhere at all for an installed plugin. Adding a path outside the root is accepted silently, and on the reporter's machine registered nothing: no event arrived, the transformed `?raw` module for a board kept the HTML read at startup, its ETag never changed, and no reload in the browser could get past it.

Honestly: **that repro did not reproduce here** — vite 8.2.2, Node 26.3.1, macOS 15.7, boards under `/tmp`, run both as `npx vite` and as `bun run dev`. `.add()` did register, the edit did invalidate the module. So that half is environment-dependent, which is precisely the argument for not depending on it.

**The reload.** This half reproduces everywhere, and is why "editing a board changes nothing in the browser" is true even where the watcher works. The comment said "editing a board already reloads, because the file is in the module graph once fetched", but `virtual:canvases` is self-accepting — deliberately, so a `layout.json` edit does not cost the viewport — so the update stopped there and no reload was ever broadcast. What that module hands over on re-execution is layouts, never HTML, and the page keeps every board it has fetched in `canvasFileHtml`.

## The fix

One recursive `fs.watch` on the boards directory (macOS, Windows, Linux since Node 20; where it throws, the old `server.watcher` wiring is the fallback feeding the same queue). Events are batched on the trailing edge, 120ms, so a generator writing twenty boards answers with one reload when it is done rather than one per file mid-write.

A batch is answered by what changed, classified in the new `canvas/src/boardWatch.ts`:

| change | answer |
| --- | --- |
| the set of boards moved (added, removed, renamed) | index dropped, page reloads |
| a board's HTML | its module dropped, page reloads |
| `layout.json` | parsed and sent over `sp:board-status` — the message the status endpoint already sends, so a hand edit lands live exactly as a badge click does |
| an asset or `assets.json` | index regenerated (it names images by the hash of their bytes) |
| `comments.json` | index dropped, **no** reload — the page that wrote it holds the composer |
| a generator, a README, `scratch/**`, `assets/refs/**` | nothing |

That last row is a fix in its own right: a `scratch/draft.html` was a board file to the old watcher, so a run reloaded the canvas out from under itself.

## Checked

Against the dev server, reading the HMR socket directly: a board edit sends `full-reload` and the module serves the new HTML; a board folder added or deleted sends `full-reload` and the index follows; the first board in an empty project appears with no restart; a hand-edited `layout.json` sends `sp:board-status` and no reload; posting a status or a comment sends no reload; an asset edited in place reloads; writes under `scratch/` and `assets/refs/` send nothing.

`bun run lint && bun run test && bun run build` all pass (84 tests, 8 of them new). The repo's own 261-board canvas still discovers everything on a bare `bun run dev`.

The decision is written up in `docs/2026-09-09-boards-watched-directly.md`, including the note that the reported repro did not reproduce here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
