### PR TITLE
notion-ios: the purchase sheet in motion, board 19

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -36,6 +36,12 @@ Everything below is on `main` and reaches no install until a version is cut.
   after the shared tokens. The cat and the sparkle strokes on the feature card
   are the folder's first `artgen` assets: `gpt-image-2` redraws of the
   capture's crops, keyed and scored in `art-gen.json`.
+- **A board that moves.** `notion-ios` gets a nineteenth board that plays the
+  purchase sheet's three states as a ten-second loop: tap, tap, subscribe,
+  spin, alert, OK. Boards render with no script, so it is a CSS timeline on
+  Open Props' easings, and it is checked the way the static boards are, by
+  freezing it at an instant and diffing the frame against the board it should
+  be. `docs/2026-09-10-motion-boards.md` says why CSS and not a library.
 
 ## v1.1.1
 

--- a/docs/2026-09-10-motion-boards.md
+++ b/docs/2026-09-10-motion-boards.md
@@ -1,0 +1,53 @@
+# A board that moves is a CSS timeline, checked by freezing it
+
+2026-09-10. The first animated board: `notion-ios/19-purchase-sheet-motion`, which plays boards
+16 → 17 → 18 → 16 as a ten-second loop. The ask was to use an open-source animation library;
+this note is why the library is a CSS one and how the board is checked.
+
+## Why not Motion, GSAP or anime.js
+
+The canvas renders every board in `<iframe srcDoc sandbox="">`. An empty `sandbox` runs no
+script, and that is the property the canvas relies on: boards are third-party-shaped HTML with
+megabytes of inlined data, and the inspector reads them in a *separate* `allow-scripts` frame
+precisely so the boards themselves never execute (`2026-09-07-inspector-panel-feasibility.md`).
+A JavaScript animation library would play when the file is opened on its own and stand still on
+the canvas, which is where the board is looked at. Loosening the sandbox for one board is a
+security decision about every board, and not one an animation should make.
+
+So the timeline is CSS animations. What the libraries would have given -- a timeline in
+seconds, easings by name, springs -- comes from two things:
+
+- **Open Props** (open-props.style, v1.7.23, MIT) for the easings and the `spin` keyframes,
+  copied verbatim into a block on `.phone` and named in `gen.py` as `OPEN_PROPS`. Its springs
+  are `linear()` easings, which is the one curve a hand-written `cubic-bezier` cannot express,
+  and the alert's entrance uses one.
+- `kf()` in `gen.py`, which turns `(seconds, declarations[, easing])` steps into a `@keyframes`
+  block. Every element animates over the same `T` with `infinite`, so they share one clock;
+  a value held between two steps is written at both; the first step is at 0 and the last at
+  `T`, so the loop closes on the resting board.
+
+## The rules that came out of it
+
+- **0% is the resting board.** Every keyframe starts at the state of the static board the loop
+  rests on (16 here), and the element's base styles are that state too. `prefers-reduced-motion:
+  reduce` drops the animations and the board is 16, not a half state.
+- **Reuse the static boards' markup.** The motion board is `paywall()` with every state's
+  element present and hidden by opacity, so a measured value moves the static boards and the
+  loop together. A state that no capture shows is not in the loop: the selection goes back to
+  monthly before the purchase because capture 18 shows it that way.
+- **Check it by freezing it.** `animation-play-state: paused` with a negative `animation-delay`
+  on every element holds the board at one instant; `refkit shoot` that copy and `refkit diff`
+  the frame against the static board it should equal. The held states of 19 read 0.03, 0.11,
+  0.10 and 0.23 against 16, 17, 16 and 18. What the diff cannot check is the motion between
+  them; a strip of frozen in-between frames is what a reviewer looks at for that.
+- Fixed-size stacks for a label that changes: the button holds both labels and the spinner
+  as absolutely positioned spans and cross-fades them, so the button's own box is what
+  animates (its height), never its text flow.
+
+## Not done
+
+- Nothing in the canvas knows a board moves. Its caption and status tab are the layout's; the
+  loop simply runs, in every mounted iframe, all the time. Twenty of these on one page would
+  be worth measuring before it is a pattern.
+- The timings are chosen to read, not measured: the captures are stills, and a real StoreKit
+  sheet's durations are not in them.

--- a/mockups/canvases/notion-ios/19-purchase-sheet-motion.html
+++ b/mockups/canvases/notion-ios/19-purchase-sheet-motion.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
-<title>Notion iOS — Purchase success</title>
+<title>Notion iOS — Purchase sheet, A to B to C</title>
 <style>
 /* ============================================================================
    NOTION iOS — DESIGN TOKENS  (single source of truth, inlined in every file
@@ -158,8 +158,37 @@ body{font-family:var(--n-font);background:#fff;-webkit-font-smoothing:antialiase
 .ok{position:absolute;left:16.2px;top:88.3px;width:286.9px;height:48.5px;border-radius:24.25px;
   background:#367CEF;color:#fff;text-align:center;font:600 17px/48.5px var(--n-font)}
 
-/* Success: the button grows to 54.4pt while it spins and the links move down with it. */
-.cta{height:54.4px}.links{top:692.51px}
+/* The loop: 10.0s, every element on the same clock. */
+.phone{--ease-3:cubic-bezier(.25,0,.3,1);--ease-out-3:cubic-bezier(0,0,.3,1);--ease-spring-2:linear(0,0.007,0.029 2.2%,0.118 4.7%,0.625 14.4%,0.826 19%,0.902,0.962,1.008 26.1%,1.041 28.7%,1.064 32.1%,1.07 36%,1.061 40.5%,1.015 53.4%,0.999 61.6%,0.995 71.2%,1);--animation-spin:spin 2s linear infinite}
+.price.r{border-color:#487ED0;box-shadow:inset 0 0 0 1px #487ED0;background:#E7F3FF}.price.r b{color:#467AB9;transform:translate(.9px,-.4px)}.price.r i{color:#4E7BB8;transform:translateX(.9px)}
+.price.l{animation:pl 10.0s infinite}.price.l b{animation:pl-b 10.0s infinite}.price.l i{animation:pl-i 10.0s infinite}
+.price.r{animation:pr 10.0s infinite}.price.r b{animation:pr-b 10.0s infinite}.price.r i{animation:pr-i 10.0s infinite}
+.price b,.price i{will-change:transform}
+.cta{animation:cta 10.0s infinite}
+.cta span{position:absolute;left:0;right:0;top:0;line-height:50px}
+.cta .m{animation:cta-m 10.0s infinite}.cta .y{opacity:0;animation:cta-y 10.0s infinite}
+.cta .sp{opacity:0;animation:cta-sp 10.0s infinite}
+.cta .sp svg{animation:var(--animation-spin);animation-duration:1s}
+.links{animation:links 10.0s infinite}
+.scrim{opacity:0;animation:scrim 10.0s infinite}
+.alert{opacity:0;transform:scale(1.12);animation:alert 10.0s infinite}
+.ok{animation:ok 10.0s infinite}
+@media (prefers-reduced-motion:reduce){.phone *{animation:none!important}}
+@keyframes spin{to{transform:rotate(1turn)}}
+@keyframes pl{0%{border-color:#E4E4E4;box-shadow:inset 0 0 0 1px rgba(72,126,208,0);background:#fff;animation-timing-function:cubic-bezier(.25,0,.3,1)}14%{border-color:#E4E4E4;box-shadow:inset 0 0 0 1px rgba(72,126,208,0);background:#fff;animation-timing-function:cubic-bezier(.25,0,.3,1)}16.2%{border-color:#487ED0;box-shadow:inset 0 0 0 1px #487ED0;background:#E7F3FF;animation-timing-function:cubic-bezier(.25,0,.3,1)}36%{border-color:#487ED0;box-shadow:inset 0 0 0 1px #487ED0;background:#E7F3FF;animation-timing-function:cubic-bezier(.25,0,.3,1)}38.2%{border-color:#E4E4E4;box-shadow:inset 0 0 0 1px rgba(72,126,208,0);background:#fff;animation-timing-function:cubic-bezier(.25,0,.3,1)}100%{border-color:#E4E4E4;box-shadow:inset 0 0 0 1px rgba(72,126,208,0);background:#fff;animation-timing-function:cubic-bezier(.25,0,.3,1)}}
+@keyframes pl-b{0%{color:#2C2C2C;transform:none;animation-timing-function:cubic-bezier(.25,0,.3,1)}14%{color:#2C2C2C;transform:none;animation-timing-function:cubic-bezier(.25,0,.3,1)}16.2%{color:#467AB9;transform:translate(.9px,-.4px);animation-timing-function:cubic-bezier(.25,0,.3,1)}36%{color:#467AB9;transform:translate(.9px,-.4px);animation-timing-function:cubic-bezier(.25,0,.3,1)}38.2%{color:#2C2C2C;transform:none;animation-timing-function:cubic-bezier(.25,0,.3,1)}100%{color:#2C2C2C;transform:none;animation-timing-function:cubic-bezier(.25,0,.3,1)}}
+@keyframes pl-i{0%{color:#787774;transform:none;animation-timing-function:cubic-bezier(.25,0,.3,1)}14%{color:#787774;transform:none;animation-timing-function:cubic-bezier(.25,0,.3,1)}16.2%{color:#4E7BB8;transform:translateX(.9px);animation-timing-function:cubic-bezier(.25,0,.3,1)}36%{color:#4E7BB8;transform:translateX(.9px);animation-timing-function:cubic-bezier(.25,0,.3,1)}38.2%{color:#787774;transform:none;animation-timing-function:cubic-bezier(.25,0,.3,1)}100%{color:#787774;transform:none;animation-timing-function:cubic-bezier(.25,0,.3,1)}}
+@keyframes pr{0%{border-color:#487ED0;box-shadow:inset 0 0 0 1px #487ED0;background:#E7F3FF;animation-timing-function:cubic-bezier(.25,0,.3,1)}14%{border-color:#487ED0;box-shadow:inset 0 0 0 1px #487ED0;background:#E7F3FF;animation-timing-function:cubic-bezier(.25,0,.3,1)}16.2%{border-color:#E4E4E4;box-shadow:inset 0 0 0 1px rgba(72,126,208,0);background:#fff;animation-timing-function:cubic-bezier(.25,0,.3,1)}36%{border-color:#E4E4E4;box-shadow:inset 0 0 0 1px rgba(72,126,208,0);background:#fff;animation-timing-function:cubic-bezier(.25,0,.3,1)}38.2%{border-color:#487ED0;box-shadow:inset 0 0 0 1px #487ED0;background:#E7F3FF;animation-timing-function:cubic-bezier(.25,0,.3,1)}100%{border-color:#487ED0;box-shadow:inset 0 0 0 1px #487ED0;background:#E7F3FF;animation-timing-function:cubic-bezier(.25,0,.3,1)}}
+@keyframes pr-b{0%{color:#467AB9;transform:translate(.9px,-.4px);animation-timing-function:cubic-bezier(.25,0,.3,1)}14%{color:#467AB9;transform:translate(.9px,-.4px);animation-timing-function:cubic-bezier(.25,0,.3,1)}16.2%{color:#2C2C2C;transform:none;animation-timing-function:cubic-bezier(.25,0,.3,1)}36%{color:#2C2C2C;transform:none;animation-timing-function:cubic-bezier(.25,0,.3,1)}38.2%{color:#467AB9;transform:translate(.9px,-.4px);animation-timing-function:cubic-bezier(.25,0,.3,1)}100%{color:#467AB9;transform:translate(.9px,-.4px);animation-timing-function:cubic-bezier(.25,0,.3,1)}}
+@keyframes pr-i{0%{color:#4E7BB8;transform:translateX(.9px);animation-timing-function:cubic-bezier(.25,0,.3,1)}14%{color:#4E7BB8;transform:translateX(.9px);animation-timing-function:cubic-bezier(.25,0,.3,1)}16.2%{color:#787774;transform:none;animation-timing-function:cubic-bezier(.25,0,.3,1)}36%{color:#787774;transform:none;animation-timing-function:cubic-bezier(.25,0,.3,1)}38.2%{color:#4E7BB8;transform:translateX(.9px);animation-timing-function:cubic-bezier(.25,0,.3,1)}100%{color:#4E7BB8;transform:translateX(.9px);animation-timing-function:cubic-bezier(.25,0,.3,1)}}
+@keyframes cta{0%{height:50.4px;background:#4380D7;animation-timing-function:cubic-bezier(.25,0,.3,1)}49%{height:50.4px;background:#4380D7;animation-timing-function:cubic-bezier(.25,0,.3,1)}50%{height:50.4px;background:#3B72C0;animation-timing-function:cubic-bezier(.25,0,.3,1)}53%{height:54.4px;background:#4380D7;animation-timing-function:cubic-bezier(.25,0,.3,1)}89.5%{height:54.4px;background:#4380D7;animation-timing-function:cubic-bezier(.25,0,.3,1)}92.5%{height:50.4px;background:#4380D7;animation-timing-function:cubic-bezier(.25,0,.3,1)}100%{height:50.4px;background:#4380D7;animation-timing-function:cubic-bezier(.25,0,.3,1)}}
+@keyframes cta-m{0%{opacity:1;animation-timing-function:cubic-bezier(.25,0,.3,1)}14.5%{opacity:1;animation-timing-function:cubic-bezier(.25,0,.3,1)}16.2%{opacity:0;animation-timing-function:cubic-bezier(.25,0,.3,1)}36%{opacity:0;animation-timing-function:cubic-bezier(.25,0,.3,1)}37.7%{opacity:1;animation-timing-function:cubic-bezier(.25,0,.3,1)}50%{opacity:1;animation-timing-function:cubic-bezier(.25,0,.3,1)}51.5%{opacity:0;animation-timing-function:cubic-bezier(.25,0,.3,1)}91%{opacity:0;animation-timing-function:cubic-bezier(.25,0,.3,1)}92.5%{opacity:1;animation-timing-function:cubic-bezier(.25,0,.3,1)}100%{opacity:1;animation-timing-function:cubic-bezier(.25,0,.3,1)}}
+@keyframes cta-y{0%{opacity:0;animation-timing-function:cubic-bezier(.25,0,.3,1)}14.5%{opacity:0;animation-timing-function:cubic-bezier(.25,0,.3,1)}16.2%{opacity:1;animation-timing-function:cubic-bezier(.25,0,.3,1)}36%{opacity:1;animation-timing-function:cubic-bezier(.25,0,.3,1)}37.7%{opacity:0;animation-timing-function:cubic-bezier(.25,0,.3,1)}100%{opacity:0;animation-timing-function:cubic-bezier(.25,0,.3,1)}}
+@keyframes cta-sp{0%{opacity:0;animation-timing-function:cubic-bezier(.25,0,.3,1)}51.5%{opacity:0;animation-timing-function:cubic-bezier(.25,0,.3,1)}53%{opacity:1;animation-timing-function:cubic-bezier(.25,0,.3,1)}89.5%{opacity:1;animation-timing-function:cubic-bezier(.25,0,.3,1)}91%{opacity:0;animation-timing-function:cubic-bezier(.25,0,.3,1)}100%{opacity:0;animation-timing-function:cubic-bezier(.25,0,.3,1)}}
+@keyframes links{0%{top:688.41px;animation-timing-function:cubic-bezier(.25,0,.3,1)}50%{top:688.41px;animation-timing-function:cubic-bezier(.25,0,.3,1)}53%{top:692.51px;animation-timing-function:cubic-bezier(.25,0,.3,1)}89.5%{top:692.51px;animation-timing-function:cubic-bezier(.25,0,.3,1)}92.5%{top:688.41px;animation-timing-function:cubic-bezier(.25,0,.3,1)}100%{top:688.41px;animation-timing-function:cubic-bezier(.25,0,.3,1)}}
+@keyframes scrim{0%{opacity:0;animation-timing-function:cubic-bezier(.25,0,.3,1)}62%{opacity:0;animation-timing-function:cubic-bezier(.25,0,.3,1)}64.5%{opacity:1;animation-timing-function:cubic-bezier(.25,0,.3,1)}87%{opacity:1;animation-timing-function:cubic-bezier(.25,0,.3,1)}89.5%{opacity:0;animation-timing-function:cubic-bezier(.25,0,.3,1)}100%{opacity:0;animation-timing-function:cubic-bezier(.25,0,.3,1)}}
+@keyframes alert{0%{opacity:0;transform:scale(1.12);animation-timing-function:cubic-bezier(.25,0,.3,1)}62.5%{opacity:0;transform:scale(1.12);animation-timing-function:linear(0,0.007,0.029 2.2%,0.118 4.7%,0.625 14.4%,0.826 19%,0.902,0.962,1.008 26.1%,1.041 28.7%,1.064 32.1%,1.07 36%,1.061 40.5%,1.015 53.4%,0.999 61.6%,0.995 71.2%,1)}66%{opacity:1;transform:none;animation-timing-function:cubic-bezier(.25,0,.3,1)}87%{opacity:1;transform:none;animation-timing-function:cubic-bezier(.25,0,.3,1)}89%{opacity:0;transform:scale(.97);animation-timing-function:cubic-bezier(.25,0,.3,1)}100%{opacity:0;transform:scale(1.12);animation-timing-function:cubic-bezier(.25,0,.3,1)}}
+@keyframes ok{0%{background:#367CEF;animation-timing-function:cubic-bezier(.25,0,.3,1)}86%{background:#367CEF;animation-timing-function:cubic-bezier(.25,0,.3,1)}87%{background:#2C6BD9;animation-timing-function:cubic-bezier(.25,0,.3,1)}88.5%{background:#367CEF;animation-timing-function:cubic-bezier(.25,0,.3,1)}100%{background:#367CEF;animation-timing-function:cubic-bezier(.25,0,.3,1)}}
 </style>
 </head>
 <body>
@@ -196,8 +225,8 @@ body{font-family:var(--n-font);background:#fff;-webkit-font-smoothing:antialiase
     </div>
 
     <div class="price l"><b>S$ 299.98</b><i>per year</i></div>
-    <div class="price r on"><b>S$ 29.98</b><i>per month</i></div>
-    <div class="cta"><svg viewBox="0 0 30 30" fill="none" stroke-width="2.3" stroke-linecap="round"><circle cx="15" cy="15" r="11" stroke="#CFDCE8"/><path d="M4.4 12.3A11 11 0 0 1 20.5 5.5" stroke="#2E3A36"/></svg></div>
+    <div class="price r"><b>S$ 29.98</b><i>per month</i></div>
+    <div class="cta"><span class="m">Subscribe for S$ 29.98 / month</span><span class="y">Subscribe for S$ 299.98 / year</span><span class="sp"><svg viewBox="0 0 30 30" fill="none" stroke-width="2.3" stroke-linecap="round"><circle cx="15" cy="15" r="11" stroke="#CFDCE8"/><path d="M4.4 12.3A11 11 0 0 1 20.5 5.5" stroke="#2E3A36"/></svg></span></div>
     <div class="links"><a>Restore subscription</a><a>Terms of service</a><a>Privacy policy</a></div>
   </div>
   <div class="scrim"></div>

--- a/mockups/canvases/notion-ios/README.md
+++ b/mockups/canvases/notion-ios/README.md
@@ -15,6 +15,7 @@ Open it with `?canvas=notion-ios`, or a single board with
 | `07-manage-data-sources` … `10-to-do-list-table` | The *adding a new data source* flow, added later against four more captures. |
 | `11-add-an-account` … `15-add-an-account-code-filled` | The *adding an account* flow, five states of one sheet, against five more captures. |
 | `16-plan-plus-ai-monthly` … `18-purchase-success` | The *Plus & Notion AI purchase sheet*, Apple's paywall over the dimmed app, against three more captures. |
+| `19-purchase-sheet-motion` | 16 → 17 → 18 → 16 as a ten-second CSS loop, on Open Props' easings. Not a screen: a board that plays the three above. |
 | `probes.json` | The measurements behind the tokens, replayable with `refkit batch probes.json --against <shots> --pt 3`. |
 
 Two things in `00-design-tokens.html` are worth reading. The capture scale
@@ -170,6 +171,68 @@ cat 13.97, sparkles 10.9, with a second independent return at 14.56 and 11.12
 that did not beat the first. The one visible cost is the cat's hind leg, which
 ends about 4pt higher than the capture's; `pw-cat` records it. A crop would
 have scored 0, and the redraw was the brief.
+
+## The purchase sheet in motion, 19
+
+One more board plays the three states as a loop: tap the yearly card, tap the
+monthly one back, press Subscribe, the spinner, the alert, OK, and round
+again. It is the same `paywall()` markup as 16–18 with every state in the DOM
+at once, so a change to a measured value moves all four boards together.
+
+**It is CSS, not a script, and that is the constraint rather than a taste.**
+The canvas renders a board in `<iframe srcDoc sandbox="">`, where no script
+runs at all, so Motion, GSAP or anime.js would play when the file is opened
+on its own and stand still on the canvas, which is where the board is seen.
+So every element carries one `animation` of the same ten seconds, `infinite`,
+and the keyframes are a timeline in seconds turned into percentages by `kf()`
+in `gen.py`. The easings come from
+[Open Props](https://open-props.style) (v1.7.23, MIT), copied verbatim from
+`easings.css` and `animations.css` into a block on `.phone`: `--ease-3` for
+every fade, ring and resize, `--ease-spring-2` for the alert's entrance, and
+its `spin` keyframes for the ring. The springs are `linear()` easings, which
+is the one thing a hand-written `cubic-bezier` cannot express.
+
+| at | what happens | over |
+|---|---|---|
+| 0.0 | board 16, monthly selected | held 1.4s |
+| 1.4 | the yearly card is tapped: its ring, fill and text colours come on as the monthly's go off; the button's label cross-fades to the yearly price | 0.22s |
+| 1.62 | board 17 | held 2.0s |
+| 3.6 | the monthly card is tapped back, the same swap the other way | 0.22s |
+| 3.82 | board 16 again, which is the sheet board 18 sits on | held 1.1s |
+| 4.9 | Subscribe is pressed: the button dims for 0.1s, then grows from 50.4 to 54.4 as the label fades out and the spinner fades in; the links move 4.1 down with it | 0.4s |
+| 5.3 | spinning | held 0.9s |
+| 6.2 | the scrim comes up to 20% black; the alert springs in from 1.12 to 1 | 0.25s, 0.35s |
+| 6.6 | board 18 | held 2.0s |
+| 8.6 | OK is pressed: the pill dims, the alert shrinks to .97 and fades, the scrim goes | 0.35s |
+| 8.95 | the button shrinks back, spinner out, label in, links up | 0.3s |
+| 9.25 | board 16 | held to 10.0, then round again |
+
+The selection goes *back* to monthly before the purchase because capture 18
+shows the monthly card selected under the alert. A loop that went 17 → 18
+directly would have to invent a state no capture has.
+
+**Checked by freezing it.** A negative `animation-delay` with
+`animation-play-state: paused` on every element holds the board at one
+instant, and `refkit diff` of that frame against the static board says
+whether the held state is the same drawing:
+
+```css
+.phone *{animation-play-state:paused!important;animation-delay:-2.8s!important}
+```
+
+| held at | against | mean Δ |
+|---|---|---|
+| 0.7s | 16 | 0.03 |
+| 2.8s | 17 | 0.11 |
+| 4.4s | 16 | 0.10 |
+| 7.6s | 18 | 0.23 |
+
+The 0.1 on 17 is the yearly card's text, which the loop places with a
+`transform` where the static board uses a class; the 0.23 on 18 is the
+spinner's arc, frozen at a different angle, and the alert's edge on its own
+compositing layer. At 0% every keyframe is board 16 exactly, so
+`prefers-reduced-motion: reduce`, which drops the animations, leaves 16
+standing rather than a half state.
 
 ## How close it lands
 

--- a/mockups/canvases/notion-ios/gen.py
+++ b/mockups/canvases/notion-ios/gen.py
@@ -3,8 +3,8 @@
 Eighteen screens of Notion iOS: the splash, search and the AI chat, a meeting
 page, the date and share sheets, the four-screen flow that adds a data source
 to a database, the five-screen flow that adds an account, and the Plus & AI
-purchase sheet in three states. The measurements behind the tokens are in
-probes.json.
+purchase sheet in three states, plus one board that plays those three states
+as a loop. The measurements behind the tokens are in probes.json.
 
     python3 mockups/canvases/notion-ios/gen.py
 
@@ -1020,6 +1020,7 @@ BODY_15 = account(EMAIL % TYPED + CODE % '<span>QGuM7E</span>'
 # The cat and the sparkles are gpt-image-2 redraws of the capture's crops
 # (assets/art/), scored in art-gen.json.
 import base64
+import re
 
 
 def cap(size, lh):
@@ -1123,10 +1124,8 @@ CSS_PW = """
     links_top=round(754.3 - SHEET - cap(13, 23.7), 2),
 )
 
-CSS_PW_OK = """
-/* Success: the button grows to 54.4pt while it spins and the links move down
-   with it; then a 20%% black scrim over the whole screen and a frosted alert. */
-.cta{height:54.4px}.links{top:%(links_top)spx}
+CSS_ALERT = """
+/* A 20%% black scrim over the whole screen and a frosted alert. */
 .scrim{position:absolute;inset:0;background:rgba(0,0,0,.2);border-radius:52px}
 .alert{position:absolute;left:37.3px;top:362.3px;width:318.7px;height:152.2px;border-radius:30px;
   background:rgba(255,255,255,.7);-webkit-backdrop-filter:blur(30px);backdrop-filter:blur(30px);
@@ -1136,8 +1135,15 @@ CSS_PW_OK = """
 .alert p{top:%(p_top)spx;font:400 15px/20px var(--n-font);color:#505050;letter-spacing:0}
 .ok{position:absolute;left:16.2px;top:88.3px;width:286.9px;height:48.5px;border-radius:24.25px;
   background:#367CEF;color:#fff;text-align:center;font:600 17px/48.5px var(--n-font)}
-""" % dict(h_top=round(388.1 - 362.3 - cap(17, 22), 2), p_top=round(415.4 - 362.3 - cap(15, 20), 2),
-            links_top=round(758.4 - SHEET - cap(13, 23.7), 2))
+""" % dict(h_top=round(388.1 - 362.3 - cap(17, 22), 2), p_top=round(415.4 - 362.3 - cap(15, 20), 2))
+
+LINKS_TOP = round(754.3 - SHEET - cap(13, 23.7), 2)
+LINKS_TOP_BUSY = round(758.4 - SHEET - cap(13, 23.7), 2)
+
+CSS_PW_OK = CSS_ALERT + """
+/* Success: the button grows to 54.4pt while it spins and the links move down with it. */
+.cta{height:54.4px}.links{top:%spx}
+""" % LINKS_TOP_BUSY
 
 STATUS = """  <div class="statusbar">
     <div class="time">9:41</div>
@@ -1161,7 +1167,12 @@ SPINNER = ('<svg viewBox="0 0 30 30" fill="none" stroke-width="2.3" stroke-linec
            '<circle cx="15" cy="15" r="11" stroke="#CFDCE8"/>'
            '<path d="M4.4 12.3A11 11 0 0 1 20.5 5.5" stroke="#2E3A36"/></svg>')
 
-def paywall(sel, cta, success=False):
+def cards(sel):
+    return ('    <div class="price l%s"><b>S$ 299.98</b><i>per year</i></div>\n' % (" on" if sel == "l" else "")
+            + '    <div class="price r%s"><b>S$ 29.98</b><i>per month</i></div>\n' % (" on" if sel == "r" else ""))
+
+
+def paywall(sel, cta, overlay=False):
     body = '<div class="phone">\n' + STATUS + '\n  <div class="sheet">\n'
     body += '    <div class="handle"></div>\n'
     body += ('    <span class="close"><svg viewBox="0 0 12 12" stroke="currentColor" stroke-width="1.5" '
@@ -1180,17 +1191,130 @@ def paywall(sel, cta, success=False):
     body += '      <img class="art spark" alt="three sparkle strokes" src="%s">\n' % png("spark")
     body += '      <img class="art cat" alt="line-drawn cat" src="%s">\n' % png("cat")
     body += '      <div class="fade"></div>\n    </div>\n\n'
-    body += '    <div class="price l%s"><b>S$ 299.98</b><i>per year</i></div>\n' % (" on" if sel == "l" else "")
-    body += '    <div class="price r%s"><b>S$ 29.98</b><i>per month</i></div>\n' % (" on" if sel == "r" else "")
-    body += '    <div class="cta">%s</div>\n' % (SPINNER if success else cta)
+    body += cards(sel)
+    body += '    <div class="cta">%s</div>\n' % cta
     body += '    <div class="links"><a>Restore subscription</a><a>Terms of service</a><a>Privacy policy</a></div>\n'
     body += '  </div>\n'
-    if success:
+    if overlay:
         body += ('  <div class="scrim"></div>\n  <div class="alert"><h3>You’re all set</h3>'
                  '<p>Your purchase was successful.</p><div class="ok">OK</div></div>\n')
     body += '</div>\n'
     return body
 
+
+
+# ---------------------------------------- 19 the purchase sheet in motion ---
+# One board that plays 16 -> 17 -> 18 and back as a loop. The canvas renders a
+# board in <iframe srcDoc sandbox="">, where no script runs, so the timeline
+# is CSS: every element animates over the same T seconds with `infinite`, and
+# the keyframes below are the timeline in seconds turned into percentages.
+# The easings are Open Props' (open-props.style, v1.7.23, MIT, Adam Argyle),
+# copied verbatim from easings.css and animations.css: the linear() springs
+# are the ones the browser cannot express as a cubic-bezier. At 0%% every
+# element is exactly board 16, so `prefers-reduced-motion: reduce` -- which
+# drops the animations -- leaves board 16 standing.
+OPEN_PROPS = {
+    "--ease-3": "cubic-bezier(.25,0,.3,1)",
+    "--ease-out-3": "cubic-bezier(0,0,.3,1)",
+    "--ease-spring-2": "linear(0,0.007,0.029 2.2%,0.118 4.7%,0.625 14.4%,0.826 19%,0.902,0.962,1.008 26.1%,"
+                       "1.041 28.7%,1.064 32.1%,1.07 36%,1.061 40.5%,1.015 53.4%,0.999 61.6%,0.995 71.2%,1)",
+    "--animation-spin": "spin 2s linear infinite",
+}
+OPEN_PROPS_KEYFRAMES = "@keyframes spin{to{transform:rotate(1turn)}}"
+
+T = 10.0  # seconds per loop
+
+
+def kf(name, steps, ease=OPEN_PROPS["--ease-3"]):
+    """A @keyframes block from (seconds, declarations[, easing]) steps.
+
+    A step's easing governs the segment that starts at it; a value holds when
+    two consecutive steps repeat it. The first step must be at 0 and the last
+    at T, so the loop closes on board 16."""
+    assert steps[0][0] == 0 and steps[-1][0] == T, name
+    out = []
+    for step in steps:
+        t, css = step[0], step[1]
+        e = step[2] if len(step) > 2 else ease
+        pct = ("%.2f" % (t / T * 100)).rstrip("0").rstrip(".")
+        out.append("%s%%{%s;animation-timing-function:%s}" % (pct, css, e))
+    return "@keyframes %s{%s}\n" % (name, "".join(out))
+
+
+def _token(name):
+    return re.search(r"%s:\s*([^;]+);" % re.escape(name), TOKENS).group(1).strip()
+
+
+# The loop, in seconds. Holds are what a reader needs to see each state.
+TAP_YEARLY, TAP_MONTHLY, PRESS, DONE, OK = 1.4, 3.6, 4.9, 6.2, 8.6
+SWAP = 0.22          # the selection ring and the button label, --ease-3
+GROW = 0.3           # the button's height and the links under it
+SPRING = 0.35        # the alert's entrance, --ease-spring-2
+
+OFF = "border-color:#E4E4E4;box-shadow:inset 0 0 0 1px rgba(72,126,208,0);background:#fff"
+ON = "border-color:#487ED0;box-shadow:inset 0 0 0 1px #487ED0;background:#E7F3FF"
+# Selected text sits 0.9 right and, for the price, 0.4 up: the 2pt ring's
+# extra point, less the -0.1 / -1.4 the static boards give .price.on.
+B_OFF, B_ON = "color:%s;transform:none" % _token("--n-text"), "color:#467AB9;transform:translate(.9px,-.4px)"
+I_OFF, I_ON = "color:%s;transform:none" % _token("--n-text-2"), "color:#4E7BB8;transform:translateX(.9px)"
+
+
+def toggle(off, on, first_on=False):
+    a, b = (on, off) if first_on else (off, on)
+    return [(0, a), (TAP_YEARLY, a), (TAP_YEARLY + SWAP, b), (TAP_MONTHLY, b), (TAP_MONTHLY + SWAP, a), (T, a)]
+
+
+CTA_UP = "height:50.4px;background:#4380D7"
+CTA_DOWN = "height:50.4px;background:#3B72C0"      # UIButton's highlighted dim, 0.1s
+CTA_BUSY = "height:54.4px;background:#4380D7"
+LINKS = "top:%spx" % LINKS_TOP
+LINKS_BUSY = "top:%spx" % LINKS_TOP_BUSY
+ALERT_HIDDEN = "opacity:0;transform:scale(1.12)"
+ALERT_GONE = "opacity:0;transform:scale(.97)"
+ALERT_SHOWN = "opacity:1;transform:none"
+UNDO = OK + 0.35    # the alert is gone; the button and links go back
+CSS_MO = "\n/* The loop: %ss, every element on the same clock. */\n" % T
+CSS_MO += ".phone{%s}\n" % ";".join("%s:%s" % kv for kv in OPEN_PROPS.items())
+CSS_MO += """.price.r{%(on)s}.price.r b{%(bon)s}.price.r i{%(ion)s}
+.price.l{animation:pl %(T)ss infinite}.price.l b{animation:pl-b %(T)ss infinite}.price.l i{animation:pl-i %(T)ss infinite}
+.price.r{animation:pr %(T)ss infinite}.price.r b{animation:pr-b %(T)ss infinite}.price.r i{animation:pr-i %(T)ss infinite}
+.price b,.price i{will-change:transform}
+.cta{animation:cta %(T)ss infinite}
+.cta span{position:absolute;left:0;right:0;top:0;line-height:50px}
+.cta .m{animation:cta-m %(T)ss infinite}.cta .y{opacity:0;animation:cta-y %(T)ss infinite}
+.cta .sp{opacity:0;animation:cta-sp %(T)ss infinite}
+.cta .sp svg{animation:var(--animation-spin);animation-duration:1s}
+.links{animation:links %(T)ss infinite}
+.scrim{opacity:0;animation:scrim %(T)ss infinite}
+.alert{%(ahid)s;animation:alert %(T)ss infinite}
+.ok{animation:ok %(T)ss infinite}
+@media (prefers-reduced-motion:reduce){.phone *{animation:none!important}}
+""" % dict(on=ON, bon=B_ON, ion=I_ON, T=T, ahid=ALERT_HIDDEN)
+CSS_MO += OPEN_PROPS_KEYFRAMES + "\n"
+CSS_MO += kf("pl", toggle(OFF, ON)) + kf("pl-b", toggle(B_OFF, B_ON)) + kf("pl-i", toggle(I_OFF, I_ON))
+CSS_MO += kf("pr", toggle(OFF, ON, True)) + kf("pr-b", toggle(B_OFF, B_ON, True)) + kf("pr-i", toggle(I_OFF, I_ON, True))
+CSS_MO += kf("cta", [(0, CTA_UP), (PRESS, CTA_UP), (PRESS + 0.1, CTA_DOWN), (PRESS + 0.1 + GROW, CTA_BUSY),
+                     (UNDO, CTA_BUSY), (UNDO + GROW, CTA_UP), (T, CTA_UP)])
+CSS_MO += kf("cta-m", [(0, "opacity:1"), (TAP_YEARLY + 0.05, "opacity:1"), (TAP_YEARLY + SWAP, "opacity:0"),
+                       (TAP_MONTHLY, "opacity:0"), (TAP_MONTHLY + SWAP - 0.05, "opacity:1"),
+                       (PRESS + 0.1, "opacity:1"), (PRESS + 0.25, "opacity:0"),
+                       (UNDO + 0.15, "opacity:0"), (UNDO + GROW, "opacity:1"), (T, "opacity:1")])
+CSS_MO += kf("cta-y", [(0, "opacity:0"), (TAP_YEARLY + 0.05, "opacity:0"), (TAP_YEARLY + SWAP, "opacity:1"),
+                       (TAP_MONTHLY, "opacity:1"), (TAP_MONTHLY + SWAP - 0.05, "opacity:0"), (T, "opacity:0")])
+CSS_MO += kf("cta-sp", [(0, "opacity:0"), (PRESS + 0.25, "opacity:0"), (PRESS + 0.1 + GROW, "opacity:1"),
+                        (UNDO, "opacity:1"), (UNDO + 0.15, "opacity:0"), (T, "opacity:0")])
+CSS_MO += kf("links", [(0, LINKS), (PRESS + 0.1, LINKS), (PRESS + 0.1 + GROW, LINKS_BUSY),
+                       (UNDO, LINKS_BUSY), (UNDO + GROW, LINKS), (T, LINKS)])
+CSS_MO += kf("scrim", [(0, "opacity:0"), (DONE, "opacity:0"), (DONE + 0.25, "opacity:1"),
+                       (OK + 0.1, "opacity:1"), (UNDO, "opacity:0"), (T, "opacity:0")])
+CSS_MO += kf("alert", [(0, ALERT_HIDDEN), (DONE + 0.05, ALERT_HIDDEN, OPEN_PROPS["--ease-spring-2"]),
+                       (DONE + 0.05 + SPRING, ALERT_SHOWN), (OK + 0.1, ALERT_SHOWN), (OK + 0.3, ALERT_GONE),
+                       (T, ALERT_HIDDEN)])
+CSS_MO += kf("ok", [(0, "background:#367CEF"), (OK, "background:#367CEF"), (OK + 0.1, "background:#2C6BD9"),
+                    (OK + 0.25, "background:#367CEF"), (T, "background:#367CEF")])
+
+MO_CTA = ('<span class="m">Subscribe for S$ 29.98 / month</span><span class="y">Subscribe for S$ 299.98 / year</span>'
+          '<span class="sp">' + SPINNER + '</span>')
 
 
 # ------------------------------------------------------------------- boards ---
@@ -1216,7 +1340,9 @@ BOARDS = [
     ("17-plan-plus-ai-yearly", "Notion iOS — Plan sheet, Plus & AI, yearly", CSS_PW,
      paywall("l", "Subscribe for S$ 299.98 / year")),
     ("18-purchase-success", "Notion iOS — Purchase success", CSS_PW + CSS_PW_OK,
-     paywall("r", "", success=True)),
+     paywall("r", SPINNER, overlay=True)),
+    ("19-purchase-sheet-motion", "Notion iOS — Purchase sheet, A to B to C", CSS_PW + CSS_ALERT + CSS_MO,
+     paywall(None, MO_CTA, overlay=True)),
 ]
 
 if __name__ == "__main__":

--- a/mockups/canvases/notion-ios/layout.json
+++ b/mockups/canvases/notion-ios/layout.json
@@ -106,6 +106,15 @@
           "label": "Purchase success"
         }
       ]
+    },
+    {
+      "title": "Motion: the purchase sheet, A to B to C",
+      "files": [
+        {
+          "file": "19-purchase-sheet-motion",
+          "label": "16 → 17 → 18, a 10s loop"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

A nineteenth board for the Notion example canvas, `19-purchase-sheet-motion`, that plays the purchase sheet's three states as a ten-second loop: 16 → tap the yearly card → 17 → tap the monthly back → press Subscribe → spinner → alert → OK → 16 again. It sits in its own layout row under the three static boards.

## Why CSS and an easing library, not a JS one

The brief was to use an open-source animation library. Boards render in `<iframe srcDoc sandbox="">`, where no script runs, so Motion, GSAP or anime.js would play when the file is opened alone and stand still on the canvas. The timeline is CSS: every element carries one `animation` of the same ten seconds, `infinite`, and `kf()` in `gen.py` turns a timeline in seconds into `@keyframes`. The easings are [Open Props](https://open-props.style)' (v1.7.23, MIT), copied verbatim into a block on `.phone`: `--ease-3` for the fades, rings and resizes, `--ease-spring-2` (a `linear()` spring) for the alert's entrance, and its `spin` keyframes for the ring. `docs/2026-09-10-motion-boards.md` is the decision note.

## What moved in the generator

- `paywall()` takes the cards and the button's contents from the caller, so the motion board is the same markup as 16–18 with every state present and hidden by opacity. A measured value moves all four boards together.
- The success CSS splits into `CSS_ALERT` (scrim and alert, shared) and the busy-button override. Board 18's CSS changes rule order and nothing else.
- At 0% every keyframe is board 16, and the base styles are 16, so `prefers-reduced-motion: reduce` leaves 16 standing.

## Checked by freezing it

`animation-play-state: paused` plus a negative `animation-delay` holds the board at an instant; `refkit shoot` that copy and `refkit diff` it against the static board it should equal:

| held at | against | mean Δ |
|---|---|---|
| 0.7s | 16 | 0.03 |
| 2.8s | 17 | 0.11 |
| 4.4s | 16 | 0.10 |
| 7.6s | 18 | 0.23 |

The in-between frames (button dimmed, growing around the spinner, spinning under the scrim) were looked at as a strip. The timings are chosen to read, not measured: the captures are stills.

## Test plan

- [x] `python3 gen.py` rewrites all twenty boards; 00–17 unchanged, 18 reorders two CSS rules
- [x] `refkit shoot 19-… --check-overflow --clip-ok div.hero` fits 478 × 980
- [x] frozen frames diff against 16 / 17 / 16 / 18 as above
- [ ] open `?canvas=notion-ios` on the Pages preview and watch the loop under the purchase-sheet row

🤖 Generated with [Claude Code](https://claude.com/claude-code)
