### PR TITLE
notes: v1.0.0 says what it holds, now that it is about to be tagged

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -70,7 +70,17 @@ Everything below is on `main` and reaches no install until a version is cut.
 
 ## v1.0.0
 
-2026-09-05, the release that packaged this repo as a plugin: code ships,
-a project's boards stay put, and `sp-canvas` joins the two. It was never
-tagged — the machinery for that is in the section above — so an install made
-before the next release reports `1.0.0` whatever it holds.
+2026-09-05, the release that packaged this repo as a plugin. The plugin ships
+code and a project keeps only its own boards, so installing it does not drop
+this repo's example canvases into your project. Installing is two halves: your
+product's own plugin command for the skills and the canvas, and one
+`uv tool install` for `refkit`, `artgen` and `sp-canvas`. `sp-canvas` starts
+the canvas against whichever boards directory it is pointed at, and the canvas
+keys its saved state per project, so two projects do not share a camera or a
+comment. Declaring the marketplace with `sparsePaths` installs only the
+directories you name, for anyone who wants the canvas and the toolkit without
+the worked examples.
+
+Tagged after the fact, at `0286f19`, where that work ended. Nine pull requests
+landed on `main` between then and the tag being cut, so this tag holds the
+packaging and not the canvas work that followed it.


### PR DESCRIPTION
## What this changes

`RELEASE-NOTES.md`'s `## v1.0.0` section only. It said "it was never tagged" and pointed at "the section above", both of which stop being true once the tag exists, and neither of which survives being lifted into a GitHub Release body, which is what `.github/workflows/release.yml` does with these sections.

It now says what 1.0.0 gives a user, stands alone, and records that the tag was cut retroactively at `0286f19` with nine pull requests already on `main` behind it.

Groundwork for tagging `super-prototyping--v1.0.0` at `0286f19`, the end of the packaging work. The Release workflow cannot cut this one: every manifest is already at 1.0.0, so the bump produces no diff and `prepare` fails by design. This is the by-hand path `CONTRIBUTING.md` documents.

## Checklist

- [x] No `ref-*.html`, `assets/refs/` or other third-party captures are in this PR.
- [x] No canvas folder changed.
- [x] No `canvas/` change.
