### PR TITLE
release: a version bump that actually reaches an install

### DIFF
--- a/.agents/plugins/README.md
+++ b/.agents/plugins/README.md
@@ -1,0 +1,21 @@
+# .agents/plugins
+
+`marketplace.json` is the catalogue Codex reads when this repo is added with
+`codex plugin marketplace add ReScienceLab/super-prototyping`. It lists one
+plugin — this repo — whose source is `./`, so the marketplace and the plugin
+are the same checkout.
+
+Codex would work without this file: it looks for
+`.agents/plugins/marketplace.json`, then `.agents/plugins/api_marketplace.json`,
+then `.claude-plugin/marketplace.json`, and the Claude catalogue is a fine
+enough description of the same plugin. The file exists so that what Codex reads
+is written for Codex: `interface.displayName`, the `policy` block and
+`category` have no Claude Code equivalent, and a future divergence between the
+two products has a place to live.
+
+It carries no version. The version comes from the plugin manifests, which
+`scripts/bump-version.sh` moves together, and Codex caches the install under
+it: `plugins/cache/<marketplace>/<plugin>/<version>/`.
+
+`.agents/skills` beside it is a symlink to `skills/`, for products that read a
+skills directory directly.

--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,21 @@
+{
+  "$comment": "The catalogue Codex reads. Without it Codex falls back to .claude-plugin/marketplace.json, which works but is a manifest written for another product; this one carries the fields only Codex has.",
+  "name": "super-prototyping",
+  "interface": {
+    "displayName": "Super Prototyping"
+  },
+  "plugins": [
+    {
+      "name": "super-prototyping",
+      "source": {
+        "source": "url",
+        "url": "./"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Design"
+    }
+  ]
+}

--- a/.claude-plugin/README.md
+++ b/.claude-plugin/README.md
@@ -12,5 +12,6 @@ It is deliberately not `strict: false`. `plugin.json` stays the single
 definition, and a second plugin later is one added entry here rather than a
 restructure.
 
-Both versions, plus `.codex-plugin/plugin.json` and `tools/pyproject.toml`,
-move together through `scripts/bump-version.sh`. Never edit a version by hand.
+Both versions move together with every other one through
+`scripts/bump-version.sh`. `.version-bump.json` is the list. Never edit a
+version by hand.

--- a/.codebuddy-plugin/README.md
+++ b/.codebuddy-plugin/README.md
@@ -1,0 +1,33 @@
+# .codebuddy-plugin
+
+The CodeBuddy-side manifest, mirroring `.claude-plugin/plugin.json` the way
+`.codex-plugin/` does. Same name, same version, same `"skills": "./skills/"`.
+CodeBuddy is the CLI behind Tencent's WorkBuddy.
+
+CodeBuddy reads a plugin manifest from `.codebuddy-plugin/plugin.json` first,
+then `.workbuddy-plugin/plugin.json`, then `.claude-plugin/plugin.json`, and it
+is built to the Claude Code plugin specification, so this repo was installable
+before this file existed. It exists for the same reason the Codex one does: what
+a product reads should be written for that product, and a divergence between the
+two then has somewhere to live. The other two spellings are not duplicated here.
+Three copies of one manifest is three chances to disagree, and the fallback
+already covers them.
+
+The catalogue `codebuddy plugin marketplace add ReScienceLab/super-prototyping`
+reads is `.claude-plugin/marketplace.json`, by that same compatibility. The docs
+do not name a `.codebuddy-plugin/marketplace.json`, so this directory
+deliberately does not guess at one: a file found first and misread is worse than
+no file at all.
+
+Install:
+
+```bash
+codebuddy plugin marketplace add ReScienceLab/super-prototyping
+codebuddy plugin install super-prototyping --scope user
+```
+
+CodeBuddy resolves the version from this manifest and caches the install under
+`~/.codebuddy/plugins/cache/<marketplace>/<plugin>/<version>/`, and it resolves
+version constraints against `{plugin-name}--v{version}` tags — the same tag this
+repo already cuts. So the version here is the cache key, and it moves with the
+others through `scripts/bump-version.sh`. Never edit it by hand.

--- a/.codebuddy-plugin/plugin.json
+++ b/.codebuddy-plugin/plugin.json
@@ -1,0 +1,23 @@
+{
+  "name": "super-prototyping",
+  "version": "1.0.0",
+  "description": "Rebuild and design product UI as self-contained HTML artboards on a local tldraw canvas. Clone a real app from screenshots by measurement, design new screens from measured tokens, and drive the canvas that shows them.",
+  "author": {
+    "name": "ReScience Lab",
+    "url": "https://github.com/ReScienceLab"
+  },
+  "homepage": "https://prototyping.rescience.com",
+  "repository": "https://github.com/ReScienceLab/super-prototyping",
+  "license": "Apache-2.0",
+  "keywords": [
+    "design",
+    "ui",
+    "prototyping",
+    "tldraw",
+    "mockups",
+    "screenshots",
+    "design-tokens",
+    "html"
+  ],
+  "skills": "./skills/"
+}

--- a/.codex-plugin/README.md
+++ b/.codex-plugin/README.md
@@ -10,7 +10,7 @@ Codex does have a marketplace, as of `codex-cli` 0.145:
 `plugins/cache/<marketplace>/<plugin>/<version>/`, keyed by the version in this
 manifest. The catalogue it reads is `.agents/plugins/marketplace.json`.
 `scripts/install-skills.sh` is still there for a Codex too old for the plugin
-commands, and for Hermes and Pi: it symlinks each `skills/*` into their skill
-roots.
+commands, and for products that have no such command at all: it symlinks each
+`skills/*` into their skill roots.
 
 Its version moves with the others through `scripts/bump-version.sh`.

--- a/.codex-plugin/README.md
+++ b/.codex-plugin/README.md
@@ -4,9 +4,13 @@ The Codex-side manifest, mirroring `.claude-plugin/plugin.json`. Same name,
 same version, same `"skills": "./skills/"` — one skills tree, a thin manifest
 per product, so a skill is never forked to be ported.
 
-Codex has no marketplace, so nothing here is fetched automatically. Users
-clone the repo and run `scripts/install-skills.sh`, which symlinks each
-`skills/*` into `~/.codex/skills`. This file is the declaration of what that
-install contains.
+Codex does have a marketplace, as of `codex-cli` 0.145:
+`codex plugin marketplace add ReScienceLab/super-prototyping` then
+`codex plugin add super-prototyping@super-prototyping` copies the plugin into
+`plugins/cache/<marketplace>/<plugin>/<version>/`, keyed by the version in this
+manifest. The catalogue it reads is `.agents/plugins/marketplace.json`.
+`scripts/install-skills.sh` is still there for a Codex too old for the plugin
+commands, and for Hermes and Pi: it symlinks each `skills/*` into their skill
+roots.
 
 Its version moves with the others through `scripts/bump-version.sh`.

--- a/.github/ISSUE_TEMPLATE/README.md
+++ b/.github/ISSUE_TEMPLATE/README.md
@@ -1,5 +1,0 @@
-# Issue templates
-
-`bug_report.md` and `feature_request.md` are the two forms offered when
-someone opens an issue. `config.yml` adds the links shown above them and keeps
-blank issues enabled.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,5 +7,5 @@
 - [ ] No `ref-*.html`, `assets/refs/` or other third-party captures are in this PR.
 - [ ] If a canvas folder changed: `gen.py` was edited and re-run, and the `NN-*.html` boards were not hand-edited.
 - [ ] If a canvas folder changed: `layout.json`, `probes.json`, `crops.json` and `assets.json` are committed alongside the boards.
-- [ ] Every new folder has a `README.md` and no folder has its own `.gitignore`.
+- [ ] Every new canvas folder has a `README.md` and no folder has its own `.gitignore`.
 - [ ] If `canvas/` changed: `bun test` and `bun run build` pass in `canvas/`.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,151 @@
+name: Release
+
+# A release is a version string, because the version is the cache key both
+# Claude Code and Codex compare against an install: merging to main ships
+# nothing until the number moves. This runs in two halves, because the "Protect
+# main" ruleset requires a pull request and no actor bypasses it.
+#
+#   1. Dispatch this workflow with a version. It runs the gates, bumps every
+#      manifest with scripts/bump-version.sh, and opens a release PR.
+#   2. Merging that PR changes .claude-plugin/plugin.json on main, which fires
+#      the second half: it tags super-prototyping--v<version> and cuts the
+#      GitHub Release from the matching RELEASE-NOTES.md section.
+#
+# Nothing tags a commit that is not on main, and re-running the second half on
+# an already-tagged version is a no-op — the tag ruleset forbids moving a tag,
+# so the job checks before it creates one.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version, e.g. 1.1.0'
+        required: true
+        type: string
+  push:
+    branches: [main]
+    paths:
+      - '.claude-plugin/plugin.json'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+jobs:
+  gates:
+    name: Gates
+    if: github.event_name == 'workflow_dispatch'
+    uses: ./.github/workflows/validate.yml
+
+  prepare:
+    name: Prepare the release PR
+    if: github.event_name == 'workflow_dispatch'
+    needs: gates
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Bump every manifest
+        run: |
+          scripts/bump-version.sh "${{ inputs.version }}"
+          scripts/bump-version.sh --check
+
+      - name: Open the release PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          if git diff --quiet; then
+            echo "::error::every manifest is already at $VERSION — nothing to release"
+            exit 1
+          fi
+          git config user.name  'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git switch -c "release/$VERSION"
+          git commit -am "release $VERSION"
+          git push --set-upstream origin "release/$VERSION"
+          # The tag and the notes come after the merge; this PR is only the bump.
+          gh pr create --base main --title "release $VERSION" --body "$(cat <<BODY
+          Version bump only — \`scripts/bump-version.sh $VERSION\`.
+
+          Merging this tags \`super-prototyping--v$VERSION\` and cuts the GitHub
+          Release from the \`## v$VERSION\` section of \`RELEASE-NOTES.md\`, so write
+          that section before merging if it is not in yet.
+
+          Users are on the old version until this merges: the version string is the
+          cache key \`/plugin update\` and \`codex plugin marketplace upgrade\` compare.
+          BODY
+          )"
+
+  tag:
+    name: Tag and release
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Read the version, and stop if it is already tagged
+        id: v
+        run: |
+          set -euo pipefail
+          version=$(python3 -c 'import json;print(json.load(open(".claude-plugin/plugin.json"))["version"])')
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          if git rev-parse -q --verify "refs/tags/super-prototyping--v$version" > /dev/null; then
+            echo "super-prototyping--v$version already exists — nothing to do"
+            echo "fresh=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "fresh=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/setup-node@v4
+        if: steps.v.outputs.fresh == 'true'
+        with:
+          node-version: "22"
+
+      - name: Install Claude Code
+        if: steps.v.outputs.fresh == 'true'
+        run: npm install -g @anthropic-ai/claude-code
+
+      # `claude plugin tag` is the tool's own spelling of this repo's tag: it
+      # validates the plugin, checks plugin.json and the marketplace entry agree on
+      # the version, and refuses a dirty tree.
+      - name: Tag
+        if: steps.v.outputs.fresh == 'true'
+        run: |
+          git config user.name  'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          claude plugin tag . --push -m 'super-prototyping %s'
+
+      - name: Cut the GitHub Release
+        if: steps.v.outputs.fresh == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.v.outputs.version }}
+        run: |
+          set -euo pipefail
+          # The section for this version, up to the next one. Written for a person
+          # deciding whether to update, which no commit log gives you.
+          awk -v want="## v$VERSION" '
+            index($0, want) == 1 { on = 1; next }
+            on && /^## v/ { exit }
+            on { print }
+          ' RELEASE-NOTES.md > notes.md
+          if [ -s notes.md ]; then
+            gh release create "super-prototyping--v$VERSION" \
+              --title "super-prototyping $VERSION" --notes-file notes.md
+          else
+            echo "::warning::RELEASE-NOTES.md has no '## v$VERSION' section — falling back to generated notes"
+            gh release create "super-prototyping--v$VERSION" \
+              --title "super-prototyping $VERSION" --generate-notes
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ name: Release
 # GitHub Actions to create and approve pull requests" must be on, or the first
 # job pushes its branch and then fails to open the PR; and a PR opened by
 # GITHUB_TOKEN does not itself trigger `pull_request` workflows, so the release
-# PR shows no Validate run. That is deliberate — `gates` ran on the commit
+# PR shows no Validate run. That is deliberate: `gates` ran on the commit
 # being released, the bump touches only version strings, and `claude plugin
 # tag` validates again before tagging.
 
@@ -75,7 +75,7 @@ jobs:
         run: |
           set -euo pipefail
           if git diff --quiet; then
-            echo "::error::every manifest is already at $VERSION — nothing to release"
+            echo "::error::every manifest is already at $VERSION, so there is nothing to release"
             exit 1
           fi
           git config user.name  'github-actions[bot]'
@@ -83,15 +83,15 @@ jobs:
           git switch -c "release/$VERSION"
           git commit -am "release $VERSION"
           # --force-with-lease so a dispatch that failed after the push (see the
-          # header) can simply be re-run rather than needing the branch deleted.
+          # header) can be re-run rather than needing the branch deleted.
           git push --force-with-lease --set-upstream origin "release/$VERSION"
           if [ -n "$(gh pr list --head "release/$VERSION" --state open --json number --jq '.[].number')" ]; then
-            echo "a PR for release/$VERSION is already open — pushed the new bump to it"
+            echo "a PR for release/$VERSION is already open; pushed the new bump to it"
             exit 0
           fi
           # The tag and the notes come after the merge; this PR is only the bump.
           gh pr create --base main --title "release $VERSION" --body "$(cat <<BODY
-          Version bump only — \`scripts/bump-version.sh $VERSION\`.
+          Version bump only: \`scripts/bump-version.sh $VERSION\`.
 
           Merging this tags \`super-prototyping--v$VERSION\` and cuts the GitHub
           Release from the \`## v$VERSION\` section of \`RELEASE-NOTES.md\`, so write
@@ -101,7 +101,7 @@ jobs:
           cache key \`/plugin update\` and \`codex plugin marketplace upgrade\` compare.
           BODY
           )" || {
-            echo "::error::could not open the PR. The branch release/$VERSION is pushed, so nothing is lost — open it by hand at https://github.com/${{ github.repository }}/compare/main...release/$VERSION, and check that Settings → Actions → General → 'Allow GitHub Actions to create and approve pull requests' is on."
+            echo "::error::could not open the PR. The branch release/$VERSION is pushed, so nothing is lost. Open it by hand at https://github.com/${{ github.repository }}/compare/main...release/$VERSION, and check that Settings → Actions → General → 'Allow GitHub Actions to create and approve pull requests' is on."
             exit 1
           }
 
@@ -131,13 +131,13 @@ jobs:
           fresh=true
 
           if ! git cat-file -e "$BEFORE:.claude-plugin/plugin.json" 2> /dev/null; then
-            echo "no plugin.json at $BEFORE — nothing to compare against, so nothing to tag"
+            echo "no plugin.json at $BEFORE, so there is nothing to compare against and nothing to tag"
             fresh=false
           elif [ "$(git show "$BEFORE:.claude-plugin/plugin.json" | read_version)" = "$version" ]; then
-            echo "plugin.json changed but the version did not ($version) — not a release"
+            echo "plugin.json changed but the version did not ($version), so this is not a release"
             fresh=false
           elif git rev-parse -q --verify "refs/tags/super-prototyping--v$version" > /dev/null; then
-            echo "super-prototyping--v$version already exists — nothing to do"
+            echo "super-prototyping--v$version already exists, so there is nothing to do"
             fresh=false
           else
             echo "this push released $version"
@@ -190,7 +190,7 @@ jobs:
             gh release create "super-prototyping--v$VERSION" $prerelease \
               --title "super-prototyping $VERSION" --notes-file notes.md
           else
-            echo "::warning::RELEASE-NOTES.md has no '## v$VERSION' section — falling back to generated notes"
+            echo "::warning::RELEASE-NOTES.md has no '## v$VERSION' section; falling back to generated notes"
             gh release create "super-prototyping--v$VERSION" $prerelease \
               --title "super-prototyping $VERSION" --generate-notes
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,9 +11,17 @@ name: Release
 #      the second half: it tags super-prototyping--v<version> and cuts the
 #      GitHub Release from the matching RELEASE-NOTES.md section.
 #
-# Nothing tags a commit that is not on main, and re-running the second half on
-# an already-tagged version is a no-op — the tag ruleset forbids moving a tag,
-# so the job checks before it creates one.
+# Nothing tags a commit that is not on main, and the second half only acts when
+# the version actually changed in that push: the tag ruleset forbids moving a
+# tag, and an edit to plugin.json that is not a release must not cut one.
+#
+# Two settings this depends on, neither of them a file in the repo: "Allow
+# GitHub Actions to create and approve pull requests" must be on, or the first
+# job pushes its branch and then fails to open the PR; and a PR opened by
+# GITHUB_TOKEN does not itself trigger `pull_request` workflows, so the release
+# PR shows no Validate run. That is deliberate — `gates` ran on the commit
+# being released, the bump touches only version strings, and `claude plugin
+# tag` validates again before tagging.
 
 on:
   workflow_dispatch:
@@ -37,12 +45,14 @@ concurrency:
 jobs:
   gates:
     name: Gates
-    if: github.event_name == 'workflow_dispatch'
+    # A release is cut from main, so dispatching from a branch would bump a tree
+    # nobody reviewed and open a PR carrying every commit on it.
+    if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'
     uses: ./.github/workflows/validate.yml
 
   prepare:
     name: Prepare the release PR
-    if: github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'
     needs: gates
     runs-on: ubuntu-latest
     permissions:
@@ -52,8 +62,10 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Bump every manifest
+        env:
+          VERSION: ${{ inputs.version }}
         run: |
-          scripts/bump-version.sh "${{ inputs.version }}"
+          scripts/bump-version.sh "$VERSION"
           scripts/bump-version.sh --check
 
       - name: Open the release PR
@@ -70,7 +82,13 @@ jobs:
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
           git switch -c "release/$VERSION"
           git commit -am "release $VERSION"
-          git push --set-upstream origin "release/$VERSION"
+          # --force-with-lease so a dispatch that failed after the push (see the
+          # header) can simply be re-run rather than needing the branch deleted.
+          git push --force-with-lease --set-upstream origin "release/$VERSION"
+          if [ -n "$(gh pr list --head "release/$VERSION" --state open --json number --jq '.[].number')" ]; then
+            echo "a PR for release/$VERSION is already open — pushed the new bump to it"
+            exit 0
+          fi
           # The tag and the notes come after the merge; this PR is only the bump.
           gh pr create --base main --title "release $VERSION" --body "$(cat <<BODY
           Version bump only — \`scripts/bump-version.sh $VERSION\`.
@@ -82,7 +100,10 @@ jobs:
           Users are on the old version until this merges: the version string is the
           cache key \`/plugin update\` and \`codex plugin marketplace upgrade\` compare.
           BODY
-          )"
+          )" || {
+            echo "::error::could not open the PR. The branch release/$VERSION is pushed, so nothing is lost — open it by hand at https://github.com/${{ github.repository }}/compare/main...release/$VERSION, and check that Settings → Actions → General → 'Allow GitHub Actions to create and approve pull requests' is on."
+            exit 1
+          }
 
   tag:
     name: Tag and release
@@ -95,18 +116,35 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Read the version, and stop if it is already tagged
+      # The trigger only says plugin.json was touched, which any edit does. A
+      # release is the narrower thing: the version *changed* in this push, and no
+      # tag names it yet. Renaming a field or adding a keyword must not cut a
+      # release of whatever version happens to be sitting in the file.
+      - name: Read the version, and stop unless this push released it
         id: v
+        env:
+          BEFORE: ${{ github.event.before }}
         run: |
           set -euo pipefail
-          version=$(python3 -c 'import json;print(json.load(open(".claude-plugin/plugin.json"))["version"])')
-          echo "version=$version" >> "$GITHUB_OUTPUT"
-          if git rev-parse -q --verify "refs/tags/super-prototyping--v$version" > /dev/null; then
+          read_version() { python3 -c 'import json,sys;print(json.load(sys.stdin)["version"])'; }
+          version=$(read_version < .claude-plugin/plugin.json)
+          fresh=true
+
+          if ! git cat-file -e "$BEFORE:.claude-plugin/plugin.json" 2> /dev/null; then
+            echo "no plugin.json at $BEFORE — nothing to compare against, so nothing to tag"
+            fresh=false
+          elif [ "$(git show "$BEFORE:.claude-plugin/plugin.json" | read_version)" = "$version" ]; then
+            echo "plugin.json changed but the version did not ($version) — not a release"
+            fresh=false
+          elif git rev-parse -q --verify "refs/tags/super-prototyping--v$version" > /dev/null; then
             echo "super-prototyping--v$version already exists — nothing to do"
-            echo "fresh=false" >> "$GITHUB_OUTPUT"
+            fresh=false
           else
-            echo "fresh=true" >> "$GITHUB_OUTPUT"
+            echo "this push released $version"
           fi
+
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "fresh=$fresh" >> "$GITHUB_OUTPUT"
 
       - uses: actions/setup-node@v4
         if: steps.v.outputs.fresh == 'true'
@@ -134,18 +172,25 @@ jobs:
           VERSION: ${{ steps.v.outputs.version }}
         run: |
           set -euo pipefail
-          # The section for this version, up to the next one. Written for a person
-          # deciding whether to update, which no commit log gives you.
+          # The section for this version, up to the next heading of any kind. The
+          # heading must match exactly: a prefix match would hand `1.1.0` the notes
+          # written under `## v1.1.0-rc.1`.
           awk -v want="## v$VERSION" '
-            index($0, want) == 1 { on = 1; next }
-            on && /^## v/ { exit }
+            $0 == want { on = 1; next }
+            on && /^## / { exit }
             on { print }
           ' RELEASE-NOTES.md > notes.md
+          # A version with a suffix is a prerelease; GitHub should not offer it as
+          # the latest release.
+          case "$VERSION" in
+            *-*) prerelease=--prerelease ;;
+            *)   prerelease= ;;
+          esac
           if [ -s notes.md ]; then
-            gh release create "super-prototyping--v$VERSION" \
+            gh release create "super-prototyping--v$VERSION" $prerelease \
               --title "super-prototyping $VERSION" --notes-file notes.md
           else
             echo "::warning::RELEASE-NOTES.md has no '## v$VERSION' section — falling back to generated notes"
-            gh release create "super-prototyping--v$VERSION" \
+            gh release create "super-prototyping--v$VERSION" $prerelease \
               --title "super-prototyping $VERSION" --generate-notes
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,9 +19,10 @@ name: Release
 # GitHub Actions to create and approve pull requests" must be on, or the first
 # job pushes its branch and then fails to open the PR; and a PR opened by
 # GITHUB_TOKEN does not itself trigger `pull_request` workflows, so the release
-# PR shows no Validate run. That is deliberate: `gates` ran on the commit
-# being released, the bump touches only version strings, and `claude plugin
-# tag` validates again before tagging.
+# PR shows no Validate run until a person pushes to it, which step 4 of the
+# release asks for anyway. Either way it is covered: `gates` ran on the commit
+# being released, the bump touches only version strings, and the tag job
+# re-checks every manifest before `claude plugin tag` runs.
 
 on:
   workflow_dispatch:
@@ -38,10 +39,6 @@ on:
 permissions:
   contents: read
 
-concurrency:
-  group: release
-  cancel-in-progress: false
-
 jobs:
   gates:
     name: Gates
@@ -52,6 +49,11 @@ jobs:
 
   prepare:
     name: Prepare the release PR
+    # A group per half. Sharing one lets a push queue behind a dispatch and then be
+    # cancelled by the next push, which would drop a version on the floor untagged.
+    concurrency:
+      group: release-prepare
+      cancel-in-progress: false
     if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'
     needs: gates
     runs-on: ubuntu-latest
@@ -80,11 +82,29 @@ jobs:
           fi
           git config user.name  'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-          git switch -c "release/$VERSION"
-          git commit -am "release $VERSION"
-          # --force-with-lease so a dispatch that failed after the push (see the
-          # header) can be re-run rather than needing the branch deleted.
-          git push --force-with-lease --set-upstream origin "release/$VERSION"
+
+          # A re-dispatch of the same version must not discard the release notes
+          # someone has already written on the branch, so the bump is replayed on
+          # top of what is there. A lease cannot protect that: actions/checkout
+          # maps only the branch it checked out, so --force-with-lease finds no
+          # remote-tracking ref for release/<version>, reads the lease as "must
+          # not exist", and rejects the push whenever the branch is already up.
+          if git ls-remote --exit-code --heads origin "release/$VERSION" > /dev/null 2>&1; then
+            git fetch --depth 1 origin "release/$VERSION"
+            git checkout -f -B "release/$VERSION" FETCH_HEAD
+            scripts/bump-version.sh "$VERSION"
+            scripts/bump-version.sh --check
+            if git diff --quiet; then
+              echo "release/$VERSION is already at $VERSION; leaving the branch as it is"
+            else
+              git commit -am "release $VERSION"
+              git push origin "release/$VERSION"
+            fi
+          else
+            git switch -c "release/$VERSION"
+            git commit -am "release $VERSION"
+            git push --set-upstream origin "release/$VERSION"
+          fi
           if [ -n "$(gh pr list --head "release/$VERSION" --state open --json number --jq '.[].number')" ]; then
             echo "a PR for release/$VERSION is already open; pushed the new bump to it"
             exit 0
@@ -107,6 +127,9 @@ jobs:
 
   tag:
     name: Tag and release
+    concurrency:
+      group: release-tag
+      cancel-in-progress: false
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
     permissions:
@@ -127,14 +150,36 @@ jobs:
         run: |
           set -euo pipefail
           read_version() { python3 -c 'import json,sys;print(json.load(sys.stdin)["version"])'; }
+          # Semver precedence, which `sort -V` does not implement: it ranks 1.1.0-rc.1
+          # above 1.1.0, so the ordinary rc-to-final release would read as a downgrade
+          # and a real downgrade would read as a release. A version neither side can
+          # parse exits 2 here, which counts as "did not move forward" and is not tagged.
+          newer() {
+            python3 -c 'import re, sys
+          def key(v):
+              m = re.match(r"(\d+)\.(\d+)\.(\d+)(?:-(.+))?$", v)
+              if not m:
+                  sys.exit(2)
+              pre = m.group(4)
+              rel = tuple(int(x) for x in m.group(1, 2, 3))
+              return rel + ((0, tuple(int(n) for n in re.findall(r"\d+", pre))) if pre else (1, ()))
+          sys.exit(0 if key(sys.argv[2]) > key(sys.argv[1]) else 1)' "$1" "$2"
+          }
           version=$(read_version < .claude-plugin/plugin.json)
           fresh=true
 
           if ! git cat-file -e "$BEFORE:.claude-plugin/plugin.json" 2> /dev/null; then
             echo "no plugin.json at $BEFORE, so there is nothing to compare against and nothing to tag"
             fresh=false
-          elif [ "$(git show "$BEFORE:.claude-plugin/plugin.json" | read_version)" = "$version" ]; then
+          elif before=$(git show "$BEFORE:.claude-plugin/plugin.json" | read_version); [ "$before" = "$version" ]; then
             echo "plugin.json changed but the version did not ($version), so this is not a release"
+            fresh=false
+          elif ! newer "$before" "$version"; then
+            # Reverting the release PR restores the old number on a tree that still
+            # holds the new code, and the tag ruleset forbids moving a tag once it is
+            # cut. So a version that does not move forward is a revert, not a release,
+            # and tagging it would be unfixable.
+            echo "the version did not move forward ($before to $version), so this is not a release"
             fresh=false
           elif git rev-parse -q --verify "refs/tags/super-prototyping--v$version" > /dev/null; then
             echo "super-prototyping--v$version already exists, so there is nothing to do"
@@ -153,7 +198,19 @@ jobs:
 
       - name: Install Claude Code
         if: steps.v.outputs.fresh == 'true'
-        run: npm install -g @anthropic-ai/claude-code
+        # Unpinned, so the version that tagged a release is worth having in the log:
+        # the tag format and what --strict rejects are both its to change.
+        run: |
+          npm install -g @anthropic-ai/claude-code
+          claude --version
+
+      # `claude plugin tag` reads .claude-plugin/plugin.json and the marketplace entry
+      # and nothing else, so without this the root, Codex, CodeBuddy and pyproject
+      # versions are unchecked at the moment of tagging: exactly the half-versioned
+      # release scripts/bump-version.sh exists to prevent.
+      - name: Every manifest still agrees
+        if: steps.v.outputs.fresh == 'true'
+        run: scripts/bump-version.sh --check
 
       # `claude plugin tag` is the tool's own spelling of this repo's tag: it
       # validates the plugin, checks plugin.json and the marketplace entry agree on
@@ -176,6 +233,7 @@ jobs:
           # heading must match exactly: a prefix match would hand `1.1.0` the notes
           # written under `## v1.1.0-rc.1`.
           awk -v want="## v$VERSION" '
+            { sub(/\r$/, ""); sub(/[ \t]+$/, "") }
             $0 == want { on = 1; next }
             on && /^## / { exit }
             on { print }
@@ -186,7 +244,8 @@ jobs:
             *-*) prerelease=--prerelease ;;
             *)   prerelease= ;;
           esac
-          if [ -s notes.md ]; then
+          # -s would pass a section that is nothing but blank lines.
+          if grep -q '[^[:space:]]' notes.md; then
             gh release create "super-prototyping--v$VERSION" $prerelease \
               --title "super-prototyping $VERSION" --notes-file notes.md
           else

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,97 @@
+name: Validate
+
+# The gates a release has to pass. Nothing here needs a secret, so it runs on
+# every pull request; `release.yml` calls this same file before it prepares one,
+# which is why `workflow_call` is in the trigger list.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_call:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  manifests:
+    name: Manifests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Install Claude Code
+        run: npm install -g @anthropic-ai/claude-code
+
+      # --strict fails on warnings: an unrecognised field is how a manifest silently
+      # ships half its components (`mcpServer` for `mcpServers` validates as an
+      # unknown key and loads nothing).
+      - name: Validate the marketplace manifest
+        run: claude plugin validate . --strict
+
+      - name: Validate the plugin manifest
+        run: claude plugin validate .claude-plugin/plugin.json --strict
+
+      # Codex reads .agents/plugins/marketplace.json and .codex-plugin/plugin.json,
+      # and `claude plugin validate` has no opinion about either. Parsing is the most
+      # this can check without a Codex CLI on the runner; a broken one there means
+      # `codex plugin add` fails at install time, with nothing upstream to catch it.
+      - name: Parse the manifests Claude Code does not read
+        run: |
+          for f in .codex-plugin/plugin.json .agents/plugins/marketplace.json .version-bump.json; do
+            echo "parsing $f"
+            python3 -m json.tool "$f" > /dev/null
+          done
+
+      # The version is the cache key an install compares against, so two manifests
+      # disagreeing means half the install updates and half does not.
+      - name: Every manifest agrees on one version
+        run: scripts/bump-version.sh --check
+
+      - name: Shell scripts parse
+        run: |
+          bash -n scripts/bump-version.sh
+          bash -n scripts/install-skills.sh
+
+  canvas:
+    name: Canvas
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: canvas
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - uses: oven-sh/setup-bun@v2
+
+      - run: bun install --frozen-lockfile
+      - run: bun run lint
+      - run: bun run test
+      - run: bun run build
+
+  tools:
+    name: Toolkit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - uses: astral-sh/setup-uv@v5
+
+      # The same two lines the README gives for running these locally.
+      - run: uv run --with pillow --with numpy python tools/test_refkit.py
+      - run: uv run python tools/test_sp_canvas.py
+
+      # The skills call these by name, so a syntax error in one is a broken install
+      # rather than a broken test.
+      - run: uv run python -m compileall -q tools

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -39,16 +39,36 @@ jobs:
       - name: Validate the plugin manifest
         run: claude plugin validate .claude-plugin/plugin.json --strict
 
-      # Codex reads .agents/plugins/marketplace.json and .codex-plugin/plugin.json,
-      # and `claude plugin validate` has no opinion about either. Parsing is the most
-      # this can check without a Codex CLI on the runner; a broken one there means
-      # `codex plugin add` fails at install time, with nothing upstream to catch it.
+      # Four other products read four other files, and `claude plugin validate` has
+      # no opinion about any of them. Parsing is the most this can check without
+      # each product's CLI on the runner; a broken one means that product's install
+      # fails, with nothing upstream to catch it.
       - name: Parse the manifests Claude Code does not read
         run: |
-          for f in .codex-plugin/plugin.json .agents/plugins/marketplace.json .version-bump.json; do
+          for f in plugin.json .codex-plugin/plugin.json .codebuddy-plugin/plugin.json \
+                   .agents/plugins/marketplace.json .version-bump.json; do
             echo "parsing $f"
             python3 -m json.tool "$f" > /dev/null
           done
+
+      # The portable manifest is schema'd, and its two required fields are the two
+      # a hand-edit is most likely to drop. `name` also has to match the other
+      # manifests, or a product installs a plugin under a name nothing else uses.
+      - name: The portable manifest is Agent Plugins v1
+        run: |
+          python3 - <<'PY'
+          import json
+
+          portable = json.load(open("plugin.json"))
+          claude = json.load(open(".claude-plugin/plugin.json"))
+
+          schema = "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json"
+          assert portable.get("$schema") == schema, portable.get("$schema")
+          assert portable.get("name") == claude["name"], portable.get("name")
+          # Skills are discovered from skills/*/SKILL.md; the schema forbids the key.
+          assert "skills" not in portable
+          print("plugin.json is a v1.0.0 manifest for", portable["name"])
+          PY
 
       # The version is the cache key an install compares against, so two manifests
       # disagreeing means half the install updates and half does not.

--- a/.version-bump.json
+++ b/.version-bump.json
@@ -1,9 +1,11 @@
 {
   "files": [
+    { "path": "plugin.json", "field": "version" },
     { "path": ".claude-plugin/plugin.json", "field": "version" },
     { "path": ".claude-plugin/marketplace.json", "field": "metadata.version" },
     { "path": ".claude-plugin/marketplace.json", "field": "plugins.0.version" },
     { "path": ".codex-plugin/plugin.json", "field": "version" },
+    { "path": ".codebuddy-plugin/plugin.json", "field": "version" },
     { "path": "tools/pyproject.toml", "field": "project.version" }
   ],
   "tagPrefix": "super-prototyping--v"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,10 +25,13 @@ commands on PATH. The skills invoke them by name, never by path: no agent
 product exposes its plugin root to a shell, so a path-based invocation would
 need a different spelling per product.
 
-`.claude-plugin/` and `.codex-plugin/` are the per-product manifests, and
-`scripts/install-skills.sh` links the skills into products that read a skills
-directory. `scripts/bump-version.sh` moves every version in `.version-bump.json`
-at once; run it with `--check` before releasing.
+`.claude-plugin/`, `.codex-plugin/` and `.codebuddy-plugin/` are the per-product
+manifests, and the root `plugin.json` is the portable Agent Plugins v1 one that
+Hermes reads. All four describe the same `skills/` tree — a manifest per
+product, never a skill per product. `scripts/install-skills.sh` links the skills
+into products that read a skills directory instead.
+`scripts/bump-version.sh` moves every version in `.version-bump.json` at once;
+run it with `--check` before releasing.
 
 Data, this repo's own:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,8 +36,9 @@ run it with `--check` before releasing.
 Data, this repo's own:
 
 `mockups/canvases/<slug>/` is one folder per app canvas. The conventions and
-the `layout.json` schema are in `mockups/canvases/README.md`, and portably in
-`skills/prototype-canvas/references/layout.md` — keep the two in step. Start a
+the `layout.json` schema are in `skills/prototype-canvas/references/layout.md`,
+which is the copy that ships inside the plugin and therefore the one to edit;
+`mockups/canvases/README.md` covers only what is true of this repo. Start a
 new folder with `cp -r mockups/canvases/templates mockups/canvases/<slug>`.
 
 Rules inside a canvas folder:
@@ -61,8 +62,11 @@ Rules inside a canvas folder:
   its five `ref-*` boards are committed so the hosted canvas shows them.
 - Put everything else a run makes in `scratch/`. The root `.gitignore`
   ignores it at any depth. Do not use the repo root or a dot directory.
-- Give every folder a `README.md`. Do not give any folder a `.gitignore`.
-  Except `.github/`: GitHub shows `.github/README.md` instead of the root
-  README, so its guide lives in `CONTRIBUTING.md`.
+- Give every canvas folder a `README.md`: it carries the evidence, and
+  `skills/clone-prototype/references/documenting.md` says what has to be in
+  it. Elsewhere, add a document only when someone would otherwise go looking
+  for one. Do not give any folder a `.gitignore`, and note that `.github/`
+  gets no README either: GitHub would show it instead of the root one, so its
+  guide lives in `CONTRIBUTING.md`.
 
 A decision worth rereading goes in `docs/YYYY-MM-DD-slug.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,4 +69,14 @@ Rules inside a canvas folder:
   gets no README either: GitHub would show it instead of the root one, so its
   guide lives in `CONTRIBUTING.md`.
 
+What to leave out:
+
+- Inline a helper that has one call site. A name read once costs a jump and
+  buys nothing.
+- Do not add configuration, an extension point or generic machinery for a case
+  that has not happened. The second real case is what shows the general
+  version its shape.
+- Do not write a fallback for a state that should be impossible. Let it fail
+  loudly, so the state gets reported instead of absorbed.
+
 A decision worth rereading goes in `docs/YYYY-MM-DD-slug.md`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,10 +113,13 @@ tag: the tag on the Releases page, `/plugin update super-prototyping` in Claude
 Code, and `uv tool install --force
 "git+https://github.com/ReScienceLab/super-prototyping@super-prototyping--v<version>#subdirectory=tools"`.
 
-**When a step fails.** The tag job only runs when the push actually changed the
-version and no such tag exists, so a re-run or an unrelated push to `main`
-cannot tag twice. If the workflow cannot open the pull request, the branch is
-already pushed and nothing is lost: open it by hand from
+**When a step fails.** The tag job runs only when the push moved the version
+forward and no tag names it yet, so a re-run, an unrelated push to `main`, and
+a revert of the release pull request all leave the tags alone. Dispatching a
+version whose branch already exists replays the bump on top of that branch
+rather than force-pushing over it, so the notes written at step 4 survive. If
+the workflow cannot open the pull request, the branch is already pushed and
+nothing is lost: open it by hand from
 `main...release/<version>`, and turn on Settings → Actions → General → "Allow
 GitHub Actions to create and approve pull requests", which is what it needed.
 The whole thing is doable by hand too. Run `scripts/bump-version.sh <version>`,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,6 +53,13 @@ with a `README.md` that says what was measured and what was excluded.
 
 Everything under `.github/`:
 
+- `workflows/validate.yml`: the gates, on every pull request — the manifests
+  agree and validate, the canvas lints, tests and builds, and the toolkit's
+  tests pass. Run the same commands locally from the root README.
+- `workflows/release.yml`: dispatch it with a version and it opens the release
+  PR; merging that PR tags `super-prototyping--v<version>` and cuts the GitHub
+  Release from the matching `RELEASE-NOTES.md` section. It is in two halves
+  because branch protection means CI cannot push to `main`.
 - `CODEOWNERS`: who is asked to review pull requests, by path.
 - `dependabot.yml`: weekly dependency updates for `canvas/` (bun) and for any
   GitHub Actions workflows.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,9 @@
 # Contributing
 
 Thanks for helping. This file covers the mechanics; `CLAUDE.md` and
-`mockups/canvases/README.md` cover the conventions inside a canvas folder in
-detail, and the pull request template repeats the ones that matter most.
+`skills/prototype-canvas/references/layout.md` cover the conventions inside a
+canvas folder in detail, and the pull request template repeats the ones that
+matter most.
 
 ## Setup
 
@@ -34,7 +35,10 @@ registry to edit and no build step per board.
   ignored by git for a reason. Do not work around the ignore.
 - **Scratch output goes in `scratch/`** inside the folder, never in the repo
   root or a dot directory.
-- **Every folder has a `README.md`. No folder has its own `.gitignore`.**
+- **Every canvas folder has a `README.md`**, carrying the evidence
+  `skills/clone-prototype/references/documenting.md` asks for. Elsewhere a new
+  document needs a reader who would go looking for it. **No folder has its own
+  `.gitignore`.**
 - **Viewer changes** in `canvas/` need `bun test` and `bun run build` to pass.
   Add a test next to the module you touched.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,6 +73,52 @@ repository settings, not files; see `SECURITY.md`.
 `.github/` must not get a `README.md`: GitHub renders `.github/README.md` in
 place of the root README on the repository page.
 
+## Cutting a release
+
+A merge to `main` reaches nobody. Every product resolves this plugin's version
+from its manifest and caches the install under it, Claude Code at
+`~/.claude/plugins/cache/<marketplace>/<plugin>/<version>/` and Codex and
+CodeBuddy at their own equivalents, so an install only moves when the version
+does. The version is the cache key, not bookkeeping.
+`docs/2026-09-09-plugin-release-mechanism.md` is the long form of why.
+
+**What the number means.** Semver, read from the user's side. Patch: a fix that
+changes no instruction a skill gives. Minor: a new skill, a new `refkit`
+subcommand, a canvas feature. Major: a board, `layout.json` or command-line
+change that makes an existing project's folders wrong. The plugin and the
+toolkit share one number and are released together, because a skill from one
+release calls a command from the other.
+
+**The steps.**
+
+1. Write the release's section in `RELEASE-NOTES.md` under `## Unreleased`,
+   grouped as it already is. Say what a user sees, not what a commit did.
+2. Run the gates locally (the block in the root README). The workflow runs them
+   again; failing them here is faster.
+3. Actions → **Release** → *Run workflow*, with the new version. It re-runs the
+   gates, runs `scripts/bump-version.sh <version>`, and opens a
+   `release/<version>` pull request. It stops there deliberately: "Protect main"
+   requires a pull request and nothing bypasses it.
+4. On that PR, rename `## Unreleased` to `## v<version>` and open a fresh empty
+   `## Unreleased` above it. The tag job reads exactly that heading.
+5. Merge. The push to `main` tags `super-prototyping--v<version>` through
+   `claude plugin tag` and cuts the GitHub Release from that notes section.
+
+**Then check the release exists**, because everything downstream keys off the
+tag: the tag on the Releases page, `/plugin update super-prototyping` in Claude
+Code, and `uv tool install --force
+"git+https://github.com/ReScienceLab/super-prototyping@super-prototyping--v<version>#subdirectory=tools"`.
+
+**When a step fails.** The tag job only runs when the push actually changed the
+version and no such tag exists, so a re-run or an unrelated push to `main`
+cannot tag twice. If the workflow cannot open the pull request, the branch is
+already pushed and nothing is lost: open it by hand from
+`main...release/<version>`, and turn on Settings → Actions → General → "Allow
+GitHub Actions to create and approve pull requests", which is what it needed.
+The whole thing is doable by hand too. Run `scripts/bump-version.sh <version>`,
+open a pull request, then `claude plugin tag . --push -m 'super-prototyping %s'`
+after it merges; the workflow is that sequence with the gates in front of it.
+
 ## Decisions
 
 A decision worth rereading goes in `docs/YYYY-MM-DD-slug.md`.

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ The **toolkit** the skills call by name is one more command, once per machine.
 | **Hermes** | `hermes plugins install ReScienceLab/super-prototyping --enable` |
 | **Pi** | `pi install git:github.com/ReScienceLab/super-prototyping@super-prototyping--v<version>` |
 | **Trae**, and anything else that reads `SKILL.md` | `npx skills add ReScienceLab/super-prototyping` |
-| Any of the above, from a clone you control | `scripts/install-skills.sh` |
+| Any of those except Claude Code, from a clone you control | `scripts/install-skills.sh` |
 
 Then the toolkit, whichever product you came from:
 

--- a/README.md
+++ b/README.md
@@ -72,24 +72,42 @@ six "Ask AI" screens are on the same board.*
 
 ## Install
 
-**Claude Code.** Two commands, from inside any project:
+It installs in two halves, in every product. The **plugin** holds the three
+skills and the canvas app, and comes from your product's own install command.
+The **toolkit** the skills call by name is one more command, once per machine.
 
-```
-/plugin marketplace add ReScienceLab/super-prototyping
-/plugin install super-prototyping@super-prototyping
-```
+| Your agent | Install the plugin |
+|---|---|
+| **Claude Code** | `/plugin marketplace add ReScienceLab/super-prototyping`<br>`/plugin install super-prototyping@super-prototyping` |
+| **Codex** | `codex plugin marketplace add ReScienceLab/super-prototyping`<br>`codex plugin add super-prototyping@super-prototyping` |
+| **WorkBuddy / CodeBuddy** | `codebuddy plugin marketplace add ReScienceLab/super-prototyping`<br>`codebuddy plugin install super-prototyping --scope user` |
+| **Hermes** | `hermes plugins install ReScienceLab/super-prototyping --enable` |
+| **Pi** | `pi install git:github.com/ReScienceLab/super-prototyping@super-prototyping--v<version>` |
+| **Trae**, and anything else that reads `SKILL.md` | `npx skills add ReScienceLab/super-prototyping` |
+| Any of the above, from a clone you control | `scripts/install-skills.sh` |
 
-Then install the toolkit the skills call, once per machine:
+Then the toolkit, whichever product you came from:
 
 ```bash
 uv tool install "git+https://github.com/ReScienceLab/super-prototyping#subdirectory=tools"
 ```
 
-`/plugin update super-prototyping` picks up a new release; re-run the `uv tool
-install` line with `--force` to move the toolkit with it. Both halves carry the
-same version, and `sp-canvas start` prints the line to run when they drift
-apart. To hold the toolkit at a release rather than at the default branch, name
-that release's tag — they are listed under
+One skills tree, a thin manifest per product, so a skill is never forked to be
+ported: `.claude-plugin/` for Claude Code, `.codex-plugin/` plus the
+`.agents/plugins/marketplace.json` catalogue for Codex, `.codebuddy-plugin/` for
+WorkBuddy, and a root `plugin.json` in the portable
+[Agent Plugins v1](https://agent-plugins.org/specification) format, which is what
+Hermes installs. Pi and `npx skills` read `skills/*/SKILL.md` directly and need
+no manifest at all.
+
+`/plugin update super-prototyping` picks up a new release. The others are
+`codex plugin add` again, `codebuddy plugin install` again, `hermes plugins
+update super-prototyping`, `npx skills update`, and for Pi another `pi install`
+naming the new tag, since Pi pins the ref you gave it and never moves it on its
+own. Re-run the `uv tool install` line with `--force` to move the toolkit too.
+Both halves carry the same version, and `sp-canvas start` prints the line to run
+when they drift apart. To hold the toolkit at a release rather than at the
+default branch, name that release's tag. They are listed under
 [Releases](https://github.com/ReScienceLab/super-prototyping/releases):
 
 ```bash
@@ -122,34 +140,36 @@ Measured at 6.7 MB installed, against 151 MB. Add
 `mockups/canvases/duolingo-ios` to that list to keep the one example
 `clone-prototype` reads most, or drop the key entirely to get everything.
 
-**Codex.** The same two steps, from the CLI:
+**Per product, the parts worth knowing.** `codex plugin marketplace upgrade`
+refreshes the catalogue before `codex plugin add` moves you to the new version.
+Codex has the sparse field too, spelled `--sparse`, but as of 0.145 a plugin
+cannot be installed from a marketplace added with it. The install re-clones the
+sparse snapshot and git cannot read the objects that were left out, so the small
+install above is Claude Code's for now. Hermes leaves an installed plugin
+disabled until you say otherwise, which is what `--enable` is for; it also takes
+this repo as a skill tap (`hermes skills tap add
+ReScienceLab/super-prototyping`) if you want the skills without the plugin. Pi
+pins whatever ref you install, so name a release tag rather than a branch. `npx
+skills add` asks which agents and whether to install globally, and knows Trae,
+Trae CN, CodeBuddy, Hermes, Pi and Codex by name; `-a trae -g` answers both
+questions up front.
 
-```bash
-codex plugin marketplace add ReScienceLab/super-prototyping
-codex plugin add super-prototyping@super-prototyping
-```
-
-`codex plugin marketplace upgrade` refreshes the catalogue and `codex plugin
-add` again moves to the new version. Codex has the sparse field too, spelled
-`--sparse`, but as of 0.145 a plugin cannot be installed from a marketplace
-added with it — the install re-clones the sparse snapshot and git cannot read
-the objects that were left out — so the small install above is Claude Code's
-for now.
-
-**Anything else that reads a skills directory** — Hermes, Pi, or a Codex
-without the plugin commands. Clone once, then link:
+**No install command, or you want one checkout behind all of them.** Clone
+once, then link:
 
 ```bash
 git clone https://github.com/ReScienceLab/super-prototyping.git ~/.super-prototyping
 ~/.super-prototyping/scripts/install-skills.sh
 ```
 
-It installs the toolkit and symlinks `skills/*` into every product skill root
-it finds (`~/.codex/skills`, `~/.hermes/skills`, `~/.pi/agent/skills`). The
-skills are links, not copies, so `git pull` in that checkout updates every
-product at once. The toolkit is a copy, so re-run the script after a pull to
-move `refkit`, `artgen` and `sp-canvas` with it. `--list` shows what it would
-do and changes nothing.
+It installs the toolkit and symlinks `skills/*` into every product skill root it
+finds (`~/.codex/skills`, `~/.codebuddy/skills`, `~/.hermes/skills`,
+`~/.pi/agent/skills`, `~/.trae/skills`, `~/.trae-cn/skills`). The skills are
+links, not copies, so `git pull` in that checkout updates every product at once.
+The toolkit is a copy, so re-run the script after a pull to move `refkit`,
+`artgen` and `sp-canvas` with it. `--list` shows what it would do and changes
+nothing. What it cannot give you is a version. A linked checkout is whatever you
+last pulled, where a marketplace install is a release.
 
 ## Start a project
 
@@ -271,6 +291,8 @@ manifest with `scripts/bump-version.sh`, and opens a release PR, because
 "Protect main" wants a pull request and nothing bypasses it. Write that
 version's section in `RELEASE-NOTES.md`, then merge: the tag
 `super-prototyping--v<version>` and the GitHub Release follow from the merge.
+The whole procedure, including what to do when a step fails, is under "Cutting a
+release" in `CONTRIBUTING.md`.
 
 ## Licence
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,15 @@ uv tool install "git+https://github.com/ReScienceLab/super-prototyping#subdirect
 ```
 
 `/plugin update super-prototyping` picks up a new release; re-run the `uv tool
-install` line with `--force` to move the toolkit with it.
+install` line with `--force` to move the toolkit with it. Both halves carry the
+same version, and `sp-canvas start` prints the line to run when they drift
+apart. To hold the toolkit at a release rather than at the default branch, name
+that release's tag — they are listed under
+[Releases](https://github.com/ReScienceLab/super-prototyping/releases):
+
+```bash
+uv tool install --force "git+https://github.com/ReScienceLab/super-prototyping@super-prototyping--v<version>#subdirectory=tools"
+```
 
 **A smaller install.** The full one is about 151 MB, because this repo is also
 the workspace whose fourteen worked example boards the skills read, and a
@@ -113,10 +121,23 @@ clones just those directories, cone mode:
 Measured at 6.7 MB installed, against 151 MB. Add
 `mockups/canvases/duolingo-ios` to that list to keep the one example
 `clone-prototype` reads most, or drop the key entirely to get everything.
-Codex has the same field, spelled `sparse_paths`.
 
-**Codex, or anything else that reads a skills directory.** Clone once, then
-link:
+**Codex.** The same two steps, from the CLI:
+
+```bash
+codex plugin marketplace add ReScienceLab/super-prototyping
+codex plugin add super-prototyping@super-prototyping
+```
+
+`codex plugin marketplace upgrade` refreshes the catalogue and `codex plugin
+add` again moves to the new version. Codex has the sparse field too, spelled
+`--sparse`, but as of 0.145 a plugin cannot be installed from a marketplace
+added with it — the install re-clones the sparse snapshot and git cannot read
+the objects that were left out — so the small install above is Claude Code's
+for now.
+
+**Anything else that reads a skills directory** — Hermes, Pi, or a Codex
+without the plugin commands. Clone once, then link:
 
 ```bash
 git clone https://github.com/ReScienceLab/super-prototyping.git ~/.super-prototyping
@@ -235,11 +256,21 @@ refkit --version                                  # which release you are on
 ```bash
 cd canvas && bun run lint && bun run test && bun run build
 uv run --with pillow --with numpy python tools/test_refkit.py
+uv run python tools/test_sp_canvas.py
 scripts/bump-version.sh --check      # every manifest agrees on one version
+claude plugin validate . --strict    # and the manifests are what they claim
 ```
 
-Releasing: `scripts/bump-version.sh <version>`, commit, then tag
-`super-prototyping--v<version>`.
+The **Validate** workflow runs all of that on every pull request.
+
+**Releasing.** The version is not bookkeeping: it is the cache key that
+`/plugin update` and `codex plugin marketplace upgrade` compare against an
+install, so commits on main reach nobody until it moves. Dispatch the
+**Release** workflow with the new version — it runs the gates, moves every
+manifest with `scripts/bump-version.sh`, and opens a release PR, because
+"Protect main" wants a pull request and nothing bypasses it. Write that
+version's section in `RELEASE-NOTES.md`, then merge: the tag
+`super-prototyping--v<version>` and the GitHub Release follow from the merge.
 
 ## Licence
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -5,9 +5,9 @@ someone using the plugin, not what changed in the tree. One `## v<version>`
 section per release: `.github/workflows/release.yml` reads the section matching
 the version being tagged and makes it the GitHub Release body.
 
-Update with `/plugin update super-prototyping` (Claude Code) or
-`codex plugin marketplace upgrade` then `codex plugin add` (Codex), and move the
-toolkit with the `uv tool install` line in the README. The plugin and the
+Update with `/plugin update super-prototyping` (Claude Code), or the equivalent
+for your product, which README's install table lists. Then move the toolkit with
+the `uv tool install` line in the README. The plugin and the
 toolkit carry the same version; `sp-canvas start` says so when they drift.
 
 ## Unreleased
@@ -43,6 +43,15 @@ Everything below is on `main` and reaches no install until a version is cut.
   `codex plugin marketplace add ReScienceLab/super-prototyping` then
   `codex plugin add super-prototyping@super-prototyping`. The repo now also
   ships the catalogue Codex prefers, so it reads a manifest meant for it.
+- **Six products install it with their own command**, each from a manifest
+  written for it: Claude Code, Codex, WorkBuddy/CodeBuddy
+  (`.codebuddy-plugin/plugin.json`), Hermes (a root `plugin.json` in the
+  portable Agent Plugins v1 format), Pi (`pi install git:…`, which reads
+  `skills/` with no manifest at all), and `npx skills add` for Trae and the
+  rest. One skills tree behind all of them.
+- **`install-skills.sh` covers the products that have no install command.** It
+  now links into CodeBuddy, Trae and Trae CN as well as Codex, Hermes and Pi,
+  and it says which of them it found.
 - **The plugin and the toolkit say when they have drifted.** `sp-canvas start`
   prints the `uv tool install` line that moves the toolkit to the plugin's
   version, and `sp-canvas --version` and `sp-canvas root -v` answer "which
@@ -55,6 +64,9 @@ Everything below is on `main` and reaches no install until a version is cut.
   `super-prototyping--v<version>` and cuts the GitHub Release from this file.
 - **Validate** runs the manifests, the canvas (lint, test, build) and the
   toolkit tests on every pull request.
+- The procedure, including what the version number means and what to do when a
+  step fails, is "Cutting a release" in `CONTRIBUTING.md`. This file is the log
+  it publishes from.
 
 ## v1.0.0
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,0 +1,64 @@
+# Release notes
+
+Written for the person deciding whether to update, so it says what changed for
+someone using the plugin, not what changed in the tree. One `## v<version>`
+section per release: `.github/workflows/release.yml` reads the section matching
+the version being tagged and makes it the GitHub Release body.
+
+Update with `/plugin update super-prototyping` (Claude Code) or
+`codex plugin marketplace upgrade` then `codex plugin add` (Codex), and move the
+toolkit with the `uv tool install` line in the README. The plugin and the
+toolkit carry the same version; `sp-canvas start` says so when they drift.
+
+## Unreleased
+
+Everything below is on `main` and reaches no install until a version is cut.
+
+### The canvas
+
+- **An inspector panel.** Select a board and read its layers: the image behind
+  a layer, its measured colours, and the icons and inline SVGs named as vector
+  assets rather than as anonymous shapes.
+- **Every board has an address.** `?canvas=<slug>` opens a page and
+  `?canvas=<slug>#<file>` opens one board of it in the inspector, with the
+  camera on it. That is the link to give when pointing at one screen.
+- **Comments that live in the repo.** A board can be commented on and its
+  status set, both stored beside the boards as `comments.json`, so a review
+  survives the browser it was written in. The hosted canvas can be commented on
+  too.
+- **The dev server watches the boards directly** (#52, #53). Rewriting a board
+  reloads the page onto the new HTML instead of needing the server restarted,
+  a board folder added or removed re-indexes on its own, and writes under
+  `scratch/` and `assets/refs/` no longer interrupt a generator or a clone run.
+- Fixes: the status badge keeps its corner in a built canvas, the rail's
+  collapse handle sits on its divider, a pan is a pan wherever the cursor is,
+  and a malformed board link fails as a board that does not exist.
+
+### Install
+
+- **A 6.7 MB install**, against 151 MB, by declaring the marketplace with
+  `sparsePaths` in `~/.claude/settings.json`. The README has the recipe.
+- **Codex installs as a plugin**, not only as symlinked skills. It always
+  could — Codex falls back to the Claude manifest — but nothing said so:
+  `codex plugin marketplace add ReScienceLab/super-prototyping` then
+  `codex plugin add super-prototyping@super-prototyping`. The repo now also
+  ships the catalogue Codex prefers, so it reads a manifest meant for it.
+- **The plugin and the toolkit say when they have drifted.** `sp-canvas start`
+  prints the `uv tool install` line that moves the toolkit to the plugin's
+  version, and `sp-canvas --version` and `sp-canvas root -v` answer "which
+  release is this".
+
+### Releasing
+
+- Releases are made by dispatching **Release** with a version: it runs the
+  gates, bumps every manifest, and opens the release PR; merging that PR tags
+  `super-prototyping--v<version>` and cuts the GitHub Release from this file.
+- **Validate** runs the manifests, the canvas (lint, test, build) and the
+  toolkit tests on every pull request.
+
+## v1.0.0
+
+2026-09-05, the release that packaged this repo as a plugin: code ships,
+a project's boards stay put, and `sp-canvas` joins the two. It was never
+tagged — the machinery for that is in the section above — so an install made
+before the next release reports `1.0.0` whatever it holds.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -17,7 +17,7 @@ unless you prefer otherwise.
 ## Scope
 
 - The `canvas/` viewer (the code behind https://prototyping.rescience.com).
-- The measuring tools in `tools/` and the agent skills in `.agents/skills/`.
+- The measuring tools in `tools/` and the agent skills in `skills/`.
 - The generators (`gen.py`) and boards under `mockups/canvases/`.
 
 Boards render inside sandboxed `<iframe srcdoc>` shapes. A report that shows a

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -27,13 +27,21 @@ it reproduces are not security issues.
 
 ## Supported versions
 
-Only the `main` branch is supported. There are no tagged releases yet.
+Only the latest release is supported, and `main` between releases. Releases are
+tagged `super-prototyping--v<version>` and listed under Releases; the version
+in the manifests is what an install of any product compares against, so an
+older cached version gets no fixes.
 
 ## What the repository already does
 
 - `main` requires a pull request; force pushes and deletion are blocked.
   Tags cannot be deleted or overwritten.
 - Secret scanning with push protection is on, so credentials cannot be pushed.
+- Actions run with a read-only `GITHUB_TOKEN` by default; the release workflow
+  requests `contents: write` and `pull-requests: write` for its own jobs only.
+  It also needs "Allow GitHub Actions to create and approve pull requests" —
+  without it the release stops after pushing its branch, which is a safe place
+  to stop.
 - Dependabot opens pull requests for vulnerable and outdated dependencies.
 - CodeQL scans JavaScript, TypeScript and Python on every pull request.
 - Third-party captures (`ref-*.html`, `assets/refs/`) are ignored by git and

--- a/docs/2026-09-05-plugin-packaging.md
+++ b/docs/2026-09-05-plugin-packaging.md
@@ -5,6 +5,11 @@ inside it. That makes every user a fork: their boards and our code sit in one
 tree, so there is no upgrade path that does not risk their work. This note
 records what changed and why the split falls where it does.
 
+Two sentences below have since been overtaken. The repo now runs its own
+workflows (`docs/2026-09-09-plugin-release-mechanism.md`) and ships a manifest
+for four products rather than two (`docs/2026-09-09-multi-product-install.md`).
+The split itself is unchanged.
+
 ## The rule
 
 **The plugin ships code. A user's project holds only data.**

--- a/docs/2026-09-07-inspector-panel-feasibility.md
+++ b/docs/2026-09-07-inspector-panel-feasibility.md
@@ -1,6 +1,8 @@
 <!-- Written 2026-09-07 after building the inspector panel design as a throwaway spike on
 canvas/ and driving it in a real browser. Kept because sections 3 and 5 are the parts a
-future implementation will otherwise rediscover the hard way. Nothing here shipped yet. -->
+future implementation will otherwise rediscover the hard way. The panel shipped the next
+day; what it became is in 2026-09-08-vector-assets.md and 2026-09-08-canvas-comments.md,
+and this note is kept as the spike that preceded it rather than as a description of it. -->
 
 # Inspecting a board from the canvas: what a spike found
 

--- a/docs/2026-09-09-multi-product-install.md
+++ b/docs/2026-09-09-multi-product-install.md
@@ -57,6 +57,13 @@ to inject a bootstrap prompt. This plugin's skills are invoked by name like any
 other skill, so the convention `skills/` directory is the whole integration and
 a TypeScript extension would be code to maintain for nothing.
 
+**A root `package.json`.** Pi's `installGit` runs `npm install` at the package
+root whenever it finds one there, so a `pi` manifest would buy a listing on
+pi.dev and charge every Pi install an npm step. Without it the install is a
+clone and a checkout, which is also the shape of its cost: full history, no
+sparse or shallow option, and the reconcile step in `pi update` wipes untracked
+files in that clone, so nobody should edit inside it.
+
 ## What the version buys, per product
 
 Claude Code, Codex and CodeBuddy each cache under

--- a/docs/2026-09-09-multi-product-install.md
+++ b/docs/2026-09-09-multi-product-install.md
@@ -1,0 +1,69 @@
+# One skills tree, six install commands
+
+2026-09-09. The plugin shipped with two manifests, for Claude Code and Codex,
+and a script that symlinked `skills/` for everyone else. A symlinked checkout
+has no version, so the argument in `docs/2026-09-09-plugin-release-mechanism.md`
+(the version is the cache key, an install only moves when it moves) applies to a
+product's own install command and to nothing else. This note records which file
+each product reads, how that was established, and what was deliberately not
+shipped.
+
+## The rule
+
+**A manifest per product, never a skill per product.** Every manifest points at
+the same `skills/` tree, and `scripts/bump-version.sh` moves every version in
+one commit. A product that reads `skills/*/SKILL.md` directly gets no manifest
+at all.
+
+## What each product reads
+
+| Product | Reads | Install |
+|---|---|---|
+| Claude Code | `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json` | `/plugin marketplace add` + `/plugin install` |
+| Codex | `.agents/plugins/marketplace.json` → `.claude-plugin/marketplace.json`; `.codex-plugin/plugin.json` | `codex plugin marketplace add` + `codex plugin add` |
+| WorkBuddy / CodeBuddy | `.codebuddy-plugin/plugin.json` → `.workbuddy-plugin/plugin.json` → `.claude-plugin/plugin.json` | `codebuddy plugin marketplace add` + `codebuddy plugin install` |
+| Hermes | root `plugin.json` (Agent Plugins v1.0.0) + `skills/*/SKILL.md` | `hermes plugins install ReScienceLab/super-prototyping --enable` |
+| Pi | `skills/` by convention, no manifest | `pi install git:github.com/ReScienceLab/super-prototyping@<tag>` |
+| Trae, Trae CN, and the rest | `SKILL.md` under a skills root | `npx skills add ReScienceLab/super-prototyping` |
+
+Sources, all read on 2026-09-09: the CodeBuddy fallback order and its
+`{plugin-name}--v{version}` tag convention from
+[its plugins reference](https://www.codebuddy.ai/docs/cli/plugins-reference);
+Hermes' portable-package layout and `--enable` from the
+[plugin developer guide](https://github.com/NousResearch/hermes-agent/blob/main/website/docs/developer-guide/plugins/index.md);
+the [Agent Plugins v1.0.0 schema](https://agent-plugins.org/schemas/1.0.0/plugin.schema.json)
+for the two required fields; Pi's convention directories and pinned git refs
+from its
+[packages doc](https://github.com/earendil-works/pi/blob/main/packages/coding-agent/docs/packages.md);
+and the skill roots (`~/.codebuddy/skills`, `~/.hermes/skills`,
+`~/.pi/agent/skills`, `~/.trae/skills`, `~/.trae-cn/skills`) from the
+[`skills` CLI](https://github.com/vercel-labs/skills)'s agent table, which
+matches each product's own docs. Codex's fallback chain was read out of the
+0.145.0 binary and probed live; that story is in the release-mechanism note.
+
+## Three things that look like manifests and are not
+
+**`.workbuddy-plugin/plugin.json` and `.claude-plugin/plugin.json` for
+CodeBuddy.** Both are accepted, both fall back to the one we ship. Three copies
+of one manifest is three chances to disagree.
+
+**A `.codebuddy-plugin/marketplace.json`.** CodeBuddy's docs name the plugin
+manifest paths and do not name a catalogue path. Its Claude compatibility
+covers `.claude-plugin/marketplace.json`; a guessed file found first and
+misread is worse than no file.
+
+**A Pi extension.** Pi loads `extensions/*.ts` too, and `superpowers` uses one
+to inject a bootstrap prompt. This plugin's skills are invoked by name like any
+other skill, so the convention `skills/` directory is the whole integration and
+a TypeScript extension would be code to maintain for nothing.
+
+## What the version buys, per product
+
+Claude Code, Codex and CodeBuddy each cache under
+`…/plugins/cache/<marketplace>/<plugin>/<version>/`, so all three are moved by
+one bump. Hermes pins a commit and moves on `hermes plugins update`. Pi pins
+whatever ref it was given and never moves it on its own, which is why the
+install line names a release tag; moving it is another `pi install`. `npx
+skills` and `scripts/install-skills.sh` track a checkout rather than a release.
+That is the trade for working in a product with no install command, and the
+README says so where someone choosing between them will read it.

--- a/docs/2026-09-09-plugin-release-mechanism.md
+++ b/docs/2026-09-09-plugin-release-mechanism.md
@@ -54,7 +54,7 @@ There are exactly two coherent contracts, and the choice is ours:
 
 ## Where we are today
 
-- `scripts/bump-version.sh` already moves all five version fields at once and
+- `scripts/bump-version.sh` already moves all seven version fields at once and
   has a `--check` mode; `.version-bump.json` lists them, and `tagPrefix` is
   `super-prototyping--v`.
 - That prefix is not arbitrary: `claude plugin tag` (CLI 2.1.263) creates

--- a/docs/2026-09-09-plugin-release-mechanism.md
+++ b/docs/2026-09-09-plugin-release-mechanism.md
@@ -188,6 +188,18 @@ skills are read by agents and whose canvas app is built on the user's machine.
    Python tests in `tools/`. And a `release.yml` on `workflow_dispatch` taking
    the version, running the same gates, then bump, commit, tag, release. The
    ordering gotcha is the whole reason to script it.
+
+   *What shipped is that in two halves.* "Protect main" requires a pull request
+   and lists no bypass actors, so no workflow can push the bump to main: the
+   dispatch runs the gates, bumps and opens a release PR, and merging that PR
+   is what fires the tag-and-release job. Tag *creation* is allowed by the tag
+   ruleset, which is why the second half can finish the job. Two consequences
+   worth knowing: a PR opened by `GITHUB_TOKEN` triggers no `pull_request`
+   workflows, so the release PR carries no Validate run of its own (the gates
+   ran on the commit being released, and `claude plugin tag` validates again);
+   and the tag job has to check that the version actually *changed* in the
+   push, or any later edit to `plugin.json` would cut a release of whatever
+   number is sitting in it.
 4. **Pin the toolkit to the release.** `uv` accepts a ref in the same URL. The
    syntax was resolved for real today against `@main`; the tag form works once
    a tag exists, which is what item 1 is for:
@@ -260,7 +272,10 @@ catalogue it used as `.claude-plugin/marketplace.json` and lists one plugin,
 which `codex plugin add super-prototyping@super-prototyping` installs as
 `1.0.0`; adding `obra/superpowers`, which does ship one, reports
 `.agents/plugins/marketplace.json` and installs `6.3.0` into
-`plugins/cache/superpowers-dev/superpowers/6.3.0`. The fallback order
+`plugins/cache/superpowers-dev/superpowers/6.3.0`; and the
+`.agents/plugins/marketplace.json` this repo now ships was probed the same way,
+which is how we know Codex reads it in preference and installs `1.0.0` from it.
+The fallback order
 `.agents/plugins/marketplace.json`, `.agents/plugins/api_marketplace.json`,
 `.claude-plugin/marketplace.json`, `.cursor-plugin/marketplace.json` is in the
 0.145.0 binary. One caveat that cost an hour: `codex plugin add` fails against

--- a/docs/2026-09-09-plugin-release-mechanism.md
+++ b/docs/2026-09-09-plugin-release-mechanism.md
@@ -249,9 +249,12 @@ Deliberately not doing:
   install cannot do well, but it adds a second release surface and a name to
   own. Revisit if users ask; the tagged git URL covers the need.
 - **Not adopting release-please / semantic-release.** They exist to derive
-  versions from conventional commits and generate changelogs; we have five
-  files in one repo and a script that already moves them, and the notes worth
+  versions from conventional commits and generate changelogs; we have a handful
+  of files in one repo and a script that already moves them, and the notes worth
   writing are not commit subjects.
+
+Which products that version actually reaches, and which file each of them reads
+to find it, is the companion note: `docs/2026-09-09-multi-product-install.md`.
 
 ## Checked
 

--- a/docs/2026-09-09-plugin-release-mechanism.md
+++ b/docs/2026-09-09-plugin-release-mechanism.md
@@ -1,0 +1,270 @@
+# Releasing the plugin: what we have, what everyone else does, what to do
+
+2026-09-09. The repo has been installable as a plugin since 2026-09-05, but it
+has never been *released*: no tag, no GitHub Release, no CI, and every manifest
+still says `1.0.0`. This note is the survey behind the fix — how Claude Code
+and Codex actually decide that an installed plugin is out of date, what the
+plugins people install do about it, and the smallest mechanism that fits this
+repo.
+
+The headline finding is not a missing nicety. **Anyone who installed this
+plugin can never receive an update, no matter how many commits land on main.**
+
+## How an update is decided
+
+Claude Code resolves a plugin's version from the first of these that is set:
+`plugin.json`'s `version`, then the marketplace entry's `version` ("if also set
+in the marketplace entry, `plugin.json` wins"), then the source itself — the
+resolved commit SHA for a git source, the SHA-256 digest for an archive, and
+the literal `unknown` for an npm source or a directory outside a git repo.
+That resolved string is both the cache directory name
+(`~/.claude/plugins/cache/<marketplace>/<plugin>/<version>/`) and the cache
+key: `/plugin update` and the background auto-update compare it against what is
+installed, and **when the string has not changed there is no download**. The
+docs say it outright: setting `version` "pins the plugin to that version
+string, so users only receive updates when you bump it."
+
+Locally, the record of that is `~/.claude/plugins/installed_plugins.json`
+(schema v2), which stores `installPath`, `version`, `installedAt`,
+`lastUpdated` and `gitCommitSha` per install; `convex@claude-plugins-official`
+sits at `1.14.0` with `1.10.0` still on disk beside it: an updated plugin's
+old directory is marked orphaned and swept about 14 days later, so that a
+session which already loaded it keeps working.
+
+We declare `1.0.0` in three fields at once (`.claude-plugin/marketplace.json`
+at both `metadata.version` and `plugins[0].version`, and
+`.claude-plugin/plugin.json`). So `plugin.json` pins — the entry would pin
+anyway if it did not — the cache key never moves, and `/plugin update
+super-prototyping` reports success while copying nothing. The README's line —
+"`/plugin update super-prototyping` picks up a new release" — is only true
+once the number moves, and it never has.
+
+This is a well-worn trap, not a subtlety we invented: `everything-claude-code`
+filed and fixed the identical bug (issue #36, "marketplace.json also needs
+version field removed for auto-updates"), and found the same two fields,
+`metadata.version` and `plugins[0].version`, holding their cache directory at
+`1.0.0/`.
+
+There are exactly two coherent contracts, and the choice is ours:
+
+- **Pinned:** keep `version` and bump it on every release. Users move in steps
+  we choose, `refkit --version` means something, and the tag names a release.
+- **Rolling:** delete `version` everywhere and let the commit SHA be the
+  version. Every merge to main is a release for everyone. Zero ceremony, no
+  release notes, and no way to hold a bad merge back from users.
+
+## Where we are today
+
+- `scripts/bump-version.sh` already moves all five version fields at once and
+  has a `--check` mode; `.version-bump.json` lists them, and `tagPrefix` is
+  `super-prototyping--v`.
+- That prefix is not arbitrary: `claude plugin tag` (CLI 2.1.263) creates
+  exactly `{name}--v{version}`, validating that `plugin.json` and the enclosing
+  marketplace entry agree, and refusing a dirty tree. Run against this worktree
+  today (`--dry-run --force`, since the tree is dirty) it prints
+  `Tag: super-prototyping--v1.0.0` and the two git commands it would run. The
+  release convention we want is already implemented in the CLI our users
+  install from.
+- `claude plugin validate <path> --strict` passes on both manifests today.
+  Nothing runs it.
+- `git tag` is empty, `gh release list` is empty, and `.github/` holds only
+  `CODEOWNERS`, `dependabot.yml`, issue templates and a PR template — no
+  workflows. CodeQL runs through GitHub's default setup and the canvas deploys
+  through the Cloudflare Pages integration, so neither is a workflow file, and
+  neither runs `bun run lint`, `bun run test`, `bun run build` or the Python
+  tests. Nothing today would stop a release that does not build.
+- The toolkit is installed with an unpinned git URL:
+  `uv tool install "git+https://github.com/ReScienceLab/super-prototyping#subdirectory=tools"`.
+  It always takes the default branch's HEAD, so the plugin (pinned at a
+  version) and the toolkit (floating on main) can be arbitrarily far apart —
+  and `tools/pyproject.toml` is the fifth file `bump-version.sh` moves, so the
+  version it reports is a release number that no install path actually selects.
+- The Codex path in the README is a `git clone` plus `scripts/install-skills.sh`
+  symlinks, with `git pull` as the upgrade. That predates Codex having plugins
+  of its own; `codex-cli` 0.145 has `codex plugin marketplace add
+  <owner/repo[@ref]>` with `--ref` and `--sparse`,
+  `codex plugin add <plugin>@<marketplace>`, and
+  `codex plugin marketplace upgrade`. It looks for a catalogue at
+  `<repo-root>/.agents/plugins/marketplace.json` and falls back to
+  `.claude-plugin/marketplace.json`, then `.cursor-plugin/marketplace.json`, so
+  this repo is *already* installable that way through the Claude manifest —
+  probed today, `codex plugin add super-prototyping@super-prototyping` installs
+  `1.0.0` with all three skills. Nothing tells a user so: the README still
+  sends them to `git clone`.
+
+## What the plugins people install actually do
+
+**The official marketplace** (`anthropics/claude-plugins-official`, 292 entries
+as cached on 2026-09-09) is the clearest picture of practice at scale:
+
+| entry shape | count |
+| --- | --- |
+| `source: "url"` (whole repo) | 152 |
+| `source: "git-subdir"` (sparse clone of a subdirectory) | 88 |
+| local `"./plugins/<name>"` or `"./external_plugins/<name>"`, vendored | 52 |
+| pinned to a tag ref + sha | 2 |
+| pinned to a branch ref + sha | 85 |
+| sha only, no ref | 153 |
+| entries carrying an explicit `version` | 14 |
+
+Two things stand out. First, every one of the 240 external entries is pinned to
+a **sha**, and only two of them name a *tag* (`v1.5.5` and
+`greptile--v1.2.3`); the rest ride `main`, `master` or nothing at all. Second,
+the marketplace, not the plugin author, does the moving: a nightly workflow
+(`bump-plugin-shas.yml`, 07:23 UTC, capped at 60 entries a run) compares each
+entry's pinned sha against upstream HEAD — or, for the fourteen entries listed
+`releases-only` in `.github/bump-tracking.json`, against the latest published
+release tag — validates the plugin at the new sha with `claude plugin
+validate`, and opens one PR per entry, which is how a failing entry stays
+isolated instead of holding up the batch. `validate-plugins.yml` and
+`scan-plugins.yml` are the required checks. Renames are handled by a top-level
+`renames` map (9 of them) rather than by breaking installs.
+
+The implication for us is direct: we are a *self-hosted, single-plugin*
+marketplace, so there is no nightly bot upstream of us. We are both halves,
+and whatever they automate we do by hand or not at all.
+
+**`obra/superpowers`** (v6.3.0) is the closest sibling — same shape as this
+repo, one skills library published to many agent products
+(`.claude-plugin`, `.codex-plugin`, `.cursor-plugin`, `.devin-plugin`,
+`.hermes-plugin`, `.kimi-plugin`, `gemini-extension.json`), and it is where our
+`.version-bump.json` and `scripts/bump-version.sh` came from. Its marketplace
+entry carries `"version": "6.3.0"` with `"source": "./"`, like ours minus our
+`metadata.version` — so the pinned contract, bumped every release. It keeps a
+`RELEASE-NOTES.md` written for humans ("Worktree removal no longer destroys
+untracked files"), cuts a GitHub Release per version, and has **no CI workflows at all**: `.github/`
+holds funding and templates only. Its `.version-bump.json` has one thing ours
+lacks — an `audit` block that greps the tree for stray version strings the
+spec does not cover.
+
+**`greptileai/claude-plugin`** tags `greptile--v1.2.3` and cuts a GitHub
+Release for each, i.e. the literal output of `claude plugin tag`, and the
+official marketplace pins that tag *and* its sha — one of the two. Worth
+knowing that the tag in the entry is downstream of the marketplace's own
+`releases-only` list as much as of greptile's convention: the bot follows
+releases for those fourteen, so an author who cuts releases gets pinned to
+them.
+
+**`get-convex/convex-backend-skill`** (the one third-party plugin installed on
+this machine) carries `"version": "1.14.0"` in `plugin.json`, no tags and no
+releases, and a `validate.yml` that on every PR, and on push to main, parses
+each JSON manifest,
+`node --check`s the hook scripts, runs their unit tests, and finishes with
+`claude plugin validate . --strict` and the same against the marketplace
+manifest. The marketplace pins it by sha and bumps nightly. Version discipline
+in the manifest, freshness handled upstream.
+
+**`wshobson/agents`** publishes 94 plugins, every one with an explicit
+`version`, plus `validate.yml` (JSON, manifests, hooks) and `code-quality.yml`
+(ruff/ty). No releases, no tags — the versions in the manifests are the whole
+release mechanism.
+
+The pattern across all of them: **an explicit version in the manifest is the
+release; a tag and release notes are how humans read it; CI is how you find out
+before users do.** None of them is published through a package registry.
+
+## What to do here
+
+Keep the pinned contract. We already have the parts that are tedious to build
+(`bump-version.sh`, `.version-bump.json`, the tag prefix `claude plugin tag`
+expects, a versioned Python package); what is missing is anything that moves
+the number, and anything that runs before it moves. Rolling would throw the
+first set away and hand users main's HEAD, which is wrong for a plugin whose
+skills are read by agents and whose canvas app is built on the user's machine.
+
+1. **Make a release actually reach people.** The next merge to main is only a
+   release once `scripts/bump-version.sh 1.1.0` runs. Replace the README's
+   two-line "Releasing:" note with the supported sequence, in this order,
+   because
+   `claude plugin tag` refuses a dirty tree and checks the two manifests agree:
+   bump → commit → `claude plugin tag --push -m 'super-prototyping %s'` →
+   `gh release create super-prototyping--v1.1.0 --notes-file …`.
+2. **Add `RELEASE-NOTES.md`**, written for the person deciding whether to
+   update, not generated from commit subjects. Superpowers' is the model.
+3. **Add two workflows.** A `validate.yml` on PR and push to main:
+   `claude plugin validate . --strict`, `claude plugin validate
+   .claude-plugin/plugin.json --strict`, `scripts/bump-version.sh --check`,
+   then `bun run lint && bun run test && bun run build` in `canvas/` and the
+   Python tests in `tools/`. And a `release.yml` on `workflow_dispatch` taking
+   the version, running the same gates, then bump, commit, tag, release. The
+   ordering gotcha is the whole reason to script it.
+4. **Pin the toolkit to the release.** `uv` accepts a ref in the same URL. The
+   syntax was resolved for real today against `@main`; the tag form works once
+   a tag exists, which is what item 1 is for:
+
+   ```bash
+   uv tool install "git+https://github.com/ReScienceLab/super-prototyping@super-prototyping--v1.1.0#subdirectory=tools"
+   ```
+
+   Say that in the README next to `/plugin install`, and keep
+   `--force` for the unpinned form. The two halves of the install then carry
+   the same number, which is what `bump-version.sh` was always for.
+5. **Make skew visible.** `sp-canvas root` already finds the installed plugin;
+   have it compare that plugin's `plugin.json` version against
+   `importlib.metadata.version("super-prototyping-tools")` and print one line
+   when they differ. A user who updated the plugin and forgot the toolkit
+   currently gets a confusing failure much later.
+6. **Document the Codex install, and give Codex its own catalogue.** The
+   install works today through the fallback, so the first half is a README
+   change: `codex plugin marketplace add ReScienceLab/super-prototyping`, then
+   `codex plugin add super-prototyping@super-prototyping`, refreshed with
+   `codex plugin marketplace upgrade`. Adding `.agents/plugins/marketplace.json`
+   is then not what makes it possible but what stops Codex reading a manifest
+   written for a different product: the file Codex prefers carries the fields
+   only it has. Superpowers' is the shape to copy — a marketplace `name`, an
+   `interface.displayName`, and one plugin with `name`, a
+   `{"source": "url", "url": "./"}` source, a `policy` block and a `category`.
+   It carries no version; Codex caches to
+   `plugins/cache/<marketplace>/<plugin>/<version>/`, the same version-keyed
+   cache Claude Code uses, so one `bump-version.sh` run releases both products.
+   (Which file it reads that version *from* we could not separate: superpowers
+   and this repo both declare the same number in `.codex-plugin` and
+   `.claude-plugin`. It does not matter while `bump-version.sh` moves them
+   together, which is the point of the script.)
+
+Deliberately not doing:
+
+- **Not switching `source: "./"` to a pinned `github`/`url` source.** It would
+  serve the tagged commit instead of the marketplace clone's HEAD, but
+  `sparsePaths` applies to the marketplace source, so the 6.7 MB install
+  documented in the README would go back to 151 MB. A plugin source has no
+  sparse option of its own — `git-subdir` is the one kind that clones sparsely
+  and it wants a subdirectory, which a root-level plugin does not have. With a
+  self-hosted marketplace whose only entry is itself, bumping the version buys
+  the same control at no cost.
+- **Not publishing the toolkit to PyPI yet.** It would make
+  `uv tool upgrade super-prototyping-tools` work, which is the one thing a git
+  install cannot do well, but it adds a second release surface and a name to
+  own. Revisit if users ask; the tagged git URL covers the need.
+- **Not adopting release-please / semantic-release.** They exist to derive
+  versions from conventional commits and generate changelogs; we have five
+  files in one repo and a script that already moves them, and the notes worth
+  writing are not commit subjects.
+
+## Checked
+
+Claude Code 2.1.263, codex-cli 0.145.0 and uv 0.11.29 on this machine.
+`claude plugin validate --strict` passes on both manifests, and `claude plugin
+tag --dry-run --force` (plain `--dry-run` refuses this dirty tree, which is the
+check item 1 leans on) prints `Tag: super-prototyping--v1.0.0`. The resolution
+order, the 14-day orphan sweep and the cache layout are from the plugins
+reference; the `installed_plugins.json` v2 fields were read from
+`~/.claude/plugins`. The marketplace numbers were recomputed from the locally
+cached `claude-plugins-official` manifest (292 entries, fetched 2026-09-09),
+and the workflow details from that repo on GitHub. The uv
+ref-plus-subdirectory syntax was resolved for real against `@main` and produced
+`super-prototyping-tools @ git+…@f56f52fe…#subdirectory=tools`. The Codex
+behaviour was probed in throwaway `CODEX_HOME`s: adding this repo at
+`origin/main`, which has no `.agents/plugins/marketplace.json`, reports the
+catalogue it used as `.claude-plugin/marketplace.json` and lists one plugin,
+which `codex plugin add super-prototyping@super-prototyping` installs as
+`1.0.0`; adding `obra/superpowers`, which does ship one, reports
+`.agents/plugins/marketplace.json` and installs `6.3.0` into
+`plugins/cache/superpowers-dev/superpowers/6.3.0`. The fallback order
+`.agents/plugins/marketplace.json`, `.agents/plugins/api_marketplace.json`,
+`.claude-plugin/marketplace.json`, `.cursor-plugin/marketplace.json` is in the
+0.145.0 binary. One caveat that cost an hour: `codex plugin add` fails against
+a marketplace added with `--sparse` ("unable to read sha1 file … unable to
+checkout working tree" — it re-clones the sparse snapshot and git cannot read
+the objects that were left out), so the small-install trick is Claude Code's
+only for now.

--- a/docs/2026-09-09-plugin-release-mechanism.md
+++ b/docs/2026-09-09-plugin-release-mechanism.md
@@ -2,10 +2,9 @@
 
 2026-09-09. The repo has been installable as a plugin since 2026-09-05, but it
 has never been *released*: no tag, no GitHub Release, no CI, and every manifest
-still says `1.0.0`. This note is the survey behind the fix — how Claude Code
-and Codex actually decide that an installed plugin is out of date, what the
-plugins people install do about it, and the smallest mechanism that fits this
-repo.
+still says `1.0.0`. This note is the survey behind the fix: how Claude Code and
+Codex actually decide that an installed plugin is out of date, what the plugins
+people install do about it, and the smallest mechanism that fits this repo.
 
 The headline finding is not a missing nicety. **Anyone who installed this
 plugin can never receive an update, no matter how many commits land on main.**
@@ -33,10 +32,10 @@ session which already loaded it keeps working.
 
 We declare `1.0.0` in three fields at once (`.claude-plugin/marketplace.json`
 at both `metadata.version` and `plugins[0].version`, and
-`.claude-plugin/plugin.json`). So `plugin.json` pins — the entry would pin
-anyway if it did not — the cache key never moves, and `/plugin update
-super-prototyping` reports success while copying nothing. The README's line —
-"`/plugin update super-prototyping` picks up a new release" — is only true
+`.claude-plugin/plugin.json`). So `plugin.json` pins the version, the entry
+would pin it anyway if it did not, the cache key never moves, and `/plugin
+update super-prototyping` reports success while copying nothing. The README's
+line, "`/plugin update super-prototyping` picks up a new release", is only true
 once the number moves, and it never has.
 
 This is a well-worn trap, not a subtlety we invented: `everything-claude-code`
@@ -68,7 +67,7 @@ There are exactly two coherent contracts, and the choice is ours:
 - `claude plugin validate <path> --strict` passes on both manifests today.
   Nothing runs it.
 - `git tag` is empty, `gh release list` is empty, and `.github/` holds only
-  `CODEOWNERS`, `dependabot.yml`, issue templates and a PR template — no
+  `CODEOWNERS`, `dependabot.yml`, issue templates and a PR template, with no
   workflows. CodeQL runs through GitHub's default setup and the canvas deploys
   through the Cloudflare Pages integration, so neither is a workflow file, and
   neither runs `bun run lint`, `bun run test`, `bun run build` or the Python
@@ -76,8 +75,8 @@ There are exactly two coherent contracts, and the choice is ours:
 - The toolkit is installed with an unpinned git URL:
   `uv tool install "git+https://github.com/ReScienceLab/super-prototyping#subdirectory=tools"`.
   It always takes the default branch's HEAD, so the plugin (pinned at a
-  version) and the toolkit (floating on main) can be arbitrarily far apart —
-  and `tools/pyproject.toml` is the fifth file `bump-version.sh` moves, so the
+  version) and the toolkit (floating on main) can be arbitrarily far apart.
+  `tools/pyproject.toml` is one of the files `bump-version.sh` moves, so the
   version it reports is a release number that no install path actually selects.
 - The Codex path in the README is a `git clone` plus `scripts/install-skills.sh`
   symlinks, with `git pull` as the upgrade. That predates Codex having plugins
@@ -87,8 +86,8 @@ There are exactly two coherent contracts, and the choice is ours:
   `codex plugin marketplace upgrade`. It looks for a catalogue at
   `<repo-root>/.agents/plugins/marketplace.json` and falls back to
   `.claude-plugin/marketplace.json`, then `.cursor-plugin/marketplace.json`, so
-  this repo is *already* installable that way through the Claude manifest —
-  probed today, `codex plugin add super-prototyping@super-prototyping` installs
+  this repo is *already* installable that way through the Claude manifest.
+  Probed today, `codex plugin add super-prototyping@super-prototyping` installs
   `1.0.0` with all three skills. Nothing tells a user so: the README still
   sends them to `git clone`.
 
@@ -112,9 +111,9 @@ a **sha**, and only two of them name a *tag* (`v1.5.5` and
 `greptile--v1.2.3`); the rest ride `main`, `master` or nothing at all. Second,
 the marketplace, not the plugin author, does the moving: a nightly workflow
 (`bump-plugin-shas.yml`, 07:23 UTC, capped at 60 entries a run) compares each
-entry's pinned sha against upstream HEAD — or, for the fourteen entries listed
+entry's pinned sha against upstream HEAD (or, for the fourteen entries listed
 `releases-only` in `.github/bump-tracking.json`, against the latest published
-release tag — validates the plugin at the new sha with `claude plugin
+release tag), validates the plugin at the new sha with `claude plugin
 validate`, and opens one PR per entry, which is how a failing entry stays
 isolated instead of holding up the batch. `validate-plugins.yml` and
 `scan-plugins.yml` are the required checks. Renames are handled by a top-level
@@ -124,22 +123,23 @@ The implication for us is direct: we are a *self-hosted, single-plugin*
 marketplace, so there is no nightly bot upstream of us. We are both halves,
 and whatever they automate we do by hand or not at all.
 
-**`obra/superpowers`** (v6.3.0) is the closest sibling — same shape as this
-repo, one skills library published to many agent products
+**`obra/superpowers`** (v6.3.0) is the closest sibling, the same shape as this
+repo: one skills library published to many agent products
 (`.claude-plugin`, `.codex-plugin`, `.cursor-plugin`, `.devin-plugin`,
 `.hermes-plugin`, `.kimi-plugin`, `gemini-extension.json`), and it is where our
 `.version-bump.json` and `scripts/bump-version.sh` came from. Its marketplace
 entry carries `"version": "6.3.0"` with `"source": "./"`, like ours minus our
-`metadata.version` — so the pinned contract, bumped every release. It keeps a
+`metadata.version`, so the pinned contract, bumped every release. It keeps a
 `RELEASE-NOTES.md` written for humans ("Worktree removal no longer destroys
 untracked files"), cuts a GitHub Release per version, and has **no CI workflows at all**: `.github/`
 holds funding and templates only. Its `.version-bump.json` has one thing ours
-lacks — an `audit` block that greps the tree for stray version strings the
-spec does not cover.
+lacks: an `audit` block that greps the tree for stray version strings the spec
+does not cover.
 
 **`greptileai/claude-plugin`** tags `greptile--v1.2.3` and cuts a GitHub
 Release for each, i.e. the literal output of `claude plugin tag`, and the
-official marketplace pins that tag *and* its sha — one of the two. Worth
+official marketplace pins that tag *and* its sha, one of only two entries so
+pinned. Worth
 knowing that the tag in the entry is downstream of the marketplace's own
 `releases-only` list as much as of greptile's convention: the bot follows
 releases for those fourteen, so an author who cuts releases gets pinned to
@@ -156,7 +156,7 @@ in the manifest, freshness handled upstream.
 
 **`wshobson/agents`** publishes 94 plugins, every one with an explicit
 `version`, plus `validate.yml` (JSON, manifests, hooks) and `code-quality.yml`
-(ruff/ty). No releases, no tags — the versions in the manifests are the whole
+(ruff/ty). No releases, no tags; the versions in the manifests are the whole
 release mechanism.
 
 The pattern across all of them: **an explicit version in the manifest is the
@@ -197,7 +197,7 @@ skills are read by agents and whose canvas app is built on the user's machine.
    worth knowing: a PR opened by `GITHUB_TOKEN` triggers no `pull_request`
    workflows, so the release PR carries no Validate run of its own (the gates
    ran on the commit being released, and `claude plugin tag` validates again);
-   and the tag job has to check that the version actually *changed* in the
+   and the tag job has to check that the version *changed* in the
    push, or any later edit to `plugin.json` would cut a release of whatever
    number is sitting in it.
 4. **Pin the toolkit to the release.** `uv` accepts a ref in the same URL. The
@@ -223,7 +223,7 @@ skills are read by agents and whose canvas app is built on the user's machine.
    `codex plugin marketplace upgrade`. Adding `.agents/plugins/marketplace.json`
    is then not what makes it possible but what stops Codex reading a manifest
    written for a different product: the file Codex prefers carries the fields
-   only it has. Superpowers' is the shape to copy — a marketplace `name`, an
+   only it has. Superpowers' is the shape to copy: a marketplace `name`, an
    `interface.displayName`, and one plugin with `name`, a
    `{"source": "url", "url": "./"}` source, a `policy` block and a `category`.
    It carries no version; Codex caches to
@@ -253,7 +253,7 @@ Deliberately not doing:
   of files in one repo and a script that already moves them, and the notes worth
   writing are not commit subjects.
 
-Which products that version actually reaches, and which file each of them reads
+Which products that version reaches, and which file each of them reads
 to find it, is the companion note: `docs/2026-09-09-multi-product-install.md`.
 
 ## Checked

--- a/mockups/canvases/README.md
+++ b/mockups/canvases/README.md
@@ -1,45 +1,24 @@
 # Canvases
 
-One subfolder per board. Drop `.html` files into `mockups/canvases/<slug>/`,
-no code change needed anywhere:
+This repo's own boards, one subfolder each. The folder conventions are in
+[`skills/prototype-canvas/references/layout.md`](../../skills/prototype-canvas/references/layout.md):
+how a folder becomes a page, `layout.json` field by field, the constraints
+every artboard renders under, and why the generator ships beside its output.
+That file is the copy that ships inside the plugin and has to stand alone on a
+machine that does not have this repo, so it is the one kept current. What
+follows is only what is true here and nowhere else.
 
-- Each folder becomes one tldraw page, named after the folder
-  (`kebab-case` → `Title Case`). Folders sort numerically, and the page menu
-  is put in that same order, so a `00-` prefix is what puts a page on top.
-  `order` in `layout.json` moves a folder without renaming it.
-- Each `.html` file in it becomes one shape on that page.
-- Files sort numerically by name, so prefix them `00-`, `01-`, `02-` …
-- Discovery is the `prototyping-canvases` plugin in `canvas/vite.config.ts`,
-  which scans `PROTOTYPING_CANVASES_DIR` (this folder by default) and
-  generates the index `canvas/src/canvasLibrary.ts` reads.
+Discovery in this checkout is the `prototyping-canvases` plugin in
+`canvas/vite.config.ts`, which scans `PROTOTYPING_CANVASES_DIR` (this folder by
+default) and generates the index `canvas/src/canvasLibrary.ts` reads.
 
-Two things the scanner will not do. A folder or file whose name contains `#`
-or `?` is skipped with a warning: both are URL punctuation, no encoding
-survives the round trip, and such a board would silently render blank. And a
-symlink in here is followed, which is how you point the canvas at boards
-living somewhere else — but it also reaches outside the directory the dev
-server is otherwise confined to, so only link at something you trust.
+Switch pages with the page menu at the top-left of the canvas. Deep-link a page
+with `?canvas=<slug>`, e.g. `http://127.0.0.1:5173/?canvas=notion-ios`, and one
+board of it with `#<file>` after that, e.g. `?canvas=notion-ios#02-search-ask-ai`.
 
-A folder is an unzipped Sketch file: `layout.json` plays `document.json` and
-`meta.json`, `icon.png` plays `previews/preview.png`, `assets/` plays
-`images/`, and the numbered boards are the pages. `probes.json` and
-`crops.json` are the measurement evidence. Commit them with the boards.
-`assets.json`, where a folder has one, is a `name → data URI` map of
-pre-encoded images the generator inlines; commit it too, it is the only
-copy of those images. The canvas's inspector names a board's images by
-content, from `assets/` first and `assets.json` second, and falls back to
-the image's `alt` when a generator re-encoded it. It names an inline
-`<svg>` the same way from `assets/icons/`, by its geometry rather than its
-bytes, so keep each icon as a file there and inline it through a helper in
-`gen.py`. Everything a run makes on the way, grids, shots, montages,
-candidate boards, goes in `<slug>/scratch/`. The root `.gitignore` ignores
-`scratch/` at any depth, and `assets/refs/` too, which is where third-party
-captures go. No folder needs a `.gitignore` of its own.
-
-Switch pages with the page menu at the top-left of the canvas. Deep-link a
-page with `?canvas=<slug>`, e.g. `http://127.0.0.1:5173/?canvas=notion-ios`,
-and one board of it with `#<file>` after that, e.g.
-`?canvas=notion-ios#02-search-ask-ai`.
+Every folder shipped with the repo is named `(example) …` in its `layout.json`
+and a board of your own is not, which is how the two tell apart in the page
+menu.
 
 ## 00-welcome
 
@@ -68,141 +47,23 @@ squircle; the ones here came from the App Store's own artwork
 Apple's system apps, out of `apple-icons/assets/`. Each carries its source in
 a PNG `Source` text chunk. A folder with no `icon.png` simply shows none.
 
-## layout.json
+## Generators in this repo
 
-Optional, one per folder. It groups the board's files into labelled rows
-laid out top to bottom:
-
-```json
-{
-  "name": "(example) Notion iOS",
-  "status": "exploring",
-  "rows": [
-    { "title": "Foundations", "files": ["00-design-tokens"] },
-    { "title": "Screens", "numbered": true,
-      "files": [{ "file": "01-example-screen", "label": "Home" }],
-      "links": [{ "label": "example.com", "url": "https://example.com" }] },
-    { "title": "Source of truth: references", "numbered": true,
-      "files": [{ "file": "ref-01-home", "label": "Home" }] }
-  ]
-}
-```
-
-- `name` overrides the page name. Without it the folder slug is humanized,
-  which cannot express casing or punctuation. `notion-ios` becomes
-  "Notion Ios". Set it when the humanized name reads wrong. A page is tied to
-  its folder, not to its name, so changing it renames the page you already
-  have open rather than starting a second one. Every folder shipped with the
-  repo is an example and is named `(example) …`; a board of your own is not,
-  which is how the two tell apart in the page menu.
-- `cover` names the board that stands in for the folder on the welcome page,
-  e.g. `"00-launch-light"`. Without one the card shows the first board that is
-  not a `00-` sheet, which is the right guess for most folders and the wrong
-  one where the front door is a `00-` board.
-- `order` sorts the folder in the page menu and on the welcome page: lower
-  first, default 0, and folders that say nothing keep slug order. The welcome
-  page stays on top whatever it says.
-- `coverBox` is the part of the cover board the card shows, `[x, y, w, h]` in
-  board px. The default is the phone frame every folder here draws at the same
-  place, `[46, 24, 393, 852]`, so a card crops to the mockup rather than
-  framing it in artboard margin. Declare one for a phone drawn somewhere else,
-  or for a cover that is not a phone at all: `[0, 0, 478, 980]`.
-- `files` entries are file names **without** `.html`, either bare (the
-  humanized file name becomes the caption) or `{ "file", "label" }`.
-- `numbered: true` prefixes each caption with its 1-based position. Never
-  hand-number labels, position is computed.
-- `{ "file", "label", "w", "h" }` overrides the 478 x 980 artboard for a board
-  that is not phone-shaped, a landscape banner say. A row is laid out at its
-  first file's size, so give every file in the row the same one.
-- `status` is how far along a board is: `exploring`, `outdated`, or `live`.
-  `live` is the default and draws nothing; the other two draw a coloured tab
-  above the board, amber for exploring and grey for outdated. Declare it once
-  at the top level for a folder that is one round of exploration, and per file
-  (`{ "file", "label", "status": "outdated" }`) for a board that differs,
-  including back to `"live"` to drop a tab the folder would otherwise give it.
-  The status control at the top left of the inspector writes this field, so
-  clicking it changes a board's status without editing this file. It
-  is a tldraw shape the layout places, not markup in the board, so a board
-  keeps no record of its own status and does not need regenerating when that
-  status changes. A row reserves the tab's height for all of its boards as soon
-  as one of them carries a tab, which is what keeps item N of one row aligned
-  with item N of the next.
-- `"links": [{ "label", "url" }]` puts buttons under the row that open an
-  address in a new tab. A board renders in `<iframe srcDoc sandbox="">`, where
-  a link can navigate nothing, so anything clickable has to be a shape out
-  here rather than markup in the board.
-- Every row starts at x = 0 with the same column pitch, so **item N of one
-  row sits directly under item N of the row above**. That is what makes a
-  reference row readable against the mockup row above it.
-- Files not listed in any row still appear, in a fallback grid below.
-
-After editing `layout.json`, press the **refresh** button in the top bar,
-next to the `…` actions menu.
-Shape creation is idempotent (it never moves a shape that already exists),
-so reordering a row needs that force-relayout to take effect.
-
-## Constraints on every artboard
-
-Boards render inside `<iframe srcDoc sandbox="">`:
-
-- **Fully self-contained.** No external CSS, JS, fonts or images. Inline
-  the token block in every file; embed images as `data:` URIs; icons are
-  inline SVG, each kept as `assets/icons/<name>.svg` so the inspector can
-  name it.
-- **The shape box is 478 × 980** (`CANVAS_FILE_DEFAULT_SIZE`). The iframe
-  clips anything past that box with no warning, so check every fixed-height
-  board after adding a row. `00-welcome` is the one exception, a landscape
-  2153 × 819 board. Its `gen.py` writes that size into `layout.json` as
-  `w`/`h`, which is how any board declares a box of its own.
-- iPhone frame is 393 × 852 pt at 1pt = 1px: 54px status bar,
-  125 × 36 Dynamic Island, 139 × 5 home indicator.
-
-Mockup HTML routinely has single lines of 100KB–2MB of embedded base64. To
-splice a large blob into an existing artboard without pulling it through an
-agent's context, locate the target line with `grep -n` on a distinguishing
-class or attribute (never on the blob line itself), then read/replace that
-one line with a short Python script
-(`base64.b64encode(open(path,'rb').read())`) run from the shell. Never
-`cat`/`echo` a blob into a tool call. Prefer real product assets (the actual
-icon, the actual logo, a rasterized system symbol) over hand-drawn
-approximations.
-
-## Ship the generator with the boards
-
-The clone workflow forbids hand-editing a generated artboard: you edit the
-generator and re-run. That rule is dead on arrival if the generator lives in
-a session scratch directory, because the scratch directory is deleted with
-the session. The next person who needs to fix one board then has to either
-hand-edit measured output (forbidden) or redo the whole run. `notion-ios`
-and `raycast-ios` have exactly this problem: neither committed its
-generator, so neither can be regenerated by its own rules.
-
-So the convention: **a board folder ships its generator as `gen.py`, next
-to its output, plus any asset JSON it reads** (base64 `data:` URIs for
-bitmaps). `gen.py` resolves every path relative to `__file__`, so from
-anywhere:
-
-```bash
-python3 mockups/canvases/<slug>/gen.py
-```
-
-regenerates the folder in place, byte-identical. A folder whose boards
-cannot be regenerated is incomplete. A folder built from more than one source
-may split the measurements across further modules that `gen.py` imports
-(`apple-wallet` has two, one per Figma file), but the entry point stays
-`gen.py`.
+`notion-ios` and `raycast-ios` are finished boards whose generators were never
+committed, so neither can be regenerated by its own rules and their HTML is
+read-only. Every other folder here rebuilds with
+`python3 mockups/canvases/<slug>/gen.py`.
 
 Generators come in two lineages, and the only difference is the `page()`
 helper's signature. The Figma-sourced runs, `apple-photos`, `apple-calendar`
-and `apple-settings`, use `page(title, css, body)`. The screenshot-sourced
-runs and `templates/` use `page(title, body, extra_css="")`. Copy whichever
-matches your source. There is no shared library, and no `gen.py` imports
-anything from another folder or from `tools/`, so copying one folder gets
-you a complete generator.
+and `apple-settings`, use `page(title, css, body)`. The screenshot-sourced runs
+and `templates/` use `page(title, body, extra_css="")`. Copy whichever matches
+your source. `apple-wallet` is the folder built from more than one source: two
+modules, one per Figma file, imported by its `gen.py`.
 
-This is safe for discovery: the canvas indexes only `*.html` (plus
-`layout.json` and `icon.png`), so `gen.py` and its asset files sitting in the
-folder are invisible to it.
+`00-welcome` is the one board here that is not phone-shaped. Its `gen.py`
+writes 2153 x 819 into `layout.json` as `w`/`h`, which is how any board
+declares a box other than the default 478 x 980.
 
 ## Examples
 

--- a/plugin.json
+++ b/plugin.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+  "name": "super-prototyping",
+  "version": "1.0.0",
+  "description": "Rebuild and design product UI as self-contained HTML artboards on a local tldraw canvas. Clone a real app from screenshots by measurement, design new screens from measured tokens, and drive the canvas that shows them.",
+  "author": {
+    "name": "ReScience Lab",
+    "url": "https://github.com/ReScienceLab"
+  },
+  "homepage": "https://prototyping.rescience.com",
+  "repository": "https://github.com/ReScienceLab/super-prototyping",
+  "license": "Apache-2.0",
+  "keywords": [
+    "design",
+    "ui",
+    "prototyping",
+    "tldraw",
+    "mockups",
+    "screenshots",
+    "design-tokens",
+    "html"
+  ]
+}

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -20,5 +20,10 @@ time one of them is edited by hand.
 ```bash
 scripts/bump-version.sh --check
 scripts/bump-version.sh 1.1.0
-git commit -am "release 1.1.0" && git tag super-prototyping--v1.1.0
 ```
+
+Nobody has to run the bump by hand, though: dispatching the **Release**
+workflow with a version runs it on a branch and opens the release PR, and
+merging that PR tags `super-prototyping--v1.1.0` and cuts the release from
+`RELEASE-NOTES.md`. Bumping locally is for seeing the diff before asking for
+it.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -2,21 +2,24 @@
 
 Two release-and-install scripts. Neither is needed to *use* the plugin.
 
-**`install-skills.sh`** links `skills/*` into the skill roots of products
-installing without a marketplace — Hermes, Pi, and a Codex older than the
-`codex plugin` commands — and installs the Python toolkit that
+**`install-skills.sh`** links `skills/*` into the skill roots of every product
+on the machine that reads one (Codex, CodeBuddy, Hermes, Pi, Trae, Trae CN) and
+installs the Python toolkit that
 puts `refkit`, `artgen` and `sp-canvas` on PATH. Links, not copies, so one
 `git pull` in this checkout updates every product at once. `--list` shows what
-it would do and changes nothing; `--tools-only` skips the linking. Claude Code
-users do not need it: `/plugin install` covers the skills, and only the
-toolkit line from the README is left to run.
+it would do and changes nothing; `--tools-only` skips the linking. Most of those
+products also have an install command of their own, and README's install table
+prefers it: a linked checkout is whatever you last pulled, where an install is a
+release. This is the route for a product with no such command (Trae), for a
+release too old to have one, and for anyone who would rather run every product
+off one checkout.
 
 **`bump-version.sh`** moves the release version in every file listed in
-`.version-bump.json` at once — the two plugin manifests, the marketplace entry
-and `tools/pyproject.toml`. `--check` verifies they agree and prints each one,
-which is the useful thing to run before tagging. Four manifests drifting apart
-is what makes "which version am I on" unanswerable, and it happens the first
-time one of them is edited by hand.
+`.version-bump.json` at once — the four plugin manifests, the marketplace entry
+twice over, and `tools/pyproject.toml`. `--check` verifies they agree and prints
+each one, which is the useful thing to run before tagging. Manifests drifting
+apart is what makes "which version am I on" unanswerable, and it happens the
+first time one of them is edited by hand.
 
 ```bash
 scripts/bump-version.sh --check

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -2,8 +2,9 @@
 
 Two release-and-install scripts. Neither is needed to *use* the plugin.
 
-**`install-skills.sh`** links `skills/*` into the skill roots of products that
-have no marketplace — Codex, Hermes, Pi — and installs the Python toolkit that
+**`install-skills.sh`** links `skills/*` into the skill roots of products
+installing without a marketplace — Hermes, Pi, and a Codex older than the
+`codex plugin` commands — and installs the Python toolkit that
 puts `refkit`, `artgen` and `sp-canvas` on PATH. Links, not copies, so one
 `git pull` in this checkout updates every product at once. `--list` shows what
 it would do and changes nothing; `--tools-only` skips the linking. Claude Code

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -72,7 +72,9 @@ def write_toml_version(text, parts, value):
         raise SystemExit("error: no `version = \"...\"` line to rewrite")
     return new
 
-seen, failures = {}, []
+# Read every file before writing any of them. A bump that stops halfway leaves the
+# tree half-versioned, which is the one state this script exists to make impossible.
+seen, failures, planned = {}, [], []
 
 for entry in spec["files"]:
     path  = root / entry["path"]
@@ -95,27 +97,27 @@ for entry in spec["files"]:
         current = get_in(json.loads(text), parts)
 
     seen[label] = current
-
-    if mode == "check":
-        continue
-
-    if current == version:
-        print(f"  = {label} already {version}")
-        continue
-
-    if path.suffix == ".toml":
-        path.write_text(write_toml_version(text, parts, version))
-    else:
-        data = json.loads(text)
-        set_in(data, parts, version)
-        path.write_text(json.dumps(data, indent=2) + "\n")
-    print(f"  → {label}  {current} → {version}")
+    planned.append((path, parts, label, text, current))
 
 if failures:
     print("", file=sys.stderr)
     for problem in failures:
         print(f"error: {problem}", file=sys.stderr)
+    print("error: nothing was written", file=sys.stderr)
     sys.exit(1)
+
+if mode == "set":
+    for path, parts, label, text, current in planned:
+        if current == version:
+            print(f"  = {label} already {version}")
+            continue
+        if path.suffix == ".toml":
+            path.write_text(write_toml_version(text, parts, version))
+        else:
+            data = json.loads(text)
+            set_in(data, parts, version)
+            path.write_text(json.dumps(data, indent=2) + "\n")
+        print(f"  → {label}  {current} → {version}")
 
 if mode == "check":
     distinct = sorted(set(seen.values()))

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -5,11 +5,12 @@
 #   scripts/bump-version.sh 1.1.0
 #   scripts/bump-version.sh --check          # verify every file already agrees
 #
-# A plugin's version lives in five places (see .version-bump.json): the Claude
-# Code manifest, twice inside the marketplace catalogue, the Codex manifest, and
-# the Python toolkit. Bumping them by hand is how a release ends up
-# half-versioned, with `/plugin update` reporting one number and `refkit
-# --version` another. This is the only supported way to change them.
+# A plugin's version lives in seven places (see .version-bump.json): the
+# portable manifest at the root, the Claude Code manifest, twice inside the
+# marketplace catalogue, the Codex and CodeBuddy manifests, and the Python
+# toolkit. Bumping them by hand is how a release ends up half-versioned, with
+# `/plugin update` reporting one number and `refkit --version` another. This is
+# the only supported way to change them.
 #
 set -euo pipefail
 

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -127,6 +127,8 @@ if mode == "check":
     print(f"\nall {len(seen)} files agree on {distinct[0]}")
 else:
     print(f"\nbumped {len(seen)} files to {version}")
-    print(f"next: git commit -am 'release {version}' "
-          f"&& git tag {spec['tagPrefix']}{version}")
+    # The tag is not cut here: .github/workflows/release.yml cuts it once the bump
+    # is on main, with `claude plugin tag` re-checking these same files first.
+    print(f"next: commit as 'release {version}' and open a PR — merging it tags "
+          f"{spec['tagPrefix']}{version}")
 PY

--- a/scripts/install-skills.sh
+++ b/scripts/install-skills.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
-# Install the super-prototyping skills and toolkit for agent products that have
-# no plugin marketplace of their own.
+# Install the super-prototyping skills and toolkit into every agent product on
+# this machine that reads a skills directory.
 #
 #   scripts/install-skills.sh              # toolkit + every product found
 #   scripts/install-skills.sh --tools-only # just refkit and artgen
@@ -12,12 +12,15 @@
 #   /plugin marketplace add ReScienceLab/super-prototyping
 #   /plugin install super-prototyping@super-prototyping
 #
-# Codex has plugin commands of its own now (`codex plugin marketplace add`),
-# but Hermes and Pi read the same SKILL.md directories with no marketplace to
-# install from, so this links `skills/` into each of their skill roots. Links,
-# not copies: `git pull` in this checkout then updates every product at once,
-# and there is no forked copy to drift. The toolkit is a real install rather
-# than a link, so re-run this after a pull to move it too.
+# Claude Code, Codex, CodeBuddy/WorkBuddy, Hermes and Pi each have an install
+# command of their own — README's install table has them, and they are the
+# better route because they carry a version. This script is for everything else
+# that reads a SKILL.md directory, Trae above all, and for a product whose
+# release is too old for its own plugin commands. It links `skills/` into every
+# skill root it finds. Links, not copies: `git pull` in this checkout then
+# updates every product at once, and there is no forked copy to drift. The
+# toolkit is a real install rather than a link, so re-run this after a pull to
+# move it too.
 #
 set -euo pipefail
 
@@ -28,7 +31,7 @@ MODE=all
 case "${1-}" in
   --tools-only) MODE=tools ;;
   --list)       MODE=list ;;
-  --help|-h)    sed -n '3,19p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+  --help|-h)    sed -n '3,23p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
   "")           ;;
   *)            echo "error: unknown option '$1' (try --help)" >&2; exit 2 ;;
 esac
@@ -63,17 +66,21 @@ install_tools() {
 }
 
 # --- the skills --------------------------------------------------------------
-# One row per product: label, skill root. Codex follows symlinks by design and
-# scans from the working directory up to the repo root; Hermes and Pi read
-# their own home directories.
+# One row per product: label, skill root. Every path here is the product's own
+# documented user-level skills directory, and `npx skills` writes to the same
+# ones — Trae CN is a separate install of Trae with a separate home, which is
+# why it gets its own row.
 
 link_skills() {
   step "skills"
   local any=0
   local products=(
     "Codex CLI|$HOME/.codex/skills"
+    "CodeBuddy|$HOME/.codebuddy/skills"
     "Hermes|$HOME/.hermes/skills"
     "Pi|$HOME/.pi/agent/skills"
+    "Trae|$HOME/.trae/skills"
+    "Trae CN|$HOME/.trae-cn/skills"
   )
 
   for row in "${products[@]}"; do

--- a/scripts/install-skills.sh
+++ b/scripts/install-skills.sh
@@ -12,8 +12,9 @@
 #   /plugin marketplace add ReScienceLab/super-prototyping
 #   /plugin install super-prototyping@super-prototyping
 #
-# Codex, Hermes and Pi read the same SKILL.md directories but have no
-# marketplace, so this links `skills/` into each of their skill roots. Links,
+# Codex has plugin commands of its own now (`codex plugin marketplace add`),
+# but Hermes and Pi read the same SKILL.md directories with no marketplace to
+# install from, so this links `skills/` into each of their skill roots. Links,
 # not copies: `git pull` in this checkout then updates every product at once,
 # and there is no forked copy to drift. The toolkit is a real install rather
 # than a link, so re-run this after a pull to move it too.

--- a/skills/README.md
+++ b/skills/README.md
@@ -17,6 +17,9 @@ Rules for editing one:
   `description` under 1024 characters and free of `<` or `>`.
 - Keep `SKILL.md` under ~500 lines. Depth goes in `references/`, behind a
   two-line pointer that says what is in there and when to read it.
+- **This file gets no frontmatter.** Pi walks `skills/` recursively and counts
+  a top-level `.md` as a skill when it carries frontmatter with a
+  `description`, so adding one here would install a fourth skill.
 - **Never write a path to this repo.** A skill runs inside someone else's
   project. Call the tools by name (`refkit`, `artgen`, `sp-canvas`), and when
   a skill needs a file that ships with the plugin, reach it through

--- a/skills/prototype-canvas/references/layout.md
+++ b/skills/prototype-canvas/references/layout.md
@@ -5,9 +5,9 @@ default, or wherever `PROTOTYPING_CANVASES_DIR` points). Drop `.html` files in
 and nothing else needs changing:
 
 - Each folder becomes one tldraw page, named after the folder
-  (`kebab-case` → `Title Case`). Folders sort numerically, so a `00-` prefix
-  puts a page on top. `order` in `layout.json` moves a folder without
-  renaming it.
+  (`kebab-case` → `Title Case`). Folders sort numerically and the page menu
+  is put in that same order, so a `00-` prefix is what puts a page on top.
+  `order` in `layout.json` moves a folder without renaming it.
 - Each `.html` file in it becomes one shape on that page.
 - Files sort numerically by name, so prefix them `00-`, `01-`, `02-` …
 - Discovery is the `prototyping-canvases` plugin in the app's

--- a/tools/README.md
+++ b/tools/README.md
@@ -17,9 +17,9 @@ Three command-line tools, packaged so the skills can call them by name.
 The skills that use them ship inside a plugin, and a plugin is installed
 outside the user's repository. `python3 "$(git rev-parse --show-toplevel)/tools/refkit.py"`
 resolves to the *user's* git root, where there is no `tools/`. No agent
-product exposes its plugin root as a shell variable that all four of Claude
-Code, Codex, Hermes and Pi agree on, so a path-based invocation would need
-four spellings and would still break outside a git repository.
+product exposes its plugin root as a shell variable that Claude Code, Codex,
+CodeBuddy, Hermes, Pi and Trae agree on, so a path-based invocation would need
+a spelling per product and would still break outside a git repository.
 
 Installing them puts `refkit`, `artgen` and `sp-canvas` on `PATH`, and every
 skill reads the same in every product:

--- a/tools/sp_canvas.py
+++ b/tools/sp_canvas.py
@@ -4,7 +4,8 @@
   start    boot the dev server against a folder of boards, print its address
   stop     kill the one on that port, and only that one
   status   say whether it is up, and on what
-  root     print the plugin root it resolved (-v: and where it looked)
+  root     print the plugin root it resolved (-v: where it looked, and the
+           release each half is on)
 
 The canvas app ships inside the plugin, which is installed outside your
 project — under ~/.claude/plugins/cache, or wherever you cloned the repo. Your
@@ -113,6 +114,41 @@ def _version_key(name: str):
     # 0 for a prerelease and 1 for the release, so 1.0.0 outranks every 1.0.0-* ; between two
     # prereleases the trailing numbers decide.
     return release + ((0, tuple(int(n) for n in re.findall(r"\d+", pre))) if pre else (1, ()))
+
+
+# The release tag this repo cuts, and what `claude plugin tag` produces. Kept in step with
+# .version-bump.json, because the note below hands the user a URL built from it.
+TAG_PREFIX = "super-prototyping--v"
+
+
+def _toolkit_version():
+    """The version of the toolkit this process runs from, or None from a source checkout."""
+    try:
+        from importlib.metadata import PackageNotFoundError, version
+        return version("super-prototyping-tools")
+    except (ImportError, PackageNotFoundError):
+        return None
+
+
+def _plugin_version(root: Path):
+    """The version of the plugin the canvas app came out of, or None if it has no manifest."""
+    try:
+        return json.loads((root / ".claude-plugin/plugin.json").read_text()).get("version")
+    except (OSError, ValueError):
+        return None
+
+
+def skew(root: Path):
+    """(plugin, toolkit) when the two halves disagree on the release, else None.
+
+    They install separately — `/plugin install` for the skills and the canvas, `uv tool
+    install` for refkit, artgen and this — so updating one and forgetting the other is the
+    ordinary mistake. Unchecked it surfaces much later, as a skill calling a flag this
+    refkit does not have. An unknown version on either side is not a disagreement: a
+    checkout has no release number to compare.
+    """
+    plugin, toolkit = _plugin_version(root), _toolkit_version()
+    return (plugin, toolkit) if plugin and toolkit and plugin != toolkit else None
 
 
 def _is_canvas_app(root: Path) -> bool:
@@ -244,6 +280,14 @@ def cmd_start(a):
     print(f"boards   {boards}")
     print(f"app      {app}")
     print(f"running  {how}")
+
+    versions = skew(root)
+    if versions:
+        plugin, toolkit = versions
+        print(f"\nnote: the plugin is {plugin}, the toolkit is {toolkit}. Move the toolkit to match:\n"
+              f'      uv tool install --force "git+https://github.com/ReScienceLab/'
+              f'super-prototyping@{TAG_PREFIX}{plugin}#subdirectory=tools"')
+
     print(f"\nDeep-link a page with ?canvas=<slug>, one board of it with #<file>, "
           f"e.g. http://127.0.0.1:{a.port}/?canvas=notion-ios#01-splash")
 
@@ -316,13 +360,21 @@ def cmd_status(a):
 
 def cmd_root(a):
     """Just the path, so it can be captured: KIT="$(sp-canvas root)"."""
-    print(resolve_root(verbose=a.verbose))
+    root = resolve_root(verbose=a.verbose)
+    print(root)
+    if a.verbose:
+        # On stderr, like the search itself, so `$(sp-canvas root -v)` is still the path.
+        print(f"  plugin  {_plugin_version(root) or 'unversioned (a checkout)'}", file=sys.stderr)
+        print(f"  toolkit {_toolkit_version() or 'dev (running from a source checkout)'}",
+              file=sys.stderr)
 
 
 def main():
     p = argparse.ArgumentParser(
         prog="sp-canvas", description=__doc__,
         formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--version", action="version",
+                   version=f"sp-canvas {_toolkit_version() or 'dev (running from a source checkout)'}")
     s = p.add_subparsers(dest="cmd", required=True)
 
     def add(name, fn, ports=True, canvases=True):

--- a/tools/sp_canvas.py
+++ b/tools/sp_canvas.py
@@ -151,6 +151,18 @@ def skew(root: Path):
     return (plugin, toolkit) if plugin and toolkit and plugin != toolkit else None
 
 
+def skew_fix(plugin, toolkit):
+    """The one command that closes the gap, whichever half is behind.
+
+    Which way round matters: telling someone whose toolkit is ahead to `uv tool install`
+    the plugin's older tag is a downgrade, and to a tag that need not even exist yet.
+    """
+    if _version_key(toolkit) > _version_key(plugin):
+        return "/plugin update super-prototyping   (in Claude Code; codex plugin add, in Codex)"
+    return ('uv tool install --force "git+https://github.com/ReScienceLab/'
+            f'super-prototyping@{TAG_PREFIX}{plugin}#subdirectory=tools"')
+
+
 def _is_canvas_app(root: Path) -> bool:
     pkg = root / "canvas" / "package.json"
     try:
@@ -284,9 +296,8 @@ def cmd_start(a):
     versions = skew(root)
     if versions:
         plugin, toolkit = versions
-        print(f"\nnote: the plugin is {plugin}, the toolkit is {toolkit}. Move the toolkit to match:\n"
-              f'      uv tool install --force "git+https://github.com/ReScienceLab/'
-              f'super-prototyping@{TAG_PREFIX}{plugin}#subdirectory=tools"')
+        print(f"\nnote: the plugin is {plugin}, the toolkit is {toolkit}. "
+              f"Move the older one up:\n      {skew_fix(*versions)}")
 
     print(f"\nDeep-link a page with ?canvas=<slug>, one board of it with #<file>, "
           f"e.g. http://127.0.0.1:{a.port}/?canvas=notion-ios#01-splash")

--- a/tools/sp_canvas.py
+++ b/tools/sp_canvas.py
@@ -126,7 +126,11 @@ def _version_key(name: str):
     (1, 0, 0, 1), which beat 1.0.0. bump-version.sh accepts prereleases, so the cache
     really can hold both. Anything unparseable sorts oldest.
     """
-    m = re.match(r"v?(\d+)(?:\.(\d+))?(?:\.(\d+))?(?:[-+](.*))?$", name)
+    # The separator is optional because the two halves spell a prerelease differently:
+    # the manifests carry semver's 1.1.0-rc.1 and hatchling normalises the wheel to
+    # PEP 440's 1.1.0rc1. Both have to land on the same key or every prerelease
+    # install reports drift against itself.
+    m = re.match(r"v?(\d+)(?:\.(\d+))?(?:\.(\d+))?(?:[-+._]?([A-Za-z][0-9A-Za-z.+-]*))?$", name)
     if not m:
         return (-1,)
     release = tuple(int(p or 0) for p in m.group(1, 2, 3))
@@ -154,7 +158,7 @@ def _plugin_version(root: Path):
     """The version of the plugin the canvas app came out of, or None if it has no manifest."""
     try:
         return json.loads((root / ".claude-plugin/plugin.json").read_text()).get("version")
-    except (OSError, ValueError):
+    except (OSError, ValueError, AttributeError):
         return None
 
 
@@ -168,7 +172,10 @@ def skew(root: Path):
     checkout has no release number to compare.
     """
     plugin, toolkit = _plugin_version(root), _toolkit_version()
-    return (plugin, toolkit) if plugin and toolkit and plugin != toolkit else None
+    if not (plugin and toolkit):
+        return None
+    # Compared as versions, not as strings: see _version_key on the two spellings.
+    return (plugin, toolkit) if _version_key(plugin) != _version_key(toolkit) else None
 
 
 def skew_fix(plugin, toolkit):

--- a/tools/sp_canvas.py
+++ b/tools/sp_canvas.py
@@ -47,8 +47,8 @@ def _candidates():
     """Every place a canvas app could be, most explicit first.
 
     Yields (label, path). No product exposes its plugin root to a shell in a way
-    all four of Claude Code, Codex, Hermes and Pi agree on, so the app is found
-    rather than addressed.
+    Claude Code, Codex, CodeBuddy, Hermes, Pi and Trae agree on, so the app is
+    found rather than addressed.
     """
     env = os.environ.get("SUPER_PROTOTYPING_ROOT")
     if env:
@@ -70,17 +70,37 @@ def _candidates():
 
     # Failing that, the cache holds one directory per installed version, and old ones are not
     # cleaned up. Sort by version, not by mtime: two directories can share an mtime, and then
-    # mtime order is arbitrary and can hand back the older release.
-    cache = glob.glob(str(Path.home() / ".claude/plugins/cache/*/super-prototyping/*"))
-    for path in sorted(cache, key=lambda p: _version_key(Path(p).name), reverse=True):
-        yield "Claude Code plugin cache", Path(path)
+    # mtime order is arbitrary and can hand back the older release. Codex and CodeBuddy cache
+    # the same way under their own homes, so the same pick works for all three.
+    for label, pattern in (
+        ("Claude Code plugin cache", ".claude/plugins/cache/*/super-prototyping/*"),
+        ("Codex plugin cache",       ".codex/plugins/cache/*/super-prototyping/*"),
+        ("CodeBuddy plugin cache",   ".codebuddy/plugins/cache/*/super-prototyping/*"),
+    ):
+        found = glob.glob(str(Path.home() / pattern))
+        for path in sorted(found, key=lambda p: _version_key(Path(p).name), reverse=True):
+            yield label, Path(path)
 
-    # The other products hold a symlink per skill, pointing back into the
-    # checkout: <root>/skills/prototype-canvas -> up two levels is <root>.
+    # Hermes and Pi clone the repo whole rather than keeping a copy per version: Hermes into
+    # its plugins directory, flat or one category level deep, Pi into a git package keyed by
+    # host and repo path.
+    for label, pattern in (
+        ("Hermes plugin", ".hermes/plugins/super-prototyping"),
+        ("Hermes plugin", ".hermes/plugins/*/super-prototyping"),
+        ("Pi git package", ".pi/agent/git/*/ReScienceLab/super-prototyping"),
+    ):
+        for path in sorted(glob.glob(str(Path.home() / pattern))):
+            yield label, Path(path)
+
+    # Everything else holds a symlink per skill, pointing back into the checkout:
+    # <root>/skills/prototype-canvas -> up two levels is <root>.
     for label, root in (
         ("Codex CLI", "~/.codex/skills"),
+        ("CodeBuddy", "~/.codebuddy/skills"),
         ("Hermes", "~/.hermes/skills"),
         ("Pi", "~/.pi/agent/skills"),
+        ("Trae", "~/.trae/skills"),
+        ("Trae CN", "~/.trae-cn/skills"),
     ):
         link = Path(root).expanduser() / "prototype-canvas"
         if link.is_symlink():
@@ -158,7 +178,8 @@ def skew_fix(plugin, toolkit):
     the plugin's older tag is a downgrade, and to a tag that need not even exist yet.
     """
     if _version_key(toolkit) > _version_key(plugin):
-        return "/plugin update super-prototyping   (in Claude Code; codex plugin add, in Codex)"
+        return ("/plugin update super-prototyping   (Claude Code; or codex plugin add, "
+                "codebuddy plugin install, hermes plugins update, npx skills update)")
     return ('uv tool install --force "git+https://github.com/ReScienceLab/'
             f'super-prototyping@{TAG_PREFIX}{plugin}#subdirectory=tools"')
 

--- a/tools/test_sp_canvas.py
+++ b/tools/test_sp_canvas.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
-"""Self-check for the launcher's version logic: which cached release it picks,
-and when it says the plugin and the toolkit have drifted apart.
+"""Self-check for how the launcher finds the plugin: where each product's install
+lands, which cached release it picks, and when it says the plugin and the toolkit
+have drifted apart.
 
     python3 tools/test_sp_canvas.py
 """
@@ -48,6 +49,60 @@ def test_the_fix_moves_whichever_half_is_behind():
     # The toolkit is ahead, which the uv line would *downgrade* — and to a tag that need
     # not exist. Update the plugin instead.
     assert "/plugin update" in C.skew_fix("1.0.0", "1.1.0")
+
+
+def canvas_app_at(root: Path):
+    """Make `root` look like a plugin holding the canvas app."""
+    (root / "canvas").mkdir(parents=True)
+    (root / "canvas/package.json").write_text(json.dumps({"name": "prototyping-canvas"}))
+    return root
+
+
+def with_home(home, fn):
+    """Run fn with `home` as the home directory, both ways of asking for it.
+
+    `Path.home()` and `Path("~/...").expanduser()` are separate lookups and the launcher
+    uses both, so patching one leaves half the search pointing at the real home.
+    """
+    real, real_env = C.Path.home, os.environ.get("HOME")
+    C.Path.home = staticmethod(lambda: Path(home))
+    os.environ["HOME"] = str(home)
+    try:
+        return fn()
+    finally:
+        C.Path.home = real
+        os.environ["HOME"] = real_env
+
+
+def test_each_products_install_location_is_searched():
+    """One install per product, found where that product actually puts it.
+
+    Six products install this plugin and no two agree on where it lands, so a launcher
+    that only knows Claude Code's cache prints "could not find the canvas app" to
+    everyone else — with the app sitting on their disk.
+    """
+    homes = {
+        ".claude/plugins/cache/super-prototyping/super-prototyping/1.0.0": "Claude Code",
+        ".codex/plugins/cache/super-prototyping/super-prototyping/1.0.0": "Codex",
+        ".codebuddy/plugins/cache/super-prototyping/super-prototyping/1.0.0": "CodeBuddy",
+        ".hermes/plugins/super-prototyping": "Hermes",
+        ".pi/agent/git/github.com/ReScienceLab/super-prototyping": "Pi",
+    }
+    for where, product in homes.items():
+        home = Path(tempfile.mkdtemp())
+        canvas_app_at(home / where)
+        found = with_home(home, lambda: C.resolve_root())
+        assert found == home / where, f"{product}: found {found}"
+
+    # And the products that hold a symlink per skill instead of an install.
+    for root in (".codebuddy/skills", ".trae/skills", ".trae-cn/skills"):
+        home = Path(tempfile.mkdtemp())
+        checkout = canvas_app_at(home / "checkout")
+        (checkout / "skills/prototype-canvas").mkdir(parents=True)
+        (home / root).mkdir(parents=True)
+        (home / root / "prototype-canvas").symlink_to(checkout / "skills/prototype-canvas")
+        # Resolved, because following the link is how the checkout was found.
+        assert with_home(home, lambda: C.resolve_root()) == checkout.resolve(), root
 
 
 def test_the_tag_prefix_matches_the_one_the_release_actually_cuts():

--- a/tools/test_sp_canvas.py
+++ b/tools/test_sp_canvas.py
@@ -41,6 +41,20 @@ def test_skew_is_only_reported_when_both_halves_name_a_release():
     assert with_toolkit("1.1.0", lambda: C.skew(plugin_root(None))) is None
 
 
+def test_the_fix_moves_whichever_half_is_behind():
+    # The plugin is ahead: pin the toolkit to the plugin's tag.
+    fix = C.skew_fix("1.1.0", "1.0.0")
+    assert "uv tool install" in fix and f"{C.TAG_PREFIX}1.1.0" in fix
+    # The toolkit is ahead, which the uv line would *downgrade* — and to a tag that need
+    # not exist. Update the plugin instead.
+    assert "/plugin update" in C.skew_fix("1.0.0", "1.1.0")
+
+
+def test_the_tag_prefix_matches_the_one_the_release_actually_cuts():
+    spec = json.loads((Path(__file__).resolve().parent.parent / ".version-bump.json").read_text())
+    assert C.TAG_PREFIX == spec["tagPrefix"]
+
+
 def test_the_newest_cached_release_wins_and_a_prerelease_ranks_below_it():
     names = ["1.0.0", "1.10.0", "1.2.0", "1.10.0-beta.2", "not-a-version"]
     assert sorted(names, key=C._version_key, reverse=True)[0] == "1.10.0"

--- a/tools/test_sp_canvas.py
+++ b/tools/test_sp_canvas.py
@@ -42,6 +42,15 @@ def test_skew_is_only_reported_when_both_halves_name_a_release():
     assert with_toolkit("1.1.0", lambda: C.skew(plugin_root(None))) is None
 
 
+def test_a_prerelease_does_not_report_drift_against_itself():
+    # The manifests carry semver and the built wheel carries PEP 440, so one release
+    # is spelled two ways. Compared as strings, every prerelease install would open
+    # with a note telling the user to reinstall what they already have.
+    root = plugin_root("1.1.0-rc.1")
+    assert with_toolkit("1.1.0rc1", lambda: C.skew(root)) is None
+    assert with_toolkit("1.1.0", lambda: C.skew(root)) == ("1.1.0-rc.1", "1.1.0")
+
+
 def test_the_fix_moves_whichever_half_is_behind():
     # The plugin is ahead: pin the toolkit to the plugin's tag.
     fix = C.skew_fix("1.1.0", "1.0.0")

--- a/tools/test_sp_canvas.py
+++ b/tools/test_sp_canvas.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Self-check for the launcher's version logic: which cached release it picks,
+and when it says the plugin and the toolkit have drifted apart.
+
+    python3 tools/test_sp_canvas.py
+"""
+import json, os, sys, tempfile
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import sp_canvas as C
+
+
+def plugin_root(version):
+    """A directory that looks like an installed plugin, at `version` or with no manifest."""
+    root = Path(tempfile.mkdtemp())
+    if version is not None:
+        (root / ".claude-plugin").mkdir()
+        (root / ".claude-plugin/plugin.json").write_text(
+            json.dumps({"name": "super-prototyping", "version": version}))
+    return root
+
+
+def with_toolkit(version, fn):
+    """Run fn with `_toolkit_version` answering `version`, then put the real one back."""
+    real = C._toolkit_version
+    C._toolkit_version = lambda: version
+    try:
+        return fn()
+    finally:
+        C._toolkit_version = real
+
+
+def test_skew_is_only_reported_when_both_halves_name_a_release():
+    root = plugin_root("1.1.0")
+    assert with_toolkit("1.0.0", lambda: C.skew(root)) == ("1.1.0", "1.0.0")
+    assert with_toolkit("1.1.0", lambda: C.skew(root)) is None
+    # A source checkout has no installed toolkit version, and a plugin root without a
+    # manifest has no release either. Neither is a disagreement worth a note.
+    assert with_toolkit(None, lambda: C.skew(root)) is None
+    assert with_toolkit("1.1.0", lambda: C.skew(plugin_root(None))) is None
+
+
+def test_the_newest_cached_release_wins_and_a_prerelease_ranks_below_it():
+    names = ["1.0.0", "1.10.0", "1.2.0", "1.10.0-beta.2", "not-a-version"]
+    assert sorted(names, key=C._version_key, reverse=True)[0] == "1.10.0"
+    assert C._version_key("1.10.0") > C._version_key("1.10.0-beta.2")
+    assert C._version_key("1.10.0-beta.2") > C._version_key("1.2.0")
+    assert C._version_key("not-a-version") == (-1,)
+
+
+if __name__ == "__main__":
+    fns = [(n, f) for n, f in sorted(globals().items()) if n.startswith("test_")]
+    for name, fn in fns:
+        fn()
+        print("ok  ", name)
+    print(f"\n{len(fns)} checks passed")


### PR DESCRIPTION
## The problem

The version string is the cache key. Claude Code names the plugin cache
directory `~/.claude/plugins/cache/<marketplace>/<plugin>/<version>/` and skips
the copy when that string has not moved; Codex caches the same way. This repo
has declared `1.0.0` in three fields since packaging on 2026-09-05 and has
never been tagged, so **every commit merged to main since then has reached no
installed user** — `/plugin update super-prototyping` reports success and
copies nothing.

`docs/2026-09-09-plugin-release-mechanism.md` is the survey behind the fix: how
Claude Code and Codex decide an install is stale, what the 292 entries of the
official marketplace and four widely installed plugins actually do, and what
this deliberately does not adopt.

## What this adds

- **`.github/workflows/release.yml`** — dispatch it with a version: it runs the
  gates, moves every manifest with `scripts/bump-version.sh`, and opens the
  release PR. Merging that PR tags `super-prototyping--v<version>` with
  `claude plugin tag --push` and cuts the GitHub Release from the matching
  `RELEASE-NOTES.md` section. Two halves because "Protect main" requires a pull
  request and nothing bypasses it, while tag *creation* is allowed.
- **`.github/workflows/validate.yml`** — the gates, on every PR and reusable by
  the release through `workflow_call`: both manifests under
  `claude plugin validate --strict`, the manifests Claude Code does not read
  parsed, `bump-version.sh --check`, the canvas's lint/test/build, and the
  toolkit's tests.
- **`RELEASE-NOTES.md`** — written for the person deciding whether to update.
  The release job reads the `## v<version>` section as the release body.
- **Skew is visible.** The plugin and the toolkit install separately, so
  `sp-canvas start` now prints the `uv tool install` line to run when the two
  disagree on the release, and `sp-canvas --version` / `root -v` say which
  release each half is on. `tools/test_sp_canvas.py` covers the version logic.
- **`.agents/plugins/marketplace.json`** — the catalogue Codex prefers. Codex
  already installs this repo by falling back to `.claude-plugin/marketplace.json`
  (verified), so this is about it reading a manifest meant for it; the missing
  piece was documentation, and the README now gives the two Codex commands.
- Docs: the README's install and release sections, `scripts/README.md`, the
  `next:` hint in `bump-version.sh`, and `CONTRIBUTING.md`'s `.github/` list.

No version is bumped here. This PR is the machinery; the first release is a
dispatch of **Release** after it merges.

## Checked locally

```
claude plugin validate . --strict                     ✓
claude plugin validate .claude-plugin/plugin.json --strict   ✓
scripts/bump-version.sh --check                       ✓ 5 files agree on 1.0.0
cd canvas && bun run lint && bun run test && bun run build   ✓ 84 tests
uv run --with pillow --with numpy python tools/test_refkit.py ✓ 22 checks
uv run python tools/test_sp_canvas.py                 ✓ 2 checks
```

Both workflows parse as YAML and every `run:` block passes `bash -n`. The Codex
install was probed end to end in a throwaway `CODEX_HOME`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
