### PR TITLE
canvas: read a board, or a whole page of them, as a web page

### DIFF
--- a/canvas/src/InspectorPanel.tsx
+++ b/canvas/src/InspectorPanel.tsx
@@ -8,6 +8,7 @@ import {
   BOARD_STATUS_LABEL,
   LAYOUT_CHANGED,
   type CanvasBoardStatus,
+  boardPageUrl,
   boardStatusForPath,
   readCanvasAssetNames,
   useCanvasFileHtml,
@@ -316,6 +317,9 @@ export function InspectorPanel({
 }) {
   const html = useCanvasFileHtml(path);
   const srcDoc = useMemo(() => (html ? injectAgent(html) : ""), [html]);
+  // The board's own HTML, not `srcDoc`: the agent injected there talks to a parent frame that
+  // a tab of its own does not have.
+  const pageUrl = html ? boardPageUrl(path, html) : "";
   const frame = useRef<HTMLIFrameElement>(null);
   const [data, setData] = useState<SpReady | null>(null);
   const [sel, setSel] = useState<number | null>(null);
@@ -509,7 +513,35 @@ export function InspectorPanel({
             ) : null}
           </div>
           <BoardStatus path={path} />
-          <span className="sp-zoom">{Math.round(scale * 100)}%</span>
+          {/*
+            The board at its own size, in a tab of its own. The preview is scaled to fit the
+            stage, so it is the wrong place to read type or tap through a flow; this is the
+            same board as an ordinary web page. An anchor, not a button, so the ordinary ways
+            to open a link — middle click, ⌘-click, copy — all work on it.
+          */}
+          {pageUrl ? (
+            <a
+              className="sp-full"
+              href={pageUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              title="Open this board as a page"
+              aria-label="Open this board as a page"
+            >
+              <svg
+                width="12"
+                height="12"
+                viewBox="0 0 12 12"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.4"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <path d="M4.5 1.5h-3v3M7.5 1.5h3v3M10.5 7.5v3h-3M1.5 7.5v3h3" />
+              </svg>
+            </a>
+          ) : null}
         </div>
         {editor ? (
           <BoardComments

--- a/canvas/src/boardsPage.test.ts
+++ b/canvas/src/boardsPage.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+import { boardsPageDoc } from './boardsPage'
+import { WELCOME_PAGE_SLUG } from './canvasUrl'
+
+/** The document is built as a string, so the assertions read it as one. */
+const captions = (doc: string) => [...doc.matchAll(/<figcaption>(.*?)<\/figcaption>/g)].map((m) => m[1])
+const headings = (doc: string) => [...doc.matchAll(/<h2>(.*?)<\/h2>/g)].map((m) => m[1])
+
+describe('boardsPageDoc', () => {
+  it('lays the boards out in layout.json order, with the canvas own captions', async () => {
+    const doc = await boardsPageDoc('notion-ios')
+    expect(headings(doc)).toEqual([
+      'Foundations',
+      'Notion iOS replica screens',
+      'Flow: adding a new data source',
+      'Flow: adding an account',
+      'Flow: the purchase sheet',
+    ])
+    // A `numbered` row counts from 1 within that row; a plain one is the file's own title.
+    expect(captions(doc).slice(0, 3)).toEqual(['Design tokens', '1 · Splash', '2 · Search / Ask AI'])
+    expect(doc).toContain('<h1>(example) Notion iOS</h1>')
+
+    // Every board is an iframe at the artboard size, pointed at that board as a page of its own.
+    const frames = [...doc.matchAll(/<iframe src="(blob:[^"]+)" width="(\d+)" height="(\d+)"/g)]
+    expect(frames).toHaveLength(captions(doc).length)
+    expect(frames.every(([, , w, h]) => w === '478' && h === '980')).toBe(true)
+    expect(new Set(frames.map(([, src]) => src)).size).toBe(frames.length)
+  })
+
+  it('gives a board the size its entry declares', async () => {
+    // The welcome strip is the one board in the repo that is not phone-shaped.
+    const doc = await boardsPageDoc(WELCOME_PAGE_SLUG)
+    expect(doc).toContain('width="2153" height="819"')
+    expect(captions(doc)).toEqual(['What this is'])
+    expect(doc).toContain('<p class="sub">1 board at full size</p>')
+  })
+
+  it('has nothing to draw for a page with no boards', async () => {
+    const doc = await boardsPageDoc('not-a-folder')
+    expect(doc).not.toContain('<iframe')
+    expect(doc).toContain('<p class="sub">0 boards at full size</p>')
+  })
+})

--- a/canvas/src/boardsPage.ts
+++ b/canvas/src/boardsPage.ts
@@ -1,0 +1,164 @@
+import { CANVAS_FILE_DEFAULT_SIZE } from "./CanvasFileShapeUtil";
+import {
+  type CanvasLibraryFile,
+  boardPageUrl,
+  loadCanvasFileHtml,
+  pageNameFor,
+  readCanvasLayout,
+  readCanvasLibrary,
+} from "./canvasLibrary";
+
+/**
+ * A page's boards as one scrolling web page, for the button in the top bar.
+ *
+ * The canvas is the place to read a flow; this is the place to read a screen. Every board is an
+ * iframe at its own size, so type is at the size it will ship at and anything the board does on
+ * a tap still does it — which a canvas at 25% cannot show and the inspector can only show one
+ * board at a time.
+ */
+
+/** A board on the sheet: where its page is, what to call it, and how big it is. */
+interface SheetBoard {
+  src: string;
+  caption: string;
+  w: number;
+  h: number;
+}
+
+interface SheetRow {
+  title: string;
+  boards: SheetBoard[];
+}
+
+/** For text going into the document below, which is built as a string. */
+const esc = (text: string) =>
+  text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+
+/**
+ * The page's boards in the order the canvas lays them out: layout.json's rows, with their titles
+ * and captions, then whatever no row claimed, the way the canvas puts the leftovers in a grid
+ * below rather than dropping them. Read from layout.json rather than off the shapes on screen,
+ * because a caption out there is a text shape and its rich text is a worse source for a string
+ * than the file the string was made from.
+ */
+function sheetRows(slug: string, files: CanvasLibraryFile[], src: Map<string, string>): SheetRow[] {
+  const rows: SheetRow[] = [];
+  const placed = new Set<string>();
+
+  for (const row of readCanvasLayout(slug)?.rows ?? []) {
+    const boards: SheetBoard[] = [];
+    for (const entry of row.files) {
+      // An entry is the file name alone, or that name with the overrides beside it.
+      const declared = typeof entry === "string" ? { file: entry } : entry;
+      const file = files.find((c) => c.fileName === declared.file && !placed.has(c.path));
+      const url = file && src.get(file.path);
+      if (!file || !url) continue;
+      placed.add(file.path);
+      const caption = declared.label ?? file.title;
+      boards.push({
+        src: url,
+        caption: row.numbered ? `${boards.length + 1} · ${caption}` : caption,
+        // Both or neither, the way the canvas reads a size override.
+        ...(declared.w && declared.h ? { w: declared.w, h: declared.h } : CANVAS_FILE_DEFAULT_SIZE),
+      });
+    }
+    if (boards.length) rows.push({ title: row.title, boards });
+  }
+
+  const leftover = files.filter((file) => !placed.has(file.path) && src.has(file.path));
+  if (leftover.length) {
+    rows.push({
+      title: rows.length ? "Everything else" : "",
+      boards: leftover.map((file) => ({
+        src: src.get(file.path)!,
+        caption: file.title,
+        ...CANVAS_FILE_DEFAULT_SIZE,
+      })),
+    });
+  }
+  return rows;
+}
+
+/* The sheet's own chrome. Grey ground and grey captions, like the inspector's stage, so that the
+   only thing on the page with any colour in it is the mockups. */
+const SHEET_CSS = `
+  :root { color-scheme: light }
+  * { box-sizing: border-box }
+  body {
+    margin: 0;
+    padding: 32px 40px 72px;
+    background: #f5f5f5;
+    color: #171717;
+    font: 14px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  }
+  h1 { margin: 0; font-size: 22px; letter-spacing: -0.01em }
+  .sub { margin: 4px 0 0; color: #767676 }
+  h2 { margin: 40px 0 16px; font-size: 15px; font-weight: 600 }
+  .row { display: flex; flex-wrap: wrap; align-items: flex-start; gap: 28px 24px }
+  figure { margin: 0; display: flex; flex-direction: column; gap: 8px }
+  iframe { display: block; border: 0; border-radius: 12px; background: #ffffff; box-shadow: 0 1px 3px #00000014 }
+  figcaption { color: #767676; font-size: 13px }
+`;
+
+/** Every board on a canvas page, as one HTML document. */
+export async function boardsPageDoc(slug: string) {
+  const name = pageNameFor(slug);
+  const files = readCanvasLibrary().find((page) => page[0].pageSlug === slug) ?? [];
+  const loaded = await Promise.all(
+    files.map(async (file) => [file.path, await loadCanvasFileHtml(file.path)] as const),
+  );
+  const src = new Map(
+    // A board whose chunk never arrived is left off the sheet; it is blank on the canvas too.
+    loaded.flatMap(([path, html]) => (html ? [[path, boardPageUrl(path, html)] as const] : [])),
+  );
+  const rows = sheetRows(slug, files, src);
+  const count = rows.reduce((n, row) => n + row.boards.length, 0);
+
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>${esc(name)}</title>
+<style>${SHEET_CSS}</style>
+</head>
+<body>
+<h1>${esc(name)}</h1>
+<p class="sub">${count} board${count === 1 ? "" : "s"} at full size</p>
+${rows
+  .map(
+    (row) => `<section>
+${row.title ? `<h2>${esc(row.title)}</h2>` : ""}
+<div class="row">
+${row.boards
+  .map(
+    (board) => `<figure>
+<iframe src="${board.src}" width="${board.w}" height="${board.h}" loading="lazy" title="${esc(board.caption)}"></iframe>
+<figcaption>${esc(board.caption)}</figcaption>
+</figure>`,
+  )
+  .join("\n")}
+</div>
+</section>`,
+  )
+  .join("\n")}
+</body>
+</html>`;
+}
+
+/**
+ * Opens that document in a tab of its own.
+ *
+ * The tab is opened before the boards are fetched and pointed at the page afterwards: a
+ * `window.open` on the far side of an await is a popup the browser blocks, because the click that
+ * allowed it is over by then. Most of the time there is nothing to wait for anyway — every shape
+ * on a page mounts, so a page's boards are in the library's cache before anyone can click.
+ */
+export async function openBoardsPage(slug: string) {
+  const tab = window.open("", "_blank");
+  // Blocked by the browser, and there is no window left to say so in.
+  if (!tab) return;
+  tab.document.title = pageNameFor(slug);
+  const doc = await boardsPageDoc(slug);
+  tab.location.replace(URL.createObjectURL(new Blob([doc], { type: "text/html" })));
+}

--- a/canvas/src/canvasChrome.tsx
+++ b/canvas/src/canvasChrome.tsx
@@ -28,6 +28,7 @@ import {
   type CommentUser,
 } from "./canvasComments";
 import type { CanvasFileShape } from "./CanvasFileShapeUtil";
+import { openBoardsPage } from "./boardsPage";
 import { WELCOME_PAGE_SLUG } from "./canvasUrl";
 
 const REPO_URL = "https://github.com/ReScienceLab/super-prototyping";
@@ -164,6 +165,15 @@ export const canvasChromeComponents: TLComponents = {
     return (
       <>
         <DefaultActionsMenu {...props} />
+        {slug && (
+          <TldrawUiButton
+            type="icon"
+            title="Open every board on this page as one web page"
+            onClick={() => openBoardsPage(slug)}
+          >
+            <TldrawUiButtonIcon icon="external-link" />
+          </TldrawUiButton>
+        )}
         {/* Nothing to copy on the welcome page, which the app draws and no folder backs, or on
             a page someone added by hand. */}
         {import.meta.env.DEV && slug && slug !== WELCOME_PAGE_SLUG && (

--- a/canvas/src/canvasLibrary.ts
+++ b/canvas/src/canvasLibrary.ts
@@ -268,6 +268,27 @@ export function loadCanvasFileHtml(path: string): Promise<string | undefined> {
   return load;
 }
 
+/** path -> the blob URL that board has been opened as a page at; see `boardPageUrl`. */
+const boardPages = new Map<string, string>();
+
+/**
+ * A board as a page of its own, for the buttons that open one. A blob rather than a link to the
+ * file because boards ship as strings in the bundle — lazy chunks off `virtual:canvases` — so
+ * there is no address to point at.
+ *
+ * One per board, kept for the session rather than revoked when the thing that asked for it goes
+ * away: nothing here can see when the tab it was opened in has finished fetching it, and revoking
+ * before that leaves the reader on an error page. It is a second copy of a string `canvasFileHtml`
+ * is already holding for as long anyway.
+ */
+export function boardPageUrl(path: string, html: string) {
+  const made = boardPages.get(path);
+  if (made) return made;
+  const url = URL.createObjectURL(new Blob([html], { type: "text/html" }));
+  boardPages.set(path, url);
+  return url;
+}
+
 /**
  * A rendering shape's board HTML: undefined until its chunk arrives, then the string. Every shape
  * on the page mounts (culling only hides the off-screen ones), so a page fetches its own boards

--- a/canvas/src/index.css
+++ b/canvas/src/index.css
@@ -463,12 +463,27 @@ input.canvas-clone-name:focus {
   box-shadow: 0 0 0 2px #ffffff, 0 1px 4px #00000040;
 }
 
-.sp-zoom {
+/* Opens the board as a page of its own. Sits where the zoom percentage used to: the corner of
+   the stage is the one part of it no board reaches, and the scale was a number nobody acted on. */
+.sp-full {
   position: absolute;
-  right: 12px;
-  bottom: 10px;
+  right: 8px;
+  bottom: 8px;
+  width: 24px;
+  height: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 6px;
   color: var(--sp-text-2);
-  pointer-events: none;
+  background: #ffffffd9;
+  box-shadow: 0 1px 3px #00000014;
+  cursor: pointer;
+}
+
+.sp-full:hover {
+  color: var(--sp-text);
+  background: #ffffff;
 }
 
 /* The rail's collapse handle, a lozenge straddling its divider. It was a 26px chip in the top

--- a/skills/prototype-canvas/SKILL.md
+++ b/skills/prototype-canvas/SKILL.md
@@ -46,6 +46,12 @@ actually bind, and prints the address.
   `#<file>` after that, e.g. `?canvas=notion-ios#02-search-ask-ai`: it opens
   in the inspector with the camera on it. Give the board link when pointing
   at one screen.
+- **Read a board as a web page.** The external-link button in the top bar
+  opens every board of the page in one scrolling document, each at its own
+  size; the button in the bottom right of the inspector's preview opens the
+  one board it is showing. Both are the board's own HTML in a tab of its own,
+  which is where to read type at the size it ships at, rather than at whatever
+  the canvas is zoomed to.
 
 Keep it on loopback. This is a local design tool, not a service to expose.
 


### PR DESCRIPTION
The zoom percentage in the corner of the inspector's stage was a number nobody acted on. In its place is a button that opens the board being previewed as an ordinary web page, at its own size, in a tab of its own — an anchor, so ⌘-click, middle click and copy-link all work.

The top bar gets the same thing for a whole page: every board of the current canvas page in one scrolling document, in `layout.json`'s rows, with that file's own headings and captions (including `numbered` rows and `w`/`h` overrides), and anything no row claimed underneath.

Boards ship as strings in the bundle — lazy chunks off `virtual:canvases` — so there is no file to link to and a board's page is a blob URL. One per board, kept for the session rather than revoked: nothing in the app can see when the opened tab has finished fetching it, and revoking before that leaves the reader on an error page. The all-boards tab is opened synchronously in the click and pointed at the document afterwards, since a `window.open` past an `await` is a popup the browser blocks.

`bun run lint`, `bunx tsc -b`, `bun run test` (88 passing, incl. 3 new for the sheet document) and `bun run build` are clean; verified in a browser on `notion-ios` and the welcome page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)