### PR TITLE
release: a file holding two version fields gets both

### DIFF
--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -74,7 +74,9 @@ def write_toml_version(text, parts, value):
 
 # Read every file before writing any of them. A bump that stops halfway leaves the
 # tree half-versioned, which is the one state this script exists to make impossible.
-seen, failures, planned = {}, [], []
+# Keyed by path, because the marketplace catalogue holds two of these fields and one
+# read per field would mean each write starting from the text before the other's.
+seen, failures, planned = {}, [], {}
 
 for entry in spec["files"]:
     path  = root / entry["path"]
@@ -89,7 +91,9 @@ for entry in spec["files"]:
         failures.append(f"{entry['path']} is listed in .version-bump.json but does not exist")
         continue
 
-    text = path.read_text()
+    if path not in planned:
+        planned[path] = (path.read_text(), [])
+    text, fields = planned[path]
 
     if path.suffix == ".toml":
         current = read_toml_version(text, parts)
@@ -97,7 +101,7 @@ for entry in spec["files"]:
         current = get_in(json.loads(text), parts)
 
     seen[label] = current
-    planned.append((path, parts, label, text, current))
+    fields.append((parts, label, current))
 
 if failures:
     print("", file=sys.stderr)
@@ -107,17 +111,22 @@ if failures:
     sys.exit(1)
 
 if mode == "set":
-    for path, parts, label, text, current in planned:
-        if current == version:
-            print(f"  = {label} already {version}")
-            continue
-        if path.suffix == ".toml":
-            path.write_text(write_toml_version(text, parts, version))
-        else:
-            data = json.loads(text)
-            set_in(data, parts, version)
-            path.write_text(json.dumps(data, indent=2) + "\n")
-        print(f"  → {label}  {current} → {version}")
+    # Every field of a file is applied to one text, which is then written once.
+    for path, (text, fields) in planned.items():
+        updated = text
+        for parts, label, current in fields:
+            if current == version:
+                print(f"  = {label} already {version}")
+                continue
+            if path.suffix == ".toml":
+                updated = write_toml_version(updated, parts, version)
+            else:
+                data = json.loads(updated)
+                set_in(data, parts, version)
+                updated = json.dumps(data, indent=2) + "\n"
+            print(f"  → {label}  {current} → {version}")
+        if updated != text:
+            path.write_text(updated)
 
 if mode == "check":
     distinct = sorted(set(seen.values()))


### PR DESCRIPTION
## What this changes

`scripts/bump-version.sh`. Dispatching **Release** with `1.1.0` failed at the bump step ([run](https://github.com/ReScienceLab/super-prototyping/actions/runs/34377206393)), which is the one place it was cheap to find out:

```
error: versions disagree: 1.0.0, 1.1.0
  1.0.0  .claude-plugin/marketplace.json:metadata.version
  1.1.0  .claude-plugin/marketplace.json:plugins.0.version
```

Six of the seven version fields are one per file; the marketplace catalogue holds two. Since #54 the script reads every file before writing any of them, so both catalogue writes started from the same pre-write text and the second one dropped the first.

Reading first is still right — it is what stops a file listed in `.version-bump.json` but missing from leaving a half-versioned tree. The reads are now keyed by path instead of by field, and every field of a file is applied to one text that gets written once.

## Verified

`scripts/bump-version.sh 1.1.0` then `--check`: all seven agree, both catalogue fields moved, the file's formatting is unchanged, and a second run reports all seven already there and writes nothing. Manifests reverted to 1.0.0 in this branch — moving them is the release workflow's job.

No new test: `--check` right after the set is what caught this, it already runs in the release workflow and in the local gates, and it fails on exactly the state this bug produces.

## Checklist

- [x] No `ref-*.html`, `assets/refs/` or other third-party captures are in this PR.
- [x] No canvas folder changed.
- [x] Nothing user-visible: no release has ever been cut with the bug, so no `## Unreleased` line.
- [x] No `canvas/` change.
