### PR TITLE
canvas: a sprite's <use> is inlined into the inspector's copy, and its host is no asset

### DIFF
--- a/canvas/src/inspectorAgent.test.ts
+++ b/canvas/src/inspectorAgent.test.ts
@@ -19,6 +19,12 @@ describe("AGENT", () => {
     // every backslash doubled and would silently turn `\s` into `s`.
     expect(AGENT).toContain("replace(/^\\s+|\\s+$/g,'')");
   });
+
+  it("inlines a same-document <use> and passes over a sprite host's own definitions", () => {
+    // Issue #73: a <use href="#id"> cloned alone dangles, and a <defs> of <symbol>s draws nothing.
+    expect(AGENT).toContain("document.getElementById(h.slice(1))");
+    expect(AGENT).toContain(":not(defs *,symbol *)");
+  });
 });
 
 describe("injectAgent", () => {

--- a/canvas/src/inspectorAgent.test.ts
+++ b/canvas/src/inspectorAgent.test.ts
@@ -24,6 +24,8 @@ describe("AGENT", () => {
     // Issue #73: a <use href="#id"> cloned alone dangles, and a <defs> of <symbol>s draws nothing.
     expect(AGENT).toContain("document.getElementById(h.slice(1))");
     expect(AGENT).toContain(":not(defs *,symbol *)");
+    // The ceiling is a count of resolutions, not a depth: two self-references would double per level.
+    expect(AGENT).toContain("left=64");
   });
 });
 

--- a/canvas/src/inspectorAgent.ts
+++ b/canvas/src/inspectorAgent.ts
@@ -318,9 +318,9 @@ function addAsset(i,uri,via,el){var c=uri.indexOf(','),payload=uri.slice(c+1),k=
    cascade supplied (currentColor, var(), a fill from a stylesheet) are written in, and xmlns is
    added where a literal icon had none, so an <img> in the parent draws it and Figma accepts it. */
 function addSvg(i,el){
-  if(!el.querySelector('path,rect,circle,ellipse,line,polygon,polyline,text,image,use'))return;
-  var c=el.cloneNode(true),cs=getComputedStyle(el),inner=c.querySelectorAll('[data-sp]'),n;
-  for(n=0;n<inner.length;n++)inner[n].removeAttribute('data-sp');
+  /* Geometry that only defines, a sprite host's <defs> of <symbol>s, draws nothing and is no asset. */
+  if(!el.querySelector(':is(path,rect,circle,ellipse,line,polygon,polyline,text,image,use):not(defs *,symbol *)'))return;
+  var c=el.cloneNode(true),cs=getComputedStyle(el),inner,n;
   c.removeAttribute('data-sp');c.removeAttribute('style');c.removeAttribute('class');c.removeAttribute('preserveAspectRatio');
   if(!c.hasAttribute('xmlns'))c.setAttribute('xmlns','http://www.w3.org/2000/svg');
   if(!c.hasAttribute('fill'))c.setAttribute('fill',cs.fill);
@@ -332,13 +332,32 @@ function addSvg(i,el){
   for(j=0;j<src.length;j++){s=getComputedStyle(src[j]);ps=getComputedStyle(src[j].parentNode);
     if(!dst[j].hasAttribute('fill')&&s.fill!==ps.fill)dst[j].setAttribute('fill',s.fill);
     if(!dst[j].hasAttribute('stroke')&&s.stroke!==ps.stroke)dst[j].setAttribute('stroke',s.stroke);}
+  /* A same-document <use> is inlined here and not before the pass above, which walks el and c in
+     lockstep by index: a node inlined into c has no counterpart in el. A <symbol> becomes an inner
+     <svg> carrying the use's own attributes (x, y, width, height, a fill) and the symbol's viewBox,
+     which the root adopts when it has none, so the copy draws standalone and signs like the
+     symbol's file; any other target is cloned in place. The inlined geometry takes the root's fill
+     and stroke written in above, not the sprite's own cascade. An external reference (file.svg#id)
+     stays as it is, and data-sp goes last because the inlined nodes bring the document's in.
+     ponytail: eight passes; a deeper chain, or a symbol that uses itself, keeps a dangling <use>. */
+  var us,u,t,g,h,d,m;
+  for(d=0;d<8&&(us=c.querySelectorAll('use')).length;d++)for(m=0;m<us.length;m++){u=us[m];
+    h=u.getAttribute('href')||u.getAttribute('xlink:href')||'';t=h.charAt(0)==='#'?document.getElementById(h.slice(1)):null;
+    if(!t)continue;g=document.createElementNS('http://www.w3.org/2000/svg','svg');
+    for(n=0;n<u.attributes.length;n++)if(!/href$/.test(u.attributes[n].name))g.setAttribute(u.attributes[n].name,u.attributes[n].value);
+    if(t.tagName==='symbol'){if(t.hasAttribute('viewBox')){g.setAttribute('viewBox',t.getAttribute('viewBox'));
+        if(!c.hasAttribute('viewBox'))c.setAttribute('viewBox',t.getAttribute('viewBox'));}
+      t=t.cloneNode(true);while(t.firstChild)g.appendChild(t.firstChild);}
+    else g.appendChild(t.cloneNode(true));
+    u.parentNode.replaceChild(g,u);}
+  inner=c.querySelectorAll('[data-sp]');for(n=0;n<inner.length;n++)inner[n].removeAttribute('data-sp');
   var svg=c.outerHTML.replace(/currentColor/gi,cs.color)
     .replace(/var\(\s*(--[\w-]+)[^)]*\)/g,function(m,p){return cs.getPropertyValue(p).replace(/^\s+|\s+$/g,'')||m;});
   /* One row per glyph and colour: the geometry key joins the file, and the colours after it keep
      a red and a black instance of the same glyph apart, so what a row shows is what it copies.
      ponytail: the root's computed colours; a colour that differs only in a child's var() collapses. */
   var k='svg:'+fnv(svgSignature(svg))+':'+fnv(cs.fill+'|'+cs.stroke+'|'+cs.color),a=byKey[k];
-  if(!a){var vb=(el.getAttribute('viewBox')||'').split(/[\s,]+/);
+  if(!a){var vb=(c.getAttribute('viewBox')||'').split(/[\s,]+/);
     a=byKey[k]={key:k,uri:'data:image/svg+xml;charset=utf-8,'+encodeURIComponent(svg),via:'svg',mime:'image/svg+xml',
       chars:svg.length,w:+vb[2]||0,h:+vb[3]||0,alt:svgLabel(el),svg:svg,uses:[]};assets.push(a);}
   if(a.uses.indexOf(i)<0)a.uses.push(i);nodes[i].img=true;}

--- a/canvas/src/inspectorAgent.ts
+++ b/canvas/src/inspectorAgent.ts
@@ -52,7 +52,7 @@ export interface SpAsset {
   mime: string;
   /** Payload length in characters; for a vector, the standalone markup's. */
   chars: number;
-  /** For a vector, the viewBox size in board units. */
+  /** For a vector, the viewBox size in board units, else its width and height attributes. */
   w: number;
   h: number;
   /** The `alt`; for a vector, its accessible name, class or the caption beside it. */
@@ -334,22 +334,26 @@ function addSvg(i,el){
     if(!dst[j].hasAttribute('stroke')&&s.stroke!==ps.stroke)dst[j].setAttribute('stroke',s.stroke);}
   /* A same-document <use> is inlined here and not before the pass above, which walks el and c in
      lockstep by index: a node inlined into c has no counterpart in el. A <symbol> becomes an inner
-     <svg> carrying the use's own attributes (x, y, width, height, a fill) and the symbol's viewBox,
-     which the root adopts when it has none, so the copy draws standalone and signs like the
-     symbol's file; any other target is cloned in place. The inlined geometry takes the root's fill
-     and stroke written in above, not the sprite's own cascade. An external reference (file.svg#id)
-     stays as it is, and data-sp goes last because the inlined nodes bring the document's in.
-     ponytail: eight passes; a deeper chain, or a symbol that uses itself, keeps a dangling <use>. */
-  var us,u,t,g,h,d,m;
-  for(d=0;d<8&&(us=c.querySelectorAll('use')).length;d++)for(m=0;m<us.length;m++){u=us[m];
-    h=u.getAttribute('href')||u.getAttribute('xlink:href')||'';t=h.charAt(0)==='#'?document.getElementById(h.slice(1)):null;
-    if(!t)continue;g=document.createElementNS('http://www.w3.org/2000/svg','svg');
+     <svg> carrying the use's own attributes (x, y, width, height, a fill) and the symbol's viewBox;
+     any other target is cloned in place. The inlined geometry takes the root's fill and stroke
+     written in above, not the sprite's own cascade. An external reference (file.svg#id) stays as
+     it is, and data-sp goes last because the inlined nodes bring the document's in. The root
+     adopts the symbol's viewBox only when that one use, unoffset and unsized, is the whole root: a
+     root composing two symbols side by side keeps its own coordinate system, and its size then
+     reads from its width and height.
+     ponytail: 64 resolutions in all, then whatever <use> is still queued stays dangling; a symbol
+     holding two references to itself ends as 64 wrappers, not two to the power of the depth. */
+  var q=Array.prototype.slice.call(c.querySelectorAll('use')),left=64,seen=0,svb='',u,t,g,h;
+  while(q.length&&left){u=q.shift();h=u.getAttribute('href')||u.getAttribute('xlink:href')||'';
+    t=h.charAt(0)==='#'?document.getElementById(h.slice(1)):null;if(!t)continue;left--;seen++;
+    g=document.createElementNS('http://www.w3.org/2000/svg','svg');
     for(n=0;n<u.attributes.length;n++)if(!/href$/.test(u.attributes[n].name))g.setAttribute(u.attributes[n].name,u.attributes[n].value);
-    if(t.tagName==='symbol'){if(t.hasAttribute('viewBox')){g.setAttribute('viewBox',t.getAttribute('viewBox'));
-        if(!c.hasAttribute('viewBox'))c.setAttribute('viewBox',t.getAttribute('viewBox'));}
+    if(t.tagName==='symbol'){if(t.hasAttribute('viewBox'))g.setAttribute('viewBox',t.getAttribute('viewBox'));
+      if(!(u.getAttribute('x')||u.getAttribute('y')||u.getAttribute('width')||u.getAttribute('height')))svb=t.getAttribute('viewBox')||'';
       t=t.cloneNode(true);while(t.firstChild)g.appendChild(t.firstChild);}
     else g.appendChild(t.cloneNode(true));
-    u.parentNode.replaceChild(g,u);}
+    u.parentNode.replaceChild(g,u);q.push.apply(q,g.querySelectorAll('use'));}
+  if(seen===1&&svb&&!c.hasAttribute('viewBox'))c.setAttribute('viewBox',svb);
   inner=c.querySelectorAll('[data-sp]');for(n=0;n<inner.length;n++)inner[n].removeAttribute('data-sp');
   var svg=c.outerHTML.replace(/currentColor/gi,cs.color)
     .replace(/var\(\s*(--[\w-]+)[^)]*\)/g,function(m,p){return cs.getPropertyValue(p).replace(/^\s+|\s+$/g,'')||m;});
@@ -359,7 +363,7 @@ function addSvg(i,el){
   var k='svg:'+fnv(svgSignature(svg))+':'+fnv(cs.fill+'|'+cs.stroke+'|'+cs.color),a=byKey[k];
   if(!a){var vb=(c.getAttribute('viewBox')||'').split(/[\s,]+/);
     a=byKey[k]={key:k,uri:'data:image/svg+xml;charset=utf-8,'+encodeURIComponent(svg),via:'svg',mime:'image/svg+xml',
-      chars:svg.length,w:+vb[2]||0,h:+vb[3]||0,alt:svgLabel(el),svg:svg,uses:[]};assets.push(a);}
+      chars:svg.length,w:+vb[2]||+c.getAttribute('width')||0,h:+vb[3]||+c.getAttribute('height')||0,alt:svgLabel(el),svg:svg,uses:[]};assets.push(a);}
   if(a.uses.indexOf(i)<0)a.uses.push(i);nodes[i].img=true;}
 /* No board writes a title on its icons, so with no file to name one the name is a guess from
    context: the accessible name if there is one; else a class, when it is a word (logo, aiface)


### PR DESCRIPTION
Fixes #73

`addSvg()` cloned only the root `<svg>`, so a `<use href="#id">` into a sprite of `<symbol>`s dangled in the copy and drew nothing, and with the `viewBox` on the symbol the row's size read 0×0. The copy is self-contained again:

- **Same-document `<use>` is inlined**, after the fill/stroke pass (which walks the original and the copy in lockstep by index, so inlining first would shift every later index). A `<symbol>` becomes an inner `<svg>` carrying the use's own attributes (`x`, `y`, `width`, `height`, a fill) and the symbol's `viewBox`; any other target is cloned in place. The inlined geometry takes the root's computed fill/stroke that the function already writes in. External references (`file.svg#id`) are left alone. Eight passes cap a chain or a self-referencing symbol (`ponytail:` comment).
- **The root adopts the symbol's `viewBox`** when it has none, and the row's `w`/`h` read from the copy, so the size is right and the key signs like the symbol's file would.
- **The sprite host is no asset.** `<svg width="0" height="0"><defs><symbol>…` passed the content guard because `querySelector('path')` reaches inside the `<symbol>`, and was handed out as an unnamed 0×0 row that drew nothing (confirmed below). Geometry inside `<defs>`/`<symbol>` no longer counts.

No committed board holds a `<use>` (`grep` over `mockups/canvases/*/*.html`: 0), so nothing regenerates. A census over the 1,512 root `<svg>`s in the committed boards (33 with `<defs>`/`<symbol>`) shows the new guard changes the outcome for none of them; the in-svg gradient references keep working (see the `Gradient` control below).

## Evidence

The real `AGENT` string (via `injectAgent`) run against a sprite fixture matching the issue's repro in headless Chrome (`--headless --disable-gpu --dump-dom`, the way `refkit` already drives it), reading the `sp:ready` message the agent posts. Fixture, harness and captures are in `scratch/issue-73/` (gitignored).

**Before**

```
[(unnamed)] w=0 h=0 uses=[1]        <- the sprite host, item 3
  <svg width="0" height="0" xmlns="http://www.w3.org/2000/svg" fill="rgb(0, 0, 0)" stroke="none"><defs>
  <symbol id="ic-home" viewBox="0 0 24 24"><path d="M4 11 12 4l8 7v8a1 1 0 0 1-1 1h-4v-6h-6v6H5a1 1 0 0 1-1-1z"></path></symbol>
  …</defs></svg>
[Home] w=0 h=0 uses=[11]
  <svg width="24" height="24" xmlns="http://www.w3.org/2000/svg" fill="rgb(28, 28, 30)" stroke="none"><use href="#ic-home"></use></svg>
[Alerts] w=0 h=0 uses=[14]
  <svg width="24" height="24" xmlns="http://www.w3.org/2000/svg" fill="rgb(224, 36, 94)" stroke="none"><use xlink:href="#ic-home"></use></svg>
[Dot] w=24 h=24 uses=[23]           <- <use> of a plain <path id> in the sprite
  <svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="rgb(28, 28, 30)" stroke="none"><use href="#dot"></use></svg>
[Gradient] w=24 h=24 uses=[26]      <- control: in-svg <defs> reference, already fine
  <svg … viewBox="0 0 24 24" …><defs><linearGradient id="g">…</linearGradient></defs><rect width="24" height="24" fill="url(#g)"></rect></svg>
[External] w=0 h=0 uses=[33]
  <svg width="24" height="24" … ><use href="icons.svg#ic-home"></use></svg>
```

Rendered as the inspector's `<img src="data:image/svg+xml,…">`: the host, Home and Alerts are blank (Alerts is a broken image, the `xlink:` prefix without its namespace makes the copy invalid), Dot is blank, Gradient draws.

**After**

```
[Home] w=24 h=24 uses=[11,17]
  <svg width="24" height="24" xmlns="http://www.w3.org/2000/svg" fill="rgb(28, 28, 30)" stroke="none" viewBox="0 0 24 24"><svg viewBox="0 0 24 24"><path d="M4 11 12 4l8 7v8a1 1 0 0 1-1 1h-4v-6h-6v6H5a1 1 0 0 1-1-1z"></path></svg></svg>
[Alerts] w=24 h=24 uses=[14]
  <svg width="24" height="24" xmlns="http://www.w3.org/2000/svg" fill="rgb(224, 36, 94)" stroke="none" viewBox="0 0 24 24"><svg viewBox="0 0 24 24"><path d="M4 11 …z"></path></svg></svg>
[Loop] w=24 h=24 uses=[20]          <- a symbol that uses itself: stops after eight passes
  <svg … viewBox="0 0 24 24"><svg viewBox="0 0 24 24">…×8…<use href="#ic-loop"></use></svg>…</svg>
[Dot] w=24 h=24 uses=[23]
  <svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="rgb(28, 28, 30)" stroke="none"><svg><path id="dot" d="M12 12m-4 0a4 4 0 1 0 8 0a4 4 0 1 0-8 0"></path></svg></svg>
[Gradient] w=24 h=24 uses=[26]      <- unchanged
[External] w=0 h=0 uses=[33]        <- unchanged, left alone
```

The sprite host row is gone; Home and Alerts draw the house in their own colour (`.red svg{fill:#e0245e}`), Dot draws, Gradient is byte-identical to before, Loop and External stay blank.

## Checks

`bun run lint`, `bun run test` (90 passed; one new assertion on the `AGENT` source in `inspectorAgent.test.ts`), `bun run build`. No dependency added.

## Left out

- A symbol that nests another symbol at an offset (`<symbol><use href="#a" x=6 width=12/></symbol>`) renders right but shares the row of the symbol it nests: `svgSignature` signs drawing elements, not the inner `<svg>` wrapper. Pre-existing property of the key (a `<g transform>` collides the same way); not worth changing the index's keys for.
- The symbol's own presentation attributes (`fill`, `class`) are not carried; the inlined geometry inherits the root's computed fill/stroke, as noted in the code.
- A `fill="url(#grad)"` from the inlined geometry into the sprite host's `<defs>` still dangles; no board does it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
