### PR TITLE
notes: the release log gets its line in the pull request, not at release time

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,4 +8,5 @@
 - [ ] If a canvas folder changed: `gen.py` was edited and re-run, and the `NN-*.html` boards were not hand-edited.
 - [ ] If a canvas folder changed: `layout.json`, `probes.json`, `crops.json` and `assets.json` are committed alongside the boards.
 - [ ] Every new canvas folder has a `README.md` and no folder has its own `.gitignore`.
+- [ ] If a user would see this change: it has a line under `## Unreleased` in `RELEASE-NOTES.md`.
 - [ ] If `canvas/` changed: `bun test` and `bun run build` pass in `canvas/`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,8 @@ registry to edit and no build step per board.
   `skills/clone-prototype/references/documenting.md` asks for. Elsewhere a new
   document needs a reader who would go looking for it. **No folder has its own
   `.gitignore`.**
+- **A user-visible change adds its line** to `## Unreleased` in
+  `RELEASE-NOTES.md`, in the same pull request that makes it.
 - **Viewer changes** in `canvas/` need `bun test` and `bun run build` to pass.
   Add a test next to the module you touched.
 
@@ -95,8 +97,10 @@ release calls a command from the other.
 
 **The steps.**
 
-1. Write the release's section in `RELEASE-NOTES.md` under `## Unreleased`,
-   grouped as it already is. Say what a user sees, not what a commit did.
+1. Read what is under `## Unreleased` in `RELEASE-NOTES.md` and group it the
+   way the released sections are. Every pull request should have left its line
+   there already; anything missing has to be reconstructed from the log, which
+   is the one part of a release that cannot be done well late.
 2. Run the gates locally (the block in the root README). The workflow runs them
    again; failing them here is faster.
 3. Actions → **Release** → *Run workflow*, with the new version. It re-runs the

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -5,6 +5,13 @@ someone using the plugin, not what changed in the tree. One `## v<version>`
 section per release: `.github/workflows/release.yml` reads the section matching
 the version being tagged and makes it the GitHub Release body.
 
+A pull request that changes what a user sees adds its line to `## Unreleased`
+as part of the change. Leaving it until the release means writing it from
+memory, which is how a release ends up summarising commits rather than itself.
+A `## v<version>` section is finished once its tag exists: the GitHub Release
+was cut from that text, so editing the file afterwards changes nothing anyone
+has been shown.
+
 Update with `/plugin update super-prototyping` (Claude Code), or the equivalent
 for your product, which README's install table lists. Then move the toolkit with
 the `uv tool install` line in the README. The plugin and the


### PR DESCRIPTION
## What this changes

Where the release log gets written. Step 1 of "Cutting a release" asked for the section to be written at release time, which is when the person writing it has a week of merges and no notes to work from. The rule now sits with the change instead: a pull request that changes what a user sees adds its line to `## Unreleased`, `CONTRIBUTING.md`'s review list checks it, and the pull request template asks for it. Step 1 reads and groups what is already there, and says that anything missing has to be reconstructed from the log.

Also states that a `## v<version>` section is finished once its tag exists, since the GitHub Release was cut from that text and a later edit changes nothing that was published. Rewriting the v1.0.0 section in #55 was the last moment that was allowed, which is what prompted writing the rule down.

Pi keeps the same `[Unreleased]` section, generates the release body from it, and puts the add-your-line rule in `AGENTS.md`. Not taken from them: per-entry attribution, which is a mechanism for 285 contributors, and one changelog per workspace.

## Checklist

- [x] No `ref-*.html`, `assets/refs/` or other third-party captures are in this PR.
- [x] No canvas folder changed.
- [x] Nothing here is user-visible: it changes how contributors work, not what the plugin does, so there is no `## Unreleased` line.
- [x] No `canvas/` change.
