### PR TITLE
canvas: a two-finger pan over a board no longer goes back a page

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -21,6 +21,10 @@ toolkit carry the same version; `sp-canvas start` says so when they drift.
 
 Everything below is on `main` and reaches no install until a version is cut.
 
+- **A two-finger pan over a board pans the canvas.** It used to send the browser
+  back a page instead, because a wheel event inside a board's iframe never
+  reaches the canvas and so never gets stopped.
+
 ## v1.1.0
 
 2026-09-09. The canvas became something a review can point at, and the plugin

--- a/canvas/src/canvasLibrary.test.ts
+++ b/canvas/src/canvasLibrary.test.ts
@@ -26,4 +26,12 @@ describe('loadCanvasFileHtml', () => {
     expect(await loadCanvasFileHtml(missing)).toBeUndefined()
     expect(canvasFileHtml.has(missing)).toBe(false)
   })
+
+  it('ends every board with the tag that stops the browser back gesture', async () => {
+    // A wheel inside an iframe never reaches tldraw, so a board that does not stop overscroll
+    // in its own document turns a two-finger pan over it into a back navigation.
+    const path = readCanvasLibrary()[1][0].path
+    const html = await loadCanvasFileHtml(path)
+    expect(html).toMatch(/<style>html\{overscroll-behavior:none\}<\/style>$/)
+  })
 })

--- a/canvas/src/canvasLibrary.ts
+++ b/canvas/src/canvasLibrary.ts
@@ -218,7 +218,22 @@ export async function cloneCanvas(slug: string, name: string) {
   return JSON.parse(body).slug as string;
 }
 
-/** path -> raw HTML for every file fetched so far. Filled by loadCanvasFileHtml. */
+/**
+ * Appended to every board. A wheel event whose target is inside an iframe never reaches the
+ * parent document, so tldraw's own fix for this — preventDefault on the wheel that reaches its
+ * container, in useGestureEvents — never runs, and the browser turns the horizontal part of a
+ * two-finger pan into a back navigation. The page's own `overscroll-behavior: none` in index.css
+ * cannot reach in: overscroll chains one frame at a time, so a board has to stop the chain in its
+ * own document. Every iframe in this app gets one, because the ones that can be panned over are
+ * not the same set in every browser and the fix has already been missed once per site.
+ *
+ * Appended rather than spliced: 37 of the repo's 180 boards emit no `</body>`, and a tag put
+ * before the doctype would drop the board into quirks mode. A trailing `<style>` is parsed into
+ * the body, and the inspector agent skips STYLE elements, so this adds no layer.
+ */
+const NO_OVERSCROLL = "<style>html{overscroll-behavior:none}</style>";
+
+/** path -> the HTML every board iframe renders, for every file fetched so far. */
 export const canvasFileHtml = new Map<string, string>();
 const canvasFileLoads = new Map<string, Promise<string | undefined>>();
 
@@ -237,8 +252,9 @@ export function loadCanvasFileHtml(path: string): Promise<string | undefined> {
   if (!load) {
     load = loader()
       .then((html) => {
-        canvasFileHtml.set(path, html);
-        return html;
+        const board = html + NO_OVERSCROLL;
+        canvasFileHtml.set(path, board);
+        return board;
       })
       // A chunk can fail to arrive — a board deleted between discovery and first render, a
       // dev-server restart mid-flight. Without this the rejected promise stays in the map and


### PR DESCRIPTION
## The bug

Cursor over a board on the canvas, two-finger swipe left to pan — the browser goes back a page.

## Root cause

A wheel event whose target is inside an `<iframe>` never reaches the parent document. tldraw's own answer to this gesture is to `preventDefault` the wheel that reaches its container ([`useGestureEvents`](https://github.com/tldraw/tldraw/blob/main/packages/editor/src/lib/hooks/useGestureEvents.ts), bound with `{passive: false}`) — over a board, that call never happens, and the browser reads the horizontal component as history navigation. The page's own `overscroll-behavior: none` in `canvas/src/index.css` cannot reach in: overscroll chains one frame at a time, and a board's document declares nothing. tldraw sets that property only on its own UI panels, never on the canvas, for the same reason — the canvas relies on the wheel handler.

be13507 fixed the case it could see, by putting the board iframe behind its container (`zIndex: -1`), which also does the second half of the job: it lets the pan actually reach tldraw. That line stays. But it only applies to a board that is *not* being edited, and it is not available to the other two iframes — the inspector's preview is meant to take input, and the link card's cover sits on an opaque white background, so a negative z-index there would paint it out of existence.

## The fix

What all three iframes share is the HTML, so the fix goes there: `loadCanvasFileHtml` appends `<style>html{overscroll-behavior:none}</style>` to every board. One place, and a fourth iframe cannot miss it.

Appended rather than spliced before `</body>`: 37 of the 180 boards emit none, and a tag put before the doctype would drop the board into quirks mode. A trailing `<style>` is parsed into the body, and the inspector agent already skips `STYLE` elements (`inspectorAgent.ts:292`), so this adds no layer to the inspector.

## Verified

`bun run lint`, `bun run test` (85 passing, one new), `bun run build`. `scripts/bump-version.sh --check`: all 7 agree on 1.1.0.

## Checklist

- [x] No `ref-*.html`, `assets/refs/` or other third-party captures are in this PR.
- [x] No canvas folder changed.
- [x] User-visible, so it has its `## Unreleased` line.
